### PR TITLE
modemmanager: Enable support for Huawei ME936 modem in MBIM mode

### DIFF
--- a/meta-resin-common/recipes-connectivity/modemmanager/files/77-mm-huawei-configuration.rules
+++ b/meta-resin-common/recipes-connectivity/modemmanager/files/77-mm-huawei-configuration.rules
@@ -1,0 +1,11 @@
+# Copyright (c) 2013 The Chromium OS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+# This file specifies udev rules to configure certain Huawei modems to select
+# the USB configuration expected by Chrome OS.
+# Huawei ME936: Select the MBIM configuration
+ACTION=="add|change", SUBSYSTEM=="usb", \
+  ENV{DEVTYPE}=="usb_device|usb_interface", \
+  ATTRS{idVendor}=="12d1", ATTRS{idProduct}=="15bb", \
+  ATTRS{bNumConfigurations}=="3", ATTRS{bConfigurationValue}!="3", \
+  RUN+="/lib/udev/mm-huawei-configuration-switch.sh %E{DEVTYPE} %S%p 3"

--- a/meta-resin-common/recipes-connectivity/modemmanager/files/mm-huawei-configuration-switch.sh
+++ b/meta-resin-common/recipes-connectivity/modemmanager/files/mm-huawei-configuration-switch.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Copyright (c) 2014 The Chromium OS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# $1 is either "usb_device" or "usb_interface" depending on what triggered this
+# script.
+# $2 is the full sysfs path to the device/interface.
+# $3 is the configuration mode number we switch the modem to
+
+switch_device_configuration() {
+  # expect:
+  #  $1 : sysfs path for the device.
+  #  $2 : the configuration mode number we switch the modem to
+  echo "$2" > "$1"/bConfigurationValue
+}
+
+if [ "$1" = "usb_device" ]
+then
+  switch_device_configuration "$2" "$3"
+else
+  switch_device_configuration "$(dirname "$2")" "$3"
+fi

--- a/meta-resin-common/recipes-connectivity/modemmanager/modemmanager_%.bbappend
+++ b/meta-resin-common/recipes-connectivity/modemmanager/modemmanager_%.bbappend
@@ -4,6 +4,19 @@ SYSTEMD_AUTO_ENABLE = "enable"
 SRC_URI_append = " \
     file://0001-Revert-iface-modem-the-Command-method-is-only-allowe.patch \
     file://0002-ModemManager.service.in-Log-to-systemd-journal.patch \
+    file://77-mm-huawei-configuration.rules \
+    file://mm-huawei-configuration-switch.sh \
 "
 
+do_install_append() {
+    install -d ${D}/etc/udev/rules.d/
+    install -d ${D}/lib/udev/
+    install -m 0644 ${WORKDIR}/77-mm-huawei-configuration.rules ${D}/etc/udev/rules.d/
+    install -m 0755 ${WORKDIR}/mm-huawei-configuration-switch.sh ${D}/lib/udev/
+}
+
+FILES_${PN} += " \
+    /etc/udev/rules.d/77-mm-huawei-configuration.rules \
+    /lib/udev/mm-huawei-configuration-switch.sh \
+    "
 DEPENDS_append = " libxslt-native"


### PR DESCRIPTION
Add udev rule and helper script to switch this modem to MBIM mode

Change-type: minor
Changelog-entry: Add support for Huawei ME936 modem in MBIM mode
Signed-off-by: Florin Sarbu <florin@resin.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
