### PR TITLE
Move plymouth to initramfs

### DIFF
--- a/meta-resin-common/recipes-core/images/resin-image-initramfs.bb
+++ b/meta-resin-common/recipes-core/images/resin-image-initramfs.bb
@@ -11,14 +11,16 @@ PACKAGE_INSTALL = " \
     initramfs-module-machineid \
     initramfs-module-resindataexpander \
     initramfs-module-rorootfs \
+    initramfs-module-plymouth \
     initramfs-module-udev \
     initramfs-framework-base \
     udev \
+    plymouth \
     ${ROOTFS_BOOTSTRAP_INSTALL} \
     "
 
 # Do not pollute the initrd image with rootfs features
-IMAGE_FEATURES = ""
+IMAGE_FEATURES = "splash"
 
 export IMAGE_BASENAME = "resin-image-initramfs"
 IMAGE_LINGUAS = ""

--- a/meta-resin-common/recipes-core/initrdscripts/files/plymouth
+++ b/meta-resin-common/recipes-core/initrdscripts/files/plymouth
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+plymouth_enabled() {
+  return 0
+}
+
+plymouth_run() {
+    mkdir /mnt/boot
+    mount /dev/disk/by-label/resin-boot /mnt/boot/
+    plymouthd --tty=tty1 --pid-file=/run/plymouth/pid --kernel-command-line='plymouth.ignore-serial-consoles splash'
+    plymouth --show-splash
+    plymouth quit
+    # we leave /mnt/boot mounted
+}

--- a/meta-resin-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-resin-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -6,6 +6,7 @@ SRC_URI_append = " \
     file://resindataexpander \
     file://rorootfs \
     file://rootfs \
+    file://plymouth \
     file://finish \
     "
 
@@ -17,6 +18,8 @@ do_install_append() {
     install -m 0755 ${WORKDIR}/machineid ${D}/init.d/91-machineid
     install -m 0755 ${WORKDIR}/resindataexpander ${D}/init.d/88-resindataexpander
     install -m 0755 ${WORKDIR}/rorootfs ${D}/init.d/89-rorootfs
+
+    install -m 0755 ${WORKDIR}/plymouth ${D}/init.d/92-plymouth
 }
 
 PACKAGES_append = " \
@@ -24,6 +27,7 @@ PACKAGES_append = " \
     initramfs-module-machineid \
     initramfs-module-resindataexpander \
     initramfs-module-rorootfs \
+    initramfs-module-plymouth \
     "
 
 RRECOMMENDS_${PN}-base += "initramfs-module-rootfs"
@@ -47,3 +51,7 @@ FILES_initramfs-module-rorootfs = "/init.d/89-rorootfs"
 SUMMARY_initramfs-module-rootfs = "initramfs support for locating and mounting the root partition"
 RDEPENDS_initramfs-module-rootfs = "${PN}-base"
 FILES_initramfs-module-rootfs = "/init.d/90-rootfs"
+
+SUMMARY_initramfs-module-plymouth = "display boot splash screen"
+RDEPENDS_initramfs-module-plymouth = "${PN}-base"
+FILES_initramfs-module-plymouth = "/init.d/92-plymouth"

--- a/meta-resin-common/recipes-core/plymouth/plymouth_0.9.2.bbappend
+++ b/meta-resin-common/recipes-core/plymouth/plymouth_0.9.2.bbappend
@@ -31,10 +31,6 @@ do_install_append() {
     mkdir -p ${D}${datadir}/plymouth/themes/resin
     install -m 644 ${WORKDIR}/resin.script ${D}${datadir}/plymouth/themes/resin/
     install -m 644 ${WORKDIR}/resin.plymouth ${D}${datadir}/plymouth/themes/resin/
-
-    # Don't stop splash at boot
-    rm ${D}${systemd_unitdir}/system/multi-user.target.wants/plymouth-quit.service
-    rm ${D}${systemd_unitdir}/system/multi-user.target.wants/plymouth-quit-wait.service
 }
 
 do_deploy() {

--- a/meta-resin-common/recipes-core/plymouth/plymouth_0.9.2.bbappend
+++ b/meta-resin-common/recipes-core/plymouth/plymouth_0.9.2.bbappend
@@ -55,4 +55,7 @@ pkg_postinst_${PN}_append () {
 	fi
 	systemctl $OPTS mask systemd-ask-password-plymouth.service
 	systemctl $OPTS mask systemd-ask-password-plymouth.path
+
+	# We start plymouth in the initramfs so mask the service
+	systemctl $OPTS mask plymouth-start.service
 }


### PR DESCRIPTION
Fixes #1081 

This PR moves plymouth to initramfs to display the bootsplash early.
There is still a bug that I'm currently looking into which I suspect is linked to `console=null` being passed on the cmdline in production images.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
