### PR TITLE
Add chrony v3.2 recipe to ensure minimum chrony version in devices

### DIFF
--- a/meta-resin-krogoth/recipes-core/chrony/chrony/arm_eabi.patch
+++ b/meta-resin-krogoth/recipes-core/chrony/chrony/arm_eabi.patch
@@ -1,48 +1,54 @@
     chrony: fix build failure for arma9
-    
+
     Eliminate references to syscalls not available
     for ARM_EABI.  Also add a dependency on libseccomp
     which is needed for scfilter to work.
-    
+
     Set PACKAGECONFIG to not enable scfilter, since
     kernel CONFIG_SECCOMP is unlikely to be set.  This
     aligns the usage of libseccomp with that of other packages.
 
     Upstream-Status: Pending
-    
+
     Signed-off-by: Joe Slater <jslater@windriver.com>
+
+    Refresh patch for new upstream version.
+
+    Signed-off-by: Robert Joslyn <robert.joslyn@redrectangle.org>
 
 --- a/sys_linux.c
 +++ b/sys_linux.c
-@@ -453,13 +453,12 @@ SYS_Linux_EnableSystemCallFilter(int lev
+@@ -465,14 +465,14 @@ SYS_Linux_EnableSystemCallFilter(int lev
    const int syscalls[] = {
      /* Clock */
-     SCMP_SYS(adjtimex), SCMP_SYS(gettimeofday), SCMP_SYS(settimeofday),
--    SCMP_SYS(time),
+     SCMP_SYS(adjtimex), SCMP_SYS(clock_gettime), SCMP_SYS(gettimeofday),
+-    SCMP_SYS(settimeofday), SCMP_SYS(time),
++    SCMP_SYS(settimeofday),
      /* Process */
--    SCMP_SYS(clone), SCMP_SYS(exit), SCMP_SYS(exit_group), SCMP_SYS(getrlimit),
-+    SCMP_SYS(clone), SCMP_SYS(exit), SCMP_SYS(exit_group),
-     SCMP_SYS(rt_sigaction), SCMP_SYS(rt_sigreturn), SCMP_SYS(rt_sigprocmask),
-     SCMP_SYS(set_tid_address), SCMP_SYS(sigreturn), SCMP_SYS(wait4),
+     SCMP_SYS(clone), SCMP_SYS(exit), SCMP_SYS(exit_group), SCMP_SYS(getpid),
+-    SCMP_SYS(getrlimit), SCMP_SYS(rt_sigaction), SCMP_SYS(rt_sigreturn),
++    SCMP_SYS(rt_sigaction), SCMP_SYS(rt_sigreturn),
+     SCMP_SYS(rt_sigprocmask), SCMP_SYS(set_tid_address), SCMP_SYS(sigreturn),
+     SCMP_SYS(wait4),
      /* Memory */
 -    SCMP_SYS(brk), SCMP_SYS(madvise), SCMP_SYS(mmap), SCMP_SYS(mmap2),
 +    SCMP_SYS(brk), SCMP_SYS(madvise), SCMP_SYS(mmap2),
      SCMP_SYS(mprotect), SCMP_SYS(mremap), SCMP_SYS(munmap), SCMP_SYS(shmdt),
      /* Filesystem */
      SCMP_SYS(access), SCMP_SYS(chmod), SCMP_SYS(chown), SCMP_SYS(chown32),
-@@ -470,14 +469,21 @@ SYS_Linux_EnableSystemCallFilter(int lev
+@@ -483,14 +483,21 @@
      SCMP_SYS(bind), SCMP_SYS(connect), SCMP_SYS(getsockname),
-     SCMP_SYS(recvfrom), SCMP_SYS(recvmsg), SCMP_SYS(sendmmsg),
-     SCMP_SYS(sendmsg), SCMP_SYS(sendto),
+     SCMP_SYS(recvfrom), SCMP_SYS(recvmmsg), SCMP_SYS(recvmsg),
+     SCMP_SYS(sendmmsg), SCMP_SYS(sendmsg), SCMP_SYS(sendto),
 -    /* TODO: check socketcall arguments */
 -    SCMP_SYS(socketcall),
      /* General I/O */
-     SCMP_SYS(_newselect), SCMP_SYS(close), SCMP_SYS(open), SCMP_SYS(pipe),
+     SCMP_SYS(_newselect), SCMP_SYS(close), SCMP_SYS(open), SCMP_SYS(openat), SCMP_SYS(pipe),
 -    SCMP_SYS(poll), SCMP_SYS(read), SCMP_SYS(futex), SCMP_SYS(select),
 +    SCMP_SYS(poll), SCMP_SYS(read), SCMP_SYS(futex),
      SCMP_SYS(set_robust_list), SCMP_SYS(write),
      /* Miscellaneous */
-     SCMP_SYS(uname),
+     SCMP_SYS(getrandom), SCMP_SYS(sysinfo), SCMP_SYS(uname),
 +    /* not always available */
 +#if ! defined(__ARM_EABI__)
 +    SCMP_SYS(time),

--- a/meta-resin-krogoth/recipes-core/chrony/chrony_3.2.bb
+++ b/meta-resin-krogoth/recipes-core/chrony/chrony_3.2.bb
@@ -25,7 +25,7 @@ This recipe produces two binary packages: 'chrony' which contains chronyd, \
 the configuration file and the init script, and 'chronyc' which contains \
 the client program only."
 
-HOMEPAGE = "http://chrony.tuxfamily.org/"
+HOMEPAGE = "https://chrony.tuxfamily.org/"
 SECTION = "net"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
@@ -35,8 +35,8 @@ SRC_URI = "https://download.tuxfamily.org/chrony/chrony-${PV}.tar.gz \
     file://chronyd \
     file://arm_eabi.patch \
 "
-SRC_URI[md5sum] = "d0598aa8a9be8faccef9386f6fc0d5f2"
-SRC_URI[sha256sum] = "8d04e7cda2333289c2104b731d39c3c1db94816e43bae35d7ee4e7ae8af6391f"
+SRC_URI[md5sum] = "f4c4eb0dc92f35ee4bb7d3dcd8029ecb"
+SRC_URI[sha256sum] = "329f6718dd8c3ece3eee78be1f4821cbbeb62608e7d23f25da293cfa433c4116"
 
 DEPENDS = "pps-tools"
 
@@ -59,6 +59,9 @@ inherit update-rc.d systemd
 #     chrony.conf and init script.
 #   - 'scfilter' enables support for system call filtering, but requires the
 #     kernel to have CONFIG_SECCOMP enabled.
+PACKAGECONFIG ??= "editline \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'ipv6', d)} \
+"
 PACKAGECONFIG[readline] = "--without-editline,--without-readline,readline"
 PACKAGECONFIG[editline] = ",--without-editline,libedit"
 PACKAGECONFIG[sechash] = "--without-tomcrypt,--disable-sechash,nss"

--- a/meta-resin-morty/recipes-core/chrony/chrony/arm_eabi.patch
+++ b/meta-resin-morty/recipes-core/chrony/chrony/arm_eabi.patch
@@ -1,0 +1,63 @@
+    chrony: fix build failure for arma9
+
+    Eliminate references to syscalls not available
+    for ARM_EABI.  Also add a dependency on libseccomp
+    which is needed for scfilter to work.
+
+    Set PACKAGECONFIG to not enable scfilter, since
+    kernel CONFIG_SECCOMP is unlikely to be set.  This
+    aligns the usage of libseccomp with that of other packages.
+
+    Upstream-Status: Pending
+
+    Signed-off-by: Joe Slater <jslater@windriver.com>
+
+    Refresh patch for new upstream version.
+
+    Signed-off-by: Robert Joslyn <robert.joslyn@redrectangle.org>
+
+--- a/sys_linux.c
++++ b/sys_linux.c
+@@ -465,14 +465,14 @@ SYS_Linux_EnableSystemCallFilter(int lev
+   const int syscalls[] = {
+     /* Clock */
+     SCMP_SYS(adjtimex), SCMP_SYS(clock_gettime), SCMP_SYS(gettimeofday),
+-    SCMP_SYS(settimeofday), SCMP_SYS(time),
++    SCMP_SYS(settimeofday),
+     /* Process */
+     SCMP_SYS(clone), SCMP_SYS(exit), SCMP_SYS(exit_group), SCMP_SYS(getpid),
+-    SCMP_SYS(getrlimit), SCMP_SYS(rt_sigaction), SCMP_SYS(rt_sigreturn),
++    SCMP_SYS(rt_sigaction), SCMP_SYS(rt_sigreturn),
+     SCMP_SYS(rt_sigprocmask), SCMP_SYS(set_tid_address), SCMP_SYS(sigreturn),
+     SCMP_SYS(wait4),
+     /* Memory */
+-    SCMP_SYS(brk), SCMP_SYS(madvise), SCMP_SYS(mmap), SCMP_SYS(mmap2),
++    SCMP_SYS(brk), SCMP_SYS(madvise), SCMP_SYS(mmap2),
+     SCMP_SYS(mprotect), SCMP_SYS(mremap), SCMP_SYS(munmap), SCMP_SYS(shmdt),
+     /* Filesystem */
+     SCMP_SYS(access), SCMP_SYS(chmod), SCMP_SYS(chown), SCMP_SYS(chown32),
+@@ -483,14 +483,21 @@
+     SCMP_SYS(bind), SCMP_SYS(connect), SCMP_SYS(getsockname),
+     SCMP_SYS(recvfrom), SCMP_SYS(recvmmsg), SCMP_SYS(recvmsg),
+     SCMP_SYS(sendmmsg), SCMP_SYS(sendmsg), SCMP_SYS(sendto),
+-    /* TODO: check socketcall arguments */
+-    SCMP_SYS(socketcall),
+     /* General I/O */
+     SCMP_SYS(_newselect), SCMP_SYS(close), SCMP_SYS(open), SCMP_SYS(openat), SCMP_SYS(pipe),
+-    SCMP_SYS(poll), SCMP_SYS(read), SCMP_SYS(futex), SCMP_SYS(select),
++    SCMP_SYS(poll), SCMP_SYS(read), SCMP_SYS(futex),
+     SCMP_SYS(set_robust_list), SCMP_SYS(write),
+     /* Miscellaneous */
+     SCMP_SYS(getrandom), SCMP_SYS(sysinfo), SCMP_SYS(uname),
++    /* not always available */
++#if ! defined(__ARM_EABI__)
++    SCMP_SYS(time),
++    SCMP_SYS(getrlimit),
++    SCMP_SYS(select),
++    SCMP_SYS(mmap),
++    /* TODO: check socketcall arguments */
++    SCMP_SYS(socketcall),
++#endif
+   };
+ 
+   const int socket_domains[] = {

--- a/meta-resin-morty/recipes-core/chrony/chrony/chrony.conf
+++ b/meta-resin-morty/recipes-core/chrony/chrony/chrony.conf
@@ -1,0 +1,44 @@
+# Use public NTP servers from the pool.ntp.org project.
+# Please consider joining the pool project if possible by running your own
+# server(s).
+# If you are a vendor distributing a product using chrony, you *MUST*
+# read and comply with http://www.pool.ntp.org/vendors.html
+pool 0.openembedded.pool.ntp.org iburst
+
+# Use a local timeserver in preference to the pool, if it's reachable.
+#server 192.168.22.22 iburst minpoll 2 prefer
+
+# Sync to pulse-per-second from an onboard GPS.
+#refclock PPS /dev/pps0 poll 0 prefer
+# You'll want to enable CONFIG_PPS and CONFIG_PPS_CLIENT_GPIO in your kernel,
+# and an entry something like this in your device tree:
+#	pps {
+#		compatible = "pps-gpio";
+#		gpios = <&ps7_gpio_0 56 0>;
+#	};
+
+# In first three updates step the system clock instead of slew
+# if the adjustment is larger than 1 second.
+makestep 1.0 3
+
+# Record the rate at which the system clock gains/loses time,
+# improving accuracy after reboot
+driftfile /var/lib/chrony/drift
+
+# Enable kernel synchronization of the hardware real-time clock (RTC).
+rtcsync
+
+# Allow NTP client access from local network.
+#allow 192.168/16
+
+# Serve time even if not synchronized to any NTP server.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+#keyfile /etc/chrony.keys
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking

--- a/meta-resin-morty/recipes-core/chrony/chrony/chronyd
+++ b/meta-resin-morty/recipes-core/chrony/chrony/chronyd
@@ -1,0 +1,58 @@
+#! /bin/sh
+
+# System V init script for chrony
+# Adapted from the script already in meta-networking for ntpd
+
+### BEGIN INIT INFO
+# Provides:        chrony
+# Required-Start:  $network $remote_fs $syslog
+# Required-Stop:   $network $remote_fs $syslog
+# Default-Start:   2 3 4 5
+# Default-Stop:
+# Short-Description: Start chrony time daemon
+### END INIT INFO
+
+PATH=/sbin:/bin:/usr/bin:/usr/sbin
+
+DAEMON=/usr/sbin/chronyd
+PIDFILE=/var/run/chronyd.pid
+
+test -x $DAEMON -a -r /etc/chrony.conf || exit 0
+
+# Source function library.
+. /etc/init.d/functions
+
+# Functions to do individual actions
+startdaemon(){
+	echo -n "Starting chronyd: "
+	start-stop-daemon --start --quiet --oknodo --pidfile $PIDFILE --startas $DAEMON -- "$@"
+	echo "done"
+}
+stopdaemon(){
+	echo -n "Stopping chronyd: "
+	start-stop-daemon --stop --quiet --oknodo -p $PIDFILE
+	echo "done"
+}
+
+case "$1" in
+  start)
+	startdaemon
+	;;
+  stop)
+  	stopdaemon
+	;;
+  force-reload | restart | reload)
+  	stopdaemon
+	startdaemon
+	;;
+  status)
+	status /usr/sbin/chronyd;
+	exit $?
+	;;
+  *)
+	echo "Usage: chronyd { start | stop | status | restart | reload }" >&2
+	exit 1
+	;;
+esac
+
+exit 0

--- a/meta-resin-morty/recipes-core/chrony/chrony_3.2.bb
+++ b/meta-resin-morty/recipes-core/chrony/chrony_3.2.bb
@@ -1,0 +1,134 @@
+SUMMARY = "Versatile implementation of the Network Time Protocol"
+DESCRIPTION = "Chrony can synchronize the system clock with NTP \
+servers, reference clocks (e.g. GPS receiver), and manual input using \
+wristwatch and keyboard. It can also operate as an NTPv4 (RFC 5905) \
+server and peer to provide a time service to other computers in the \
+network. \
+\
+It is designed to perform well in a wide range of conditions, \
+including intermittent network connections, heavily congested \
+networks, changing temperatures (ordinary computer clocks are \
+sensitive to temperature), and systems that do not run continuously, or \
+run on a virtual machine. \
+\
+Typical accuracy between two machines on a LAN is in tens, or a few \
+hundreds, of microseconds; over the Internet, accuracy is typically \
+within a few milliseconds. With a good hardware reference clock \
+sub-microsecond accuracy is possible. \
+\
+Two programs are included in chrony: chronyd is a daemon that can be \
+started at boot time and chronyc is a command-line interface program \
+which can be used to monitor chronyd's performance and to change \
+various operating parameters whilst it is running. \
+\
+This recipe produces two binary packages: 'chrony' which contains chronyd, \
+the configuration file and the init script, and 'chronyc' which contains \
+the client program only."
+
+HOMEPAGE = "https://chrony.tuxfamily.org/"
+SECTION = "net"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
+
+SRC_URI = "https://download.tuxfamily.org/chrony/chrony-${PV}.tar.gz \
+    file://chrony.conf \
+    file://chronyd \
+    file://arm_eabi.patch \
+"
+SRC_URI[md5sum] = "f4c4eb0dc92f35ee4bb7d3dcd8029ecb"
+SRC_URI[sha256sum] = "329f6718dd8c3ece3eee78be1f4821cbbeb62608e7d23f25da293cfa433c4116"
+
+DEPENDS = "pps-tools"
+
+# Note: Despite being built via './configure; make; make install',
+#       chrony does not use GNU Autotools.
+inherit update-rc.d systemd
+
+# Configuration options:
+# - For command line editing support in chronyc, you may specify either
+#   'editline' or 'readline' but not both.  editline is smaller, but
+#   many systems already have readline for other purposes so you might want
+#   to choose that instead.  However, beware license incompatibility
+#   since chrony is GPLv2 and readline versions after 6.0 are GPLv3+.
+#   You can of course choose neither, but if you're that tight on space
+#   consider dropping chronyc entirely (you can use it remotely with
+#   appropriate chrony.conf options).
+# - Security-related:
+#   - 'sechash' is omitted by default because it pulls in nss which is huge.
+#   - 'privdrop' allows chronyd to run as non-root; would need changes to
+#     chrony.conf and init script.
+#   - 'scfilter' enables support for system call filtering, but requires the
+#     kernel to have CONFIG_SECCOMP enabled.
+PACKAGECONFIG ??= "editline \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'ipv6', d)} \
+"
+PACKAGECONFIG[readline] = "--without-editline,--without-readline,readline"
+PACKAGECONFIG[editline] = ",--without-editline,libedit"
+PACKAGECONFIG[sechash] = "--without-tomcrypt,--disable-sechash,nss"
+PACKAGECONFIG[privdrop] = ",--disable-privdrop,libcap"
+PACKAGECONFIG[scfilter] = "--enable-scfilter,--without-seccomp,libseccomp"
+PACKAGECONFIG[ipv6] = ",--disable-ipv6,"
+PACKAGECONFIG[nss] = "--with-nss,--without-nss,nss"
+PACKAGECONFIG[libcap] = "--with-libcap,--without-libcap,libcap"
+
+# --disable-static isn't supported by chrony's configure script.
+DISABLE_STATIC = ""
+
+do_configure() {
+    ./configure --sysconfdir=${sysconfdir} --bindir=${bindir} --sbindir=${sbindir} \
+                --localstatedir=${localstatedir} --datarootdir=${datadir} \
+                ${PACKAGECONFIG_CONFARGS}
+}
+
+do_install() {
+    # Binaries
+    install -d ${D}${bindir}
+    install -m 0755 ${S}/chronyc ${D}${bindir}
+    install -d ${D}${sbindir}
+    install -m 0755 ${S}/chronyd ${D}${sbindir}
+
+    # Config file
+    install -d ${D}${sysconfdir}
+    install -m 644 ${WORKDIR}/chrony.conf ${D}${sysconfdir}
+
+    # System V init script
+    install -d ${D}${sysconfdir}/init.d
+    install -m 755 ${WORKDIR}/chronyd ${D}${sysconfdir}/init.d
+
+    # systemd unit configuration file
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${S}/examples/chronyd.service ${D}${systemd_unitdir}/system/
+
+    # Variable data (for drift and/or rtc file)
+    install -d ${D}${localstatedir}/lib/chrony
+
+    # Log files
+    install -d ${D}${localstatedir}/log/chrony
+
+    # Fix hard-coded paths in config files and init scripts
+    sed -i -e 's!/var/!${localstatedir}/!g' -e 's!/etc/!${sysconfdir}/!g' \
+           -e 's!/usr/sbin/!${sbindir}/!g' -e 's!/usr/bin/!${bindir}/!g' \
+           ${D}${sysconfdir}/chrony.conf \
+           ${D}${sysconfdir}/init.d/chronyd \
+           ${D}${systemd_unitdir}/system/chronyd.service
+    sed -i 's!^PATH=.*!PATH=${base_sbindir}:${base_bindir}:${sbindir}:${bindir}!' ${D}${sysconfdir}/init.d/chronyd
+    sed -i 's!^EnvironmentFile=.*!EnvironmentFile=-${sysconfdir}/default/chronyd!' ${D}${systemd_unitdir}/system/chronyd.service
+}
+
+FILES_${PN} = "${sbindir}/chronyd ${sysconfdir} ${localstatedir}"
+CONFFILES_${PN} = "${sysconfdir}/chrony.conf"
+INITSCRIPT_NAME = "chronyd"
+INITSCRIPT_PARAMS = "defaults"
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE_${PN} = "chronyd.service"
+
+# It's probably a bad idea to run chrony and another time daemon on
+# the same system.  systemd includes the SNTP client 'timesyncd', which
+# will be disabled by chronyd.service, however it will remain on the rootfs
+# wasting 150 kB unless you put 'PACKAGECONFIG_remove_pn-systemd = "timesyncd"'
+# in a conf file or bbappend somewhere.
+RCONFLICTS_${PN} = "ntp ntimed"
+
+# Separate the client program into its own package
+PACKAGES =+ "chronyc"
+FILES_chronyc = "${bindir}/chronyc"

--- a/meta-resin-pyro/recipes-core/chrony/chrony/arm_eabi.patch
+++ b/meta-resin-pyro/recipes-core/chrony/chrony/arm_eabi.patch
@@ -1,0 +1,63 @@
+    chrony: fix build failure for arma9
+
+    Eliminate references to syscalls not available
+    for ARM_EABI.  Also add a dependency on libseccomp
+    which is needed for scfilter to work.
+
+    Set PACKAGECONFIG to not enable scfilter, since
+    kernel CONFIG_SECCOMP is unlikely to be set.  This
+    aligns the usage of libseccomp with that of other packages.
+
+    Upstream-Status: Pending
+
+    Signed-off-by: Joe Slater <jslater@windriver.com>
+
+    Refresh patch for new upstream version.
+
+    Signed-off-by: Robert Joslyn <robert.joslyn@redrectangle.org>
+
+--- a/sys_linux.c
++++ b/sys_linux.c
+@@ -465,14 +465,14 @@ SYS_Linux_EnableSystemCallFilter(int lev
+   const int syscalls[] = {
+     /* Clock */
+     SCMP_SYS(adjtimex), SCMP_SYS(clock_gettime), SCMP_SYS(gettimeofday),
+-    SCMP_SYS(settimeofday), SCMP_SYS(time),
++    SCMP_SYS(settimeofday),
+     /* Process */
+     SCMP_SYS(clone), SCMP_SYS(exit), SCMP_SYS(exit_group), SCMP_SYS(getpid),
+-    SCMP_SYS(getrlimit), SCMP_SYS(rt_sigaction), SCMP_SYS(rt_sigreturn),
++    SCMP_SYS(rt_sigaction), SCMP_SYS(rt_sigreturn),
+     SCMP_SYS(rt_sigprocmask), SCMP_SYS(set_tid_address), SCMP_SYS(sigreturn),
+     SCMP_SYS(wait4),
+     /* Memory */
+-    SCMP_SYS(brk), SCMP_SYS(madvise), SCMP_SYS(mmap), SCMP_SYS(mmap2),
++    SCMP_SYS(brk), SCMP_SYS(madvise), SCMP_SYS(mmap2),
+     SCMP_SYS(mprotect), SCMP_SYS(mremap), SCMP_SYS(munmap), SCMP_SYS(shmdt),
+     /* Filesystem */
+     SCMP_SYS(access), SCMP_SYS(chmod), SCMP_SYS(chown), SCMP_SYS(chown32),
+@@ -483,14 +483,21 @@
+     SCMP_SYS(bind), SCMP_SYS(connect), SCMP_SYS(getsockname),
+     SCMP_SYS(recvfrom), SCMP_SYS(recvmmsg), SCMP_SYS(recvmsg),
+     SCMP_SYS(sendmmsg), SCMP_SYS(sendmsg), SCMP_SYS(sendto),
+-    /* TODO: check socketcall arguments */
+-    SCMP_SYS(socketcall),
+     /* General I/O */
+     SCMP_SYS(_newselect), SCMP_SYS(close), SCMP_SYS(open), SCMP_SYS(openat), SCMP_SYS(pipe),
+-    SCMP_SYS(poll), SCMP_SYS(read), SCMP_SYS(futex), SCMP_SYS(select),
++    SCMP_SYS(poll), SCMP_SYS(read), SCMP_SYS(futex),
+     SCMP_SYS(set_robust_list), SCMP_SYS(write),
+     /* Miscellaneous */
+     SCMP_SYS(getrandom), SCMP_SYS(sysinfo), SCMP_SYS(uname),
++    /* not always available */
++#if ! defined(__ARM_EABI__)
++    SCMP_SYS(time),
++    SCMP_SYS(getrlimit),
++    SCMP_SYS(select),
++    SCMP_SYS(mmap),
++    /* TODO: check socketcall arguments */
++    SCMP_SYS(socketcall),
++#endif
+   };
+ 
+   const int socket_domains[] = {

--- a/meta-resin-pyro/recipes-core/chrony/chrony/chrony.conf
+++ b/meta-resin-pyro/recipes-core/chrony/chrony/chrony.conf
@@ -1,0 +1,44 @@
+# Use public NTP servers from the pool.ntp.org project.
+# Please consider joining the pool project if possible by running your own
+# server(s).
+# If you are a vendor distributing a product using chrony, you *MUST*
+# read and comply with http://www.pool.ntp.org/vendors.html
+pool 0.openembedded.pool.ntp.org iburst
+
+# Use a local timeserver in preference to the pool, if it's reachable.
+#server 192.168.22.22 iburst minpoll 2 prefer
+
+# Sync to pulse-per-second from an onboard GPS.
+#refclock PPS /dev/pps0 poll 0 prefer
+# You'll want to enable CONFIG_PPS and CONFIG_PPS_CLIENT_GPIO in your kernel,
+# and an entry something like this in your device tree:
+#	pps {
+#		compatible = "pps-gpio";
+#		gpios = <&ps7_gpio_0 56 0>;
+#	};
+
+# In first three updates step the system clock instead of slew
+# if the adjustment is larger than 1 second.
+makestep 1.0 3
+
+# Record the rate at which the system clock gains/loses time,
+# improving accuracy after reboot
+driftfile /var/lib/chrony/drift
+
+# Enable kernel synchronization of the hardware real-time clock (RTC).
+rtcsync
+
+# Allow NTP client access from local network.
+#allow 192.168/16
+
+# Serve time even if not synchronized to any NTP server.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+#keyfile /etc/chrony.keys
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking

--- a/meta-resin-pyro/recipes-core/chrony/chrony/chronyd
+++ b/meta-resin-pyro/recipes-core/chrony/chrony/chronyd
@@ -1,0 +1,58 @@
+#! /bin/sh
+
+# System V init script for chrony
+# Adapted from the script already in meta-networking for ntpd
+
+### BEGIN INIT INFO
+# Provides:        chrony
+# Required-Start:  $network $remote_fs $syslog
+# Required-Stop:   $network $remote_fs $syslog
+# Default-Start:   2 3 4 5
+# Default-Stop:
+# Short-Description: Start chrony time daemon
+### END INIT INFO
+
+PATH=/sbin:/bin:/usr/bin:/usr/sbin
+
+DAEMON=/usr/sbin/chronyd
+PIDFILE=/var/run/chronyd.pid
+
+test -x $DAEMON -a -r /etc/chrony.conf || exit 0
+
+# Source function library.
+. /etc/init.d/functions
+
+# Functions to do individual actions
+startdaemon(){
+	echo -n "Starting chronyd: "
+	start-stop-daemon --start --quiet --oknodo --pidfile $PIDFILE --startas $DAEMON -- "$@"
+	echo "done"
+}
+stopdaemon(){
+	echo -n "Stopping chronyd: "
+	start-stop-daemon --stop --quiet --oknodo -p $PIDFILE
+	echo "done"
+}
+
+case "$1" in
+  start)
+	startdaemon
+	;;
+  stop)
+  	stopdaemon
+	;;
+  force-reload | restart | reload)
+  	stopdaemon
+	startdaemon
+	;;
+  status)
+	status /usr/sbin/chronyd;
+	exit $?
+	;;
+  *)
+	echo "Usage: chronyd { start | stop | status | restart | reload }" >&2
+	exit 1
+	;;
+esac
+
+exit 0

--- a/meta-resin-pyro/recipes-core/chrony/chrony_3.2.bb
+++ b/meta-resin-pyro/recipes-core/chrony/chrony_3.2.bb
@@ -1,0 +1,134 @@
+SUMMARY = "Versatile implementation of the Network Time Protocol"
+DESCRIPTION = "Chrony can synchronize the system clock with NTP \
+servers, reference clocks (e.g. GPS receiver), and manual input using \
+wristwatch and keyboard. It can also operate as an NTPv4 (RFC 5905) \
+server and peer to provide a time service to other computers in the \
+network. \
+\
+It is designed to perform well in a wide range of conditions, \
+including intermittent network connections, heavily congested \
+networks, changing temperatures (ordinary computer clocks are \
+sensitive to temperature), and systems that do not run continuously, or \
+run on a virtual machine. \
+\
+Typical accuracy between two machines on a LAN is in tens, or a few \
+hundreds, of microseconds; over the Internet, accuracy is typically \
+within a few milliseconds. With a good hardware reference clock \
+sub-microsecond accuracy is possible. \
+\
+Two programs are included in chrony: chronyd is a daemon that can be \
+started at boot time and chronyc is a command-line interface program \
+which can be used to monitor chronyd's performance and to change \
+various operating parameters whilst it is running. \
+\
+This recipe produces two binary packages: 'chrony' which contains chronyd, \
+the configuration file and the init script, and 'chronyc' which contains \
+the client program only."
+
+HOMEPAGE = "https://chrony.tuxfamily.org/"
+SECTION = "net"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
+
+SRC_URI = "https://download.tuxfamily.org/chrony/chrony-${PV}.tar.gz \
+    file://chrony.conf \
+    file://chronyd \
+    file://arm_eabi.patch \
+"
+SRC_URI[md5sum] = "f4c4eb0dc92f35ee4bb7d3dcd8029ecb"
+SRC_URI[sha256sum] = "329f6718dd8c3ece3eee78be1f4821cbbeb62608e7d23f25da293cfa433c4116"
+
+DEPENDS = "pps-tools"
+
+# Note: Despite being built via './configure; make; make install',
+#       chrony does not use GNU Autotools.
+inherit update-rc.d systemd
+
+# Configuration options:
+# - For command line editing support in chronyc, you may specify either
+#   'editline' or 'readline' but not both.  editline is smaller, but
+#   many systems already have readline for other purposes so you might want
+#   to choose that instead.  However, beware license incompatibility
+#   since chrony is GPLv2 and readline versions after 6.0 are GPLv3+.
+#   You can of course choose neither, but if you're that tight on space
+#   consider dropping chronyc entirely (you can use it remotely with
+#   appropriate chrony.conf options).
+# - Security-related:
+#   - 'sechash' is omitted by default because it pulls in nss which is huge.
+#   - 'privdrop' allows chronyd to run as non-root; would need changes to
+#     chrony.conf and init script.
+#   - 'scfilter' enables support for system call filtering, but requires the
+#     kernel to have CONFIG_SECCOMP enabled.
+PACKAGECONFIG ??= "editline \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'ipv6', d)} \
+"
+PACKAGECONFIG[readline] = "--without-editline,--without-readline,readline"
+PACKAGECONFIG[editline] = ",--without-editline,libedit"
+PACKAGECONFIG[sechash] = "--without-tomcrypt,--disable-sechash,nss"
+PACKAGECONFIG[privdrop] = ",--disable-privdrop,libcap"
+PACKAGECONFIG[scfilter] = "--enable-scfilter,--without-seccomp,libseccomp"
+PACKAGECONFIG[ipv6] = ",--disable-ipv6,"
+PACKAGECONFIG[nss] = "--with-nss,--without-nss,nss"
+PACKAGECONFIG[libcap] = "--with-libcap,--without-libcap,libcap"
+
+# --disable-static isn't supported by chrony's configure script.
+DISABLE_STATIC = ""
+
+do_configure() {
+    ./configure --sysconfdir=${sysconfdir} --bindir=${bindir} --sbindir=${sbindir} \
+                --localstatedir=${localstatedir} --datarootdir=${datadir} \
+                ${PACKAGECONFIG_CONFARGS}
+}
+
+do_install() {
+    # Binaries
+    install -d ${D}${bindir}
+    install -m 0755 ${S}/chronyc ${D}${bindir}
+    install -d ${D}${sbindir}
+    install -m 0755 ${S}/chronyd ${D}${sbindir}
+
+    # Config file
+    install -d ${D}${sysconfdir}
+    install -m 644 ${WORKDIR}/chrony.conf ${D}${sysconfdir}
+
+    # System V init script
+    install -d ${D}${sysconfdir}/init.d
+    install -m 755 ${WORKDIR}/chronyd ${D}${sysconfdir}/init.d
+
+    # systemd unit configuration file
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${S}/examples/chronyd.service ${D}${systemd_unitdir}/system/
+
+    # Variable data (for drift and/or rtc file)
+    install -d ${D}${localstatedir}/lib/chrony
+
+    # Log files
+    install -d ${D}${localstatedir}/log/chrony
+
+    # Fix hard-coded paths in config files and init scripts
+    sed -i -e 's!/var/!${localstatedir}/!g' -e 's!/etc/!${sysconfdir}/!g' \
+           -e 's!/usr/sbin/!${sbindir}/!g' -e 's!/usr/bin/!${bindir}/!g' \
+           ${D}${sysconfdir}/chrony.conf \
+           ${D}${sysconfdir}/init.d/chronyd \
+           ${D}${systemd_unitdir}/system/chronyd.service
+    sed -i 's!^PATH=.*!PATH=${base_sbindir}:${base_bindir}:${sbindir}:${bindir}!' ${D}${sysconfdir}/init.d/chronyd
+    sed -i 's!^EnvironmentFile=.*!EnvironmentFile=-${sysconfdir}/default/chronyd!' ${D}${systemd_unitdir}/system/chronyd.service
+}
+
+FILES_${PN} = "${sbindir}/chronyd ${sysconfdir} ${localstatedir}"
+CONFFILES_${PN} = "${sysconfdir}/chrony.conf"
+INITSCRIPT_NAME = "chronyd"
+INITSCRIPT_PARAMS = "defaults"
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE_${PN} = "chronyd.service"
+
+# It's probably a bad idea to run chrony and another time daemon on
+# the same system.  systemd includes the SNTP client 'timesyncd', which
+# will be disabled by chronyd.service, however it will remain on the rootfs
+# wasting 150 kB unless you put 'PACKAGECONFIG_remove_pn-systemd = "timesyncd"'
+# in a conf file or bbappend somewhere.
+RCONFLICTS_${PN} = "ntp ntimed"
+
+# Separate the client program into its own package
+PACKAGES =+ "chronyc"
+FILES_chronyc = "${bindir}/chronyc"

--- a/meta-resin-rocko/recipes-core/chrony/chrony/arm_eabi.patch
+++ b/meta-resin-rocko/recipes-core/chrony/chrony/arm_eabi.patch
@@ -1,0 +1,63 @@
+    chrony: fix build failure for arma9
+
+    Eliminate references to syscalls not available
+    for ARM_EABI.  Also add a dependency on libseccomp
+    which is needed for scfilter to work.
+
+    Set PACKAGECONFIG to not enable scfilter, since
+    kernel CONFIG_SECCOMP is unlikely to be set.  This
+    aligns the usage of libseccomp with that of other packages.
+
+    Upstream-Status: Pending
+
+    Signed-off-by: Joe Slater <jslater@windriver.com>
+
+    Refresh patch for new upstream version.
+
+    Signed-off-by: Robert Joslyn <robert.joslyn@redrectangle.org>
+
+--- a/sys_linux.c
++++ b/sys_linux.c
+@@ -465,14 +465,14 @@ SYS_Linux_EnableSystemCallFilter(int lev
+   const int syscalls[] = {
+     /* Clock */
+     SCMP_SYS(adjtimex), SCMP_SYS(clock_gettime), SCMP_SYS(gettimeofday),
+-    SCMP_SYS(settimeofday), SCMP_SYS(time),
++    SCMP_SYS(settimeofday),
+     /* Process */
+     SCMP_SYS(clone), SCMP_SYS(exit), SCMP_SYS(exit_group), SCMP_SYS(getpid),
+-    SCMP_SYS(getrlimit), SCMP_SYS(rt_sigaction), SCMP_SYS(rt_sigreturn),
++    SCMP_SYS(rt_sigaction), SCMP_SYS(rt_sigreturn),
+     SCMP_SYS(rt_sigprocmask), SCMP_SYS(set_tid_address), SCMP_SYS(sigreturn),
+     SCMP_SYS(wait4),
+     /* Memory */
+-    SCMP_SYS(brk), SCMP_SYS(madvise), SCMP_SYS(mmap), SCMP_SYS(mmap2),
++    SCMP_SYS(brk), SCMP_SYS(madvise), SCMP_SYS(mmap2),
+     SCMP_SYS(mprotect), SCMP_SYS(mremap), SCMP_SYS(munmap), SCMP_SYS(shmdt),
+     /* Filesystem */
+     SCMP_SYS(access), SCMP_SYS(chmod), SCMP_SYS(chown), SCMP_SYS(chown32),
+@@ -483,14 +483,21 @@
+     SCMP_SYS(bind), SCMP_SYS(connect), SCMP_SYS(getsockname),
+     SCMP_SYS(recvfrom), SCMP_SYS(recvmmsg), SCMP_SYS(recvmsg),
+     SCMP_SYS(sendmmsg), SCMP_SYS(sendmsg), SCMP_SYS(sendto),
+-    /* TODO: check socketcall arguments */
+-    SCMP_SYS(socketcall),
+     /* General I/O */
+     SCMP_SYS(_newselect), SCMP_SYS(close), SCMP_SYS(open), SCMP_SYS(openat), SCMP_SYS(pipe),
+-    SCMP_SYS(poll), SCMP_SYS(read), SCMP_SYS(futex), SCMP_SYS(select),
++    SCMP_SYS(poll), SCMP_SYS(read), SCMP_SYS(futex),
+     SCMP_SYS(set_robust_list), SCMP_SYS(write),
+     /* Miscellaneous */
+     SCMP_SYS(getrandom), SCMP_SYS(sysinfo), SCMP_SYS(uname),
++    /* not always available */
++#if ! defined(__ARM_EABI__)
++    SCMP_SYS(time),
++    SCMP_SYS(getrlimit),
++    SCMP_SYS(select),
++    SCMP_SYS(mmap),
++    /* TODO: check socketcall arguments */
++    SCMP_SYS(socketcall),
++#endif
+   };
+ 
+   const int socket_domains[] = {

--- a/meta-resin-rocko/recipes-core/chrony/chrony/chrony.conf
+++ b/meta-resin-rocko/recipes-core/chrony/chrony/chrony.conf
@@ -1,0 +1,44 @@
+# Use public NTP servers from the pool.ntp.org project.
+# Please consider joining the pool project if possible by running your own
+# server(s).
+# If you are a vendor distributing a product using chrony, you *MUST*
+# read and comply with http://www.pool.ntp.org/vendors.html
+pool 0.openembedded.pool.ntp.org iburst
+
+# Use a local timeserver in preference to the pool, if it's reachable.
+#server 192.168.22.22 iburst minpoll 2 prefer
+
+# Sync to pulse-per-second from an onboard GPS.
+#refclock PPS /dev/pps0 poll 0 prefer
+# You'll want to enable CONFIG_PPS and CONFIG_PPS_CLIENT_GPIO in your kernel,
+# and an entry something like this in your device tree:
+#	pps {
+#		compatible = "pps-gpio";
+#		gpios = <&ps7_gpio_0 56 0>;
+#	};
+
+# In first three updates step the system clock instead of slew
+# if the adjustment is larger than 1 second.
+makestep 1.0 3
+
+# Record the rate at which the system clock gains/loses time,
+# improving accuracy after reboot
+driftfile /var/lib/chrony/drift
+
+# Enable kernel synchronization of the hardware real-time clock (RTC).
+rtcsync
+
+# Allow NTP client access from local network.
+#allow 192.168/16
+
+# Serve time even if not synchronized to any NTP server.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+#keyfile /etc/chrony.keys
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking

--- a/meta-resin-rocko/recipes-core/chrony/chrony/chronyd
+++ b/meta-resin-rocko/recipes-core/chrony/chrony/chronyd
@@ -1,0 +1,58 @@
+#! /bin/sh
+
+# System V init script for chrony
+# Adapted from the script already in meta-networking for ntpd
+
+### BEGIN INIT INFO
+# Provides:        chrony
+# Required-Start:  $network $remote_fs $syslog
+# Required-Stop:   $network $remote_fs $syslog
+# Default-Start:   2 3 4 5
+# Default-Stop:
+# Short-Description: Start chrony time daemon
+### END INIT INFO
+
+PATH=/sbin:/bin:/usr/bin:/usr/sbin
+
+DAEMON=/usr/sbin/chronyd
+PIDFILE=/var/run/chronyd.pid
+
+test -x $DAEMON -a -r /etc/chrony.conf || exit 0
+
+# Source function library.
+. /etc/init.d/functions
+
+# Functions to do individual actions
+startdaemon(){
+	echo -n "Starting chronyd: "
+	start-stop-daemon --start --quiet --oknodo --pidfile $PIDFILE --startas $DAEMON -- "$@"
+	echo "done"
+}
+stopdaemon(){
+	echo -n "Stopping chronyd: "
+	start-stop-daemon --stop --quiet --oknodo -p $PIDFILE
+	echo "done"
+}
+
+case "$1" in
+  start)
+	startdaemon
+	;;
+  stop)
+  	stopdaemon
+	;;
+  force-reload | restart | reload)
+  	stopdaemon
+	startdaemon
+	;;
+  status)
+	status /usr/sbin/chronyd;
+	exit $?
+	;;
+  *)
+	echo "Usage: chronyd { start | stop | status | restart | reload }" >&2
+	exit 1
+	;;
+esac
+
+exit 0

--- a/meta-resin-rocko/recipes-core/chrony/chrony_3.2.bb
+++ b/meta-resin-rocko/recipes-core/chrony/chrony_3.2.bb
@@ -1,0 +1,134 @@
+SUMMARY = "Versatile implementation of the Network Time Protocol"
+DESCRIPTION = "Chrony can synchronize the system clock with NTP \
+servers, reference clocks (e.g. GPS receiver), and manual input using \
+wristwatch and keyboard. It can also operate as an NTPv4 (RFC 5905) \
+server and peer to provide a time service to other computers in the \
+network. \
+\
+It is designed to perform well in a wide range of conditions, \
+including intermittent network connections, heavily congested \
+networks, changing temperatures (ordinary computer clocks are \
+sensitive to temperature), and systems that do not run continuously, or \
+run on a virtual machine. \
+\
+Typical accuracy between two machines on a LAN is in tens, or a few \
+hundreds, of microseconds; over the Internet, accuracy is typically \
+within a few milliseconds. With a good hardware reference clock \
+sub-microsecond accuracy is possible. \
+\
+Two programs are included in chrony: chronyd is a daemon that can be \
+started at boot time and chronyc is a command-line interface program \
+which can be used to monitor chronyd's performance and to change \
+various operating parameters whilst it is running. \
+\
+This recipe produces two binary packages: 'chrony' which contains chronyd, \
+the configuration file and the init script, and 'chronyc' which contains \
+the client program only."
+
+HOMEPAGE = "https://chrony.tuxfamily.org/"
+SECTION = "net"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
+
+SRC_URI = "https://download.tuxfamily.org/chrony/chrony-${PV}.tar.gz \
+    file://chrony.conf \
+    file://chronyd \
+    file://arm_eabi.patch \
+"
+SRC_URI[md5sum] = "f4c4eb0dc92f35ee4bb7d3dcd8029ecb"
+SRC_URI[sha256sum] = "329f6718dd8c3ece3eee78be1f4821cbbeb62608e7d23f25da293cfa433c4116"
+
+DEPENDS = "pps-tools"
+
+# Note: Despite being built via './configure; make; make install',
+#       chrony does not use GNU Autotools.
+inherit update-rc.d systemd
+
+# Configuration options:
+# - For command line editing support in chronyc, you may specify either
+#   'editline' or 'readline' but not both.  editline is smaller, but
+#   many systems already have readline for other purposes so you might want
+#   to choose that instead.  However, beware license incompatibility
+#   since chrony is GPLv2 and readline versions after 6.0 are GPLv3+.
+#   You can of course choose neither, but if you're that tight on space
+#   consider dropping chronyc entirely (you can use it remotely with
+#   appropriate chrony.conf options).
+# - Security-related:
+#   - 'sechash' is omitted by default because it pulls in nss which is huge.
+#   - 'privdrop' allows chronyd to run as non-root; would need changes to
+#     chrony.conf and init script.
+#   - 'scfilter' enables support for system call filtering, but requires the
+#     kernel to have CONFIG_SECCOMP enabled.
+PACKAGECONFIG ??= "editline \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'ipv6', d)} \
+"
+PACKAGECONFIG[readline] = "--without-editline,--without-readline,readline"
+PACKAGECONFIG[editline] = ",--without-editline,libedit"
+PACKAGECONFIG[sechash] = "--without-tomcrypt,--disable-sechash,nss"
+PACKAGECONFIG[privdrop] = ",--disable-privdrop,libcap"
+PACKAGECONFIG[scfilter] = "--enable-scfilter,--without-seccomp,libseccomp"
+PACKAGECONFIG[ipv6] = ",--disable-ipv6,"
+PACKAGECONFIG[nss] = "--with-nss,--without-nss,nss"
+PACKAGECONFIG[libcap] = "--with-libcap,--without-libcap,libcap"
+
+# --disable-static isn't supported by chrony's configure script.
+DISABLE_STATIC = ""
+
+do_configure() {
+    ./configure --sysconfdir=${sysconfdir} --bindir=${bindir} --sbindir=${sbindir} \
+                --localstatedir=${localstatedir} --datarootdir=${datadir} \
+                ${PACKAGECONFIG_CONFARGS}
+}
+
+do_install() {
+    # Binaries
+    install -d ${D}${bindir}
+    install -m 0755 ${S}/chronyc ${D}${bindir}
+    install -d ${D}${sbindir}
+    install -m 0755 ${S}/chronyd ${D}${sbindir}
+
+    # Config file
+    install -d ${D}${sysconfdir}
+    install -m 644 ${WORKDIR}/chrony.conf ${D}${sysconfdir}
+
+    # System V init script
+    install -d ${D}${sysconfdir}/init.d
+    install -m 755 ${WORKDIR}/chronyd ${D}${sysconfdir}/init.d
+
+    # systemd unit configuration file
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${S}/examples/chronyd.service ${D}${systemd_unitdir}/system/
+
+    # Variable data (for drift and/or rtc file)
+    install -d ${D}${localstatedir}/lib/chrony
+
+    # Log files
+    install -d ${D}${localstatedir}/log/chrony
+
+    # Fix hard-coded paths in config files and init scripts
+    sed -i -e 's!/var/!${localstatedir}/!g' -e 's!/etc/!${sysconfdir}/!g' \
+           -e 's!/usr/sbin/!${sbindir}/!g' -e 's!/usr/bin/!${bindir}/!g' \
+           ${D}${sysconfdir}/chrony.conf \
+           ${D}${sysconfdir}/init.d/chronyd \
+           ${D}${systemd_unitdir}/system/chronyd.service
+    sed -i 's!^PATH=.*!PATH=${base_sbindir}:${base_bindir}:${sbindir}:${bindir}!' ${D}${sysconfdir}/init.d/chronyd
+    sed -i 's!^EnvironmentFile=.*!EnvironmentFile=-${sysconfdir}/default/chronyd!' ${D}${systemd_unitdir}/system/chronyd.service
+}
+
+FILES_${PN} = "${sbindir}/chronyd ${sysconfdir} ${localstatedir}"
+CONFFILES_${PN} = "${sysconfdir}/chrony.conf"
+INITSCRIPT_NAME = "chronyd"
+INITSCRIPT_PARAMS = "defaults"
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE_${PN} = "chronyd.service"
+
+# It's probably a bad idea to run chrony and another time daemon on
+# the same system.  systemd includes the SNTP client 'timesyncd', which
+# will be disabled by chronyd.service, however it will remain on the rootfs
+# wasting 150 kB unless you put 'PACKAGECONFIG_remove_pn-systemd = "timesyncd"'
+# in a conf file or bbappend somewhere.
+RCONFLICTS_${PN} = "ntp ntimed"
+
+# Separate the client program into its own package
+PACKAGES =+ "chronyc"
+FILES_chronyc = "${bindir}/chronyc"


### PR DESCRIPTION
We added an option in chrony.conf (`hwtimestamp *`) via meta-resin-common in https://github.com/balena-os/meta-balena/commit/d4f5a022799b5648dc2fcaef70435cc7abae5fb7
That option is supported in newer versions of chrony.

Add chrony 3.2 recipe to krogoth,morty,pyro,rocko layers as the chrony version in them is old.
sumo is already on chrony v3.2

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
