### PR TITLE
avahi: Bring back avahi dbus introspection files

### DIFF
--- a/meta-resin-common/recipes-connectivity/avahi/avahi_%.bbappend
+++ b/meta-resin-common/recipes-connectivity/avahi/avahi_%.bbappend
@@ -2,7 +2,10 @@ FILESEXTRAPATHS_append := ":${THISDIR}/files"
 
 SRC_URI_append = " file://avahi-daemon.conf"
 
-FILES_avahi-daemon += "${sysconfdir}/systemd/system/avahi-daemon.service.d/avahi-daemon.conf"
+FILES_avahi-daemon += " \
+    ${sysconfdir}/systemd/system/avahi-daemon.service.d/avahi-daemon.conf \
+    ${datadir}/dbus-1/interfaces \
+"
 
 RDEPENDS_avahi-daemon += "resin-hostname"
 
@@ -16,4 +19,12 @@ do_install_append() {
         install -d ${D}${sysconfdir}/systemd/system/avahi-daemon.service.d
         install -c -m 0644 ${WORKDIR}/avahi-daemon.conf ${D}${sysconfdir}/systemd/system/avahi-daemon.service.d
     fi
+
+    # Bring back the dbus introspection files poky removes
+    if [ ! -d ${D}${datadir}/dbus-1/interfaces ]; then
+        mkdir -p ${D}${datadir}/dbus-1/interfaces
+        for data in $(ls ${S}/avahi-daemon/*.xml); do
+            install -m 644 $data ${D}${datadir}/dbus-1/interfaces
+        done
+   fi
 }


### PR DESCRIPTION
Poky removes the dbus introspection description documents for avahi.
See:
http://git.yoctoproject.org/cgit.cgi/poky/commit/?id=59a08907eafffde664079b9a2068f47131dd3f5d

dbus-native node module requires this data to be available to allow
access to interfaces.

Fixes #1140

Change-type: minor
Changelog-entry: Include avahi d-bus introspection files in rootfs
Signed-off-by: Andrei Gherzan <andrei@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
