### PR TITLE
update-resin-supervisor: Allow update when there is not API key

### DIFF
--- a/meta-resin-common/recipes-containers/resin-supervisor/resin-supervisor/update-resin-supervisor
+++ b/meta-resin-common/recipes-containers/resin-supervisor/resin-supervisor/update-resin-supervisor
@@ -62,10 +62,6 @@ UPDATECONF=/tmp/update-supervisor.conf
 
 # If the user api key exists we use it instead of the deviceApiKey as it means we haven't done the key exchange yet
 _device_api_key=${PROVISIONING_API_KEY:-$DEVICE_API_KEY}
-if [ -z "$_device_api_key" ]; then
-    echo "PROVISIONING_API_KEY or DEVICE_API_KEY variables must be set."
-    exit 1
-fi
 
 error_handler() {
     # shellcheck disable=SC2181


### PR DESCRIPTION
When the device hasn't joined a backend, there is no API key available
and the update supervisor tool currently just bails out. This blocks
switching the supervisor version on an unmanaged device.

Change-type: minor
Changelog-entry: Allow supervisor update on unmanaged devices
Signed-off-by: Andrei Gherzan <andrei@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
