### PR TITLE
modemmanager: install udev rule in /lib instead of /etc/udev/rules.d

### DIFF
--- a/meta-resin-common/recipes-connectivity/modemmanager/modemmanager_%.bbappend
+++ b/meta-resin-common/recipes-connectivity/modemmanager/modemmanager_%.bbappend
@@ -9,14 +9,14 @@ SRC_URI_append = " \
 "
 
 do_install_append() {
-    install -d ${D}/etc/udev/rules.d/
     install -d ${D}/lib/udev/
-    install -m 0644 ${WORKDIR}/77-mm-huawei-configuration.rules ${D}/etc/udev/rules.d/
+    install -d ${D}/lib/udev/rules.d/
+    install -m 0644 ${WORKDIR}/77-mm-huawei-configuration.rules ${D}/lib/udev/rules.d/
     install -m 0755 ${WORKDIR}/mm-huawei-configuration-switch.sh ${D}/lib/udev/
 }
 
 FILES_${PN} += " \
-    /etc/udev/rules.d/77-mm-huawei-configuration.rules \
+    /lib/udev/rules.d/77-mm-huawei-configuration.rules \
     /lib/udev/mm-huawei-configuration-switch.sh \
     "
 DEPENDS_append = " libxslt-native"


### PR DESCRIPTION
/etc/udev/rules.d is now used by os-udevrules.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
