### PR TITLE
resin-mounts: Increase timeout for the filesystem label

### DIFF
--- a/meta-resin-common/recipes-support/resin-mounts/resin-mounts/resin-partition-mounter
+++ b/meta-resin-common/recipes-support/resin-mounts/resin-mounts/resin-partition-mounter
@@ -2,7 +2,7 @@
 
 set -e
 
-LABEL_TIMEOUT=30
+LABEL_TIMEOUT=190
 
 help () {
 	cat << EOF


### PR DESCRIPTION
The label is actually a udev symlink, but we're keeping
this naming to be consistent across the file.

The error seen is that the balena-host service wasn't
able to start because of a mnt-sysroot-active.service dependency:
resin-partition-mounter[440]: ERROR: Timeout while waiting
for filesystem label to appear

By increasing this timeout, the filesystem symlink should
already exist, at the time the mnt-sysroot-active service is
looking for this dependency.

Change-type: minor
Changelog-entry: Increase timeout for filesystem label
Signed-off-by: Vicentiu Galanopulo <vicentiu@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
