### PR TITLE
Generate the filesystem without holes

### DIFF
--- a/meta-resin-common/recipes-containers/mkfs-hostapp-native/files/create
+++ b/meta-resin-common/recipes-containers/mkfs-hostapp-native/files/create
@@ -13,4 +13,8 @@ hostapp-update -f /input -n
 kill $pid
 wait $pid
 
-mkfs.ext4 -F -E lazy_itable_init=0,lazy_journal_init=0 -i 8192 -d "$SYSROOT" /output
+mkfs.ext4 -F -E lazy_itable_init=0,lazy_journal_init=0 -i 8192 /output
+mount /output /media
+cp -a --sparse=never "$SYSROOT/." /media
+sync -f /media
+umount /media


### PR DESCRIPTION
Fixes #1000 

Currently, the filesystem is generated by mke2fs and all files copied by it as well.
mke2fs copy routine creates sparse files by default.
A possible workaround is to use cp --sparse=never to copy files into the filesystem

Without this patch
```
zubairlk@zubair-xps-resin: ~$ sudo find /media/zubairlk/resin-rootA1 -type f -printf "%S\t%p\n" | gawk '$1 < 1.0 {print}' | wc -l
588
zubairlk@zubair-xps-resin:~ $ sudo du -hs  /media/zubairlk/resin-rootA1
227M	/media/zubairlk/resin-rootA1
zubairlk@zubair-xps-resin: ~$ sudo du -hs --apparent-size /media/zubairlk/resin-rootA1
238M	/media/zubairlk/resin-rootA1
zubairlk@zubair-xps-resin: ~$ 
```

With this patch
```
zubairlk@zubair-xps-resin: ~$ sudo find /media/zubairlk/resin-rootA -type f -printf "%S\t%p\n" | gawk '$1 < 1.0 {print}'
zubairlk@zubair-xps-resin: ~$ sudo du -hs /media/zubairlk/resin-rootA
241M	/media/zubairlk/resin-rootA
zubairlk@zubair-xps-resin: ~$ sudo du -hs --apparent-size /media/zubairlk/resin-rootA
239M	/media/zubairlk/resin-rootA
```


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
