### PR TITLE
Fix rollback altboots to prevent good reboots by supervisor triggering rollback.

### DIFF
--- a/meta-resin-common/recipes-core/balena-rollback/balena-rollback.bb
+++ b/meta-resin-common/recipes-core/balena-rollback/balena-rollback.bb
@@ -18,8 +18,10 @@ LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99
 
 SRC_URI = " \
     file://rollback-altboot.service \
+    file://rollback-clear-bootcount.service \
     file://rollback-health.service \
     file://rollback-altboot \
+    file://rollback-clear-bootcount \
     file://rollback-health \
     file://rollback-stop \
     file://rollback-tests \
@@ -32,16 +34,19 @@ inherit allarch systemd
 SYSTEMD_SERVICE_${PN} = " \
 	rollback-altboot.service \
 	rollback-health.service \
+	rollback-clear-bootcount.service \
 	"
 
 do_install() {
     install -d ${D}${bindir}
     install -d ${D}${systemd_unitdir}/system
     install -m 0775 ${S}/rollback-altboot ${D}${bindir}
+    install -m 0775 ${S}/rollback-clear-bootcount ${D}${bindir}
     install -m 0775 ${S}/rollback-health ${D}${bindir}
     install -m 0775 ${S}/rollback-stop ${D}${bindir}
     install -m 0775 ${S}/rollback-tests ${D}${bindir}
     install -m 0775 ${S}/rollback-parse-bootloader ${D}${bindir}
     install -c -m 0644 ${S}/rollback-altboot.service ${D}${systemd_unitdir}/system
+    install -c -m 0644 ${S}/rollback-clear-bootcount.service ${D}${systemd_unitdir}/system
     install -c -m 0644 ${S}/rollback-health.service ${D}${systemd_unitdir}/system
 }

--- a/meta-resin-common/recipes-core/balena-rollback/files/rollback-clear-bootcount
+++ b/meta-resin-common/recipes-core/balena-rollback/files/rollback-clear-bootcount
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Copyright 2018 Balena Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+
+. /usr/sbin/resin-vars
+. /usr/bin/rollback-parse-bootloader
+
+if [ -f "/mnt/state/rollback-altboot-breadcrumb" ]; then
+	echo "Rollback: Clearing bootcount"
+	# Clear grub bootcount
+	grub_env=$(find "${RESIN_BOOT_MOUNTPOINT}" -name grubenv)
+	if [ -f "${grub_env}" ]; then
+		sed -i "s#bootcount=.*#bootcount=0 #g" "${grub_env}" || true
+	else
+		# Clear u-boot bootcount
+		rm -f "${RESIN_BOOT_MOUNTPOINT}/bootcount.env" || true
+	fi
+
+	sync -f "${RESIN_BOOT_MOUNTPOINT}"
+	echo "Rollback: Bootcount cleared"
+fi

--- a/meta-resin-common/recipes-core/balena-rollback/files/rollback-clear-bootcount.service
+++ b/meta-resin-common/recipes-core/balena-rollback/files/rollback-clear-bootcount.service
@@ -1,0 +1,28 @@
+# Copyright 2018 Balena Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=Rollback clear bootcount if altboot crumb is still present
+DefaultDependencies=no
+Before=umount.target
+Conflicts=umount.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/true
+ExecStopPost=/usr/bin/rollback-clear-bootcount
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
After a HUP, until rollbacks clears its state, the supervisor(or user)
can trigger good reboots. These reboots might be seen by the bootloader
as bad reboots.

To prevent this from happening, add a service that clears the bootcount
upon good reboots. This only runs if the rollback services have not
cleared their flag files in the state partition.

Change-type: minor
Changelog-entry: Fix rollback altboots to prevent good reboots by supervisor triggering rollback.
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
