### PR TITLE
resin-supervisor: Use an empty apps.json when nonexistent

### DIFF
--- a/meta-resin-common/recipes-containers/resin-supervisor/resin-supervisor/start-resin-supervisor
+++ b/meta-resin-common/recipes-containers/resin-supervisor/resin-supervisor/start-resin-supervisor
@@ -3,6 +3,19 @@
 # shellcheck disable=SC1091
 . /usr/sbin/resin-vars
 
+# Handle apps.json existence
+# Keep this before computing SUPERVISOR_CONTAINER_IMAGE_ID
+APPSJSON=/mnt/data/apps.json
+if [ ! -f "$APPSJSON" ]; then
+    if [ -d "$APPSJSON" ]; then
+        rm -rf "$APPSJSON"
+        balena rm -f resin_supervisor || true
+        echo '{}' > "$APPSJSON"
+    elif [ ! -e "$APPSJSON" ]; then
+        echo '{}' > "$APPSJSON"
+    fi
+fi
+
 SUPERVISOR_IMAGE_ID=$(balena inspect --format='{{.Id}}' "$SUPERVISOR_IMAGE:$SUPERVISOR_TAG")
 SUPERVISOR_CONTAINER_IMAGE_ID=$(balena inspect --format='{{.Image}}' resin_supervisor || echo "")
 


### PR DESCRIPTION
Currently, because we bind mount apps.json unconditionally, when this
file doesn't exist, balena engine will create a directory on the data
filesystem. This breaks when we add an apps.json file after the
supervisor container was already created.

Fixes #1325

Signed-off-by: Andrei Gherzan <andrei@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
