### PR TITLE
kernel-resin: Drop obsolete eval from do_kernel_resin_reconfigure

### DIFF
--- a/meta-resin-common/classes/kernel-resin.bbclass
+++ b/meta-resin-common/classes/kernel-resin.bbclass
@@ -676,7 +676,7 @@ do_kernel_resin_injectconfig[dirs] += "${WORKDIR} ${B}"
 # Reconfigure kernel after we inject resin configs
 #
 do_kernel_resin_reconfigure() {
-    eval ${KERNEL_CONFIG_COMMAND}
+    ${KERNEL_CONFIG_COMMAND}
 }
 addtask kernel_resin_reconfigure after do_kernel_resin_injectconfig before do_compile
 do_kernel_resin_reconfigure[vardeps] += "RESIN_CONFIGS RESIN_CONFIGS_DEPS"


### PR DESCRIPTION
This is not needed as bitbake already expands KERNEL_CONFIG_COMMAND
See Poky commit 95909bc788bef1baabead94231dffb3b7f59fb00 for details

Change-type: minor
Changelog-entry: Drop obsolete eval from kernel-resin's do_kernel_resin_reconfigure
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
