### PR TITLE
Fix kernel header for modules generation

### DIFF
--- a/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
+++ b/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
@@ -34,6 +34,17 @@ do_configure[noexec] = "1"
 do_compile() {
     mkdir -p kernel_modules_headers
     ${S}/gen_mod_headers ./kernel_modules_headers ${STAGING_KERNEL_DIR} ${DEPLOY_DIR_IMAGE} ${ARCH} ${TARGET_PREFIX} "${CC}" "${HOSTCC}"
+
+    # Sanity test
+    test_arch=$(find kernel_modules_headers/  | xargs file | grep ELF | xargs -I a bash -c 'if ! echo "a" | grep -Fiq "${ARCH}" ; then echo "Did not find ${ARCH}"; fi')
+    if [ ! -z "$test_arch" ]; then
+        bberror "Wrong arch found in ELF files"
+    fi
+    test_interpreter=$(find kernel_modules_headers/  | xargs file | grep ELF | xargs -I a bash -c 'if echo "a" | grep -Fiq "sysroot" ; then echo "Found sysroot in interpreter" ; fi')
+    if [ ! -z "$test_interpreter" ]; then
+        bberror "Sysroot keyword found in interpreter ELF files"
+    fi
+
     tar -czf kernel_modules_headers.tar.gz kernel_modules_headers
     rm -rf kernel_modules_headers
 }

--- a/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
+++ b/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
@@ -12,11 +12,15 @@ DEPENDS = " \
     bc-native \
     openssl \
     openssl-native \
+    util-linux-native \
+    elfutils-native \
+    util-linux \
+    elfutils \
     "
 
 SRC_URI = "git://github.com/resin-os/module-headers.git;protocol=https"
 
-SRCREV = "v0.0.11"
+SRCREV = "v0.0.12"
 
 S = "${WORKDIR}/git"
 B = "${WORKDIR}"
@@ -29,7 +33,7 @@ do_configure[noexec] = "1"
 
 do_compile() {
     mkdir -p kernel_modules_headers
-    ${S}/gen_mod_headers ./kernel_modules_headers ${STAGING_KERNEL_DIR} ${DEPLOY_DIR_IMAGE} ${ARCH} ${TARGET_PREFIX} "${HOSTCC}"
+    ${S}/gen_mod_headers ./kernel_modules_headers ${STAGING_KERNEL_DIR} ${DEPLOY_DIR_IMAGE} ${ARCH} ${TARGET_PREFIX} "${CC}" "${HOSTCC}"
     tar -czf kernel_modules_headers.tar.gz kernel_modules_headers
     rm -rf kernel_modules_headers
 }


### PR DESCRIPTION
Fixes https://github.com/balena-io-playground/kernel-module-build/issues/7
Fixes #1303 
Fixes #1302 

Tested pi3, jetson and nuc image.
NUC image needs the following workaround 
```
ln -s /lib64/ld-linux-x86-64.so.2  /lib/ld-linux-x86-64.so.2
```
in  build.sh in https://github.com/balena-io-playground/kernel-module-build/

The baselib in balenaOS is `/lib` which is used by the recipe. So the tools built inside the tarball have the interpreter path as  `/lib/ld-linux-x86-64.so.2`. But the baselib in the debian image is `/lib64`. This needs more thought on how to go about fixing this.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
