### PR TITLE
resin-proxy-config: Avoid iptables race

### DIFF
--- a/meta-resin-common/recipes-connectivity/resin-proxy-config/resin-proxy-config/resin-proxy-config
+++ b/meta-resin-common/recipes-connectivity/resin-proxy-config/resin-proxy-config/resin-proxy-config
@@ -5,6 +5,9 @@
 
 set -e
 
+IPTABLES_WAIT_SECS="10"
+IPTABLES="iptables -w $IPTABLES_WAIT_SECS"
+
 . /usr/sbin/resin-vars
 
 if [ ! -f "$CONFIG_PATH" ]; then
@@ -28,13 +31,13 @@ NOPROXYFILE=${RESIN_BOOT_MOUNTPOINT}/system-proxy/no_proxy
 # change, you need to refresh the redsocks patch as well.
 
 # Always clear the REDSOCKS chain if it exists (in case we're restarting with a changed configuration)
-iptables -t nat -D OUTPUT -p udp -m owner ! --uid-owner redsocks -j DNAT --dport 53 --to-destination 10.114.103.1:5313 || true
-iptables -t nat -D PREROUTING -p udp -j DNAT --dport 53 --to-destination 10.114.103.1:5313 || true
-iptables -t nat -D OUTPUT -m owner --uid-owner redsocks -p tcp --dport 53 -j REDSOCKS || true
-iptables -t nat -D OUTPUT -m owner ! --uid-owner redsocks -p tcp -j REDSOCKS || true
-iptables -t nat -D PREROUTING -p tcp -j REDSOCKS || true
-iptables -t nat -F REDSOCKS || true
-iptables -t nat -X REDSOCKS || true
+$IPTABLES -t nat -D OUTPUT -p udp -m owner ! --uid-owner redsocks -j DNAT --dport 53 --to-destination 10.114.103.1:5313 || true
+$IPTABLES -t nat -D PREROUTING -p udp -j DNAT --dport 53 --to-destination 10.114.103.1:5313 || true
+$IPTABLES -t nat -D OUTPUT -m owner --uid-owner redsocks -p tcp --dport 53 -j REDSOCKS || true
+$IPTABLES -t nat -D OUTPUT -m owner ! --uid-owner redsocks -p tcp -j REDSOCKS || true
+$IPTABLES -t nat -D PREROUTING -p tcp -j REDSOCKS || true
+$IPTABLES -t nat -F REDSOCKS || true
+$IPTABLES -t nat -X REDSOCKS || true
 
 if [ ! -f "$REDSOCKSCONF" ]; then
 	echo "resin-proxy-config: No proxy configuration found, skipping."
@@ -58,36 +61,36 @@ fi
 id -u redsocks > /dev/null 2>&1 || (echo "ERROR: redsocks user doesn't exist" && exit 1)
 
 # Set up iptables chain for redsocks
-iptables -t nat -N REDSOCKS
+$IPTABLES -t nat -N REDSOCKS
 
 # Use every line in the no_proxy file as an IP/subnet to not redirect through redsocks
 if [ -f "$NOPROXYFILE" ]; then
 	echo "Noproxy configuration found in $NOPROXYFILE ..."
 	while IFS= read -r line || [ -n "${line}" ]; do
 		echo "Setting no proxy for $line ..."
-		iptables -t nat -A REDSOCKS -d "$line" -j RETURN
+		$IPTABLES -t nat -A REDSOCKS -d "$line" -j RETURN
 	done < "$NOPROXYFILE"
 fi
 
 # Setup a new user chain for redsocks
-iptables -t nat -A REDSOCKS -d 0.0.0.0/8 -j RETURN
-iptables -t nat -A REDSOCKS -d 10.0.0.0/8 -j RETURN
-iptables -t nat -A REDSOCKS -d 127.0.0.0/8 -j RETURN
-iptables -t nat -A REDSOCKS -d 169.254.0.0/16 -j RETURN
-iptables -t nat -A REDSOCKS -d 172.16.0.0/12 -j RETURN
-iptables -t nat -A REDSOCKS -d 192.168.0.0/16 -j RETURN
-iptables -t nat -A REDSOCKS -d 224.0.0.0/4 -j RETURN
-iptables -t nat -A REDSOCKS -d 240.0.0.0/4 -j RETURN
-iptables -t nat -A REDSOCKS -p tcp -j DNAT --to 10.114.103.1:12345
+$IPTABLES -t nat -A REDSOCKS -d 0.0.0.0/8 -j RETURN
+$IPTABLES -t nat -A REDSOCKS -d 10.0.0.0/8 -j RETURN
+$IPTABLES -t nat -A REDSOCKS -d 127.0.0.0/8 -j RETURN
+$IPTABLES -t nat -A REDSOCKS -d 169.254.0.0/16 -j RETURN
+$IPTABLES -t nat -A REDSOCKS -d 172.16.0.0/12 -j RETURN
+$IPTABLES -t nat -A REDSOCKS -d 192.168.0.0/16 -j RETURN
+$IPTABLES -t nat -A REDSOCKS -d 224.0.0.0/4 -j RETURN
+$IPTABLES -t nat -A REDSOCKS -d 240.0.0.0/4 -j RETURN
+$IPTABLES -t nat -A REDSOCKS -p tcp -j DNAT --to 10.114.103.1:12345
 
 if $(cat /mnt/boot/system-proxy/redsocks.conf | grep ^dnsu2t > /dev/null 2>&1); then
 	# If dnsu2t module is enabled in redsocks, redirect any DNS UDP packets to
 	# REDSOCKS to force DNS over TCP
-	iptables -t nat -A OUTPUT -p udp -m owner ! --uid-owner redsocks -j DNAT --dport 53 --to-destination 10.114.103.1:5313
-	iptables -t nat -A PREROUTING -p udp -j DNAT --dport 53 --to-destination 10.114.103.1:5313
+	$IPTABLES -t nat -A OUTPUT -p udp -m owner ! --uid-owner redsocks -j DNAT --dport 53 --to-destination 10.114.103.1:5313
+	$IPTABLES -t nat -A PREROUTING -p udp -j DNAT --dport 53 --to-destination 10.114.103.1:5313
 fi
 
 # Redirect TCP connections to redsocks
-iptables -t nat -A OUTPUT -m owner --uid-owner redsocks -p tcp --dport 53 -j REDSOCKS
-iptables -t nat -A OUTPUT -m owner ! --uid-owner redsocks -p tcp -j REDSOCKS
-iptables -t nat -A PREROUTING -p tcp -j REDSOCKS
+$IPTABLES -t nat -A OUTPUT -m owner --uid-owner redsocks -p tcp --dport 53 -j REDSOCKS
+$IPTABLES -t nat -A OUTPUT -m owner ! --uid-owner redsocks -p tcp -j REDSOCKS
+$IPTABLES -t nat -A PREROUTING -p tcp -j REDSOCKS


### PR DESCRIPTION
There are other components setting up iptables rules - for example
balena. In order to avoid a lock race, run iptables commands with a 10
seconds wait flag.

Change-type: minor
Changelog-entry: Avoid xtables lock in resin-proxy-config
Signed-off-by: Andrei Gherzan <andrei@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
