### PR TITLE
Tarball and deploy complete kernel source

### DIFF
--- a/meta-resin-common/classes/image-resin.bbclass
+++ b/meta-resin-common/classes/image-resin.bbclass
@@ -6,7 +6,7 @@ inherit image_types_resin
 
 # When building a Resin OS image, we also generate the kernel modules headers
 # and ship them in the deploy directory for out-of-tree kernel modules build
-DEPENDS += "coreutils-native jq-native kernel-modules-headers"
+DEPENDS += "coreutils-native jq-native kernel-modules-headers kernel-devsrc"
 
 # Deploy the license.manifest of the current image we baked
 deploy_image_license_manifest () {

--- a/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
+++ b/meta-resin-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
@@ -46,7 +46,7 @@ do_compile() {
         fi
     done
 
-    tar -czf kernel_modules_headers.tar.gz kernel_modules_headers
+    tar -czf ${B}/kernel_modules_headers.tar.gz kernel_modules_headers
 }
 
 do_install() {
@@ -56,8 +56,8 @@ do_install() {
 }
 
 do_deploy() {
-    cp kernel_modules_headers.tar.gz ${DEPLOYDIR}
-    rm -rf kernel_modules_headers
+    cp ${B}/kernel_modules_headers.tar.gz ${DEPLOYDIR}
+    rm -rf ${B}/kernel_modules_headers
 }
 
 do_compile[depends] += "virtual/kernel:do_deploy virtual/kernel:do_patch"

--- a/meta-resin-common/recipes-kernel/linux/kernel-devsrc.bbappend
+++ b/meta-resin-common/recipes-kernel/linux/kernel-devsrc.bbappend
@@ -1,0 +1,20 @@
+do_install_append() {
+   tar -czf ${B}/kernel_source.tar.gz -C "$kerneldir/../" .
+}
+
+do_deploy() {
+    cp ${B}/kernel_source.tar.gz ${DEPLOYDIR}/
+    rm ${B}/kernel_source.tar.gz
+}
+inherit deploy
+addtask do_deploy before do_package after do_install
+
+# Quite a few devices have random precompiled elf binaries in their
+# kernel src git trees. Remove various checks from this package to prevent
+# QA errors
+INSANE_SKIP_${PN} = "arch debug-files"
+
+# kernel-modules-headers recipe does some work on the kernel tree.
+# We'd like to make sure that we dont tarball at the same time as that
+# recipe is working on the tree
+DEPENDS += "kernel-modules-headers"


### PR DESCRIPTION
Currently we ship the kernel headers using the kernel-modules-headers recipe.
That recipe pre-compiles tools to run on the device only. Using the kernel-devsrc recipe, we now want to tarball and ship the entire kernel source tree as well. This will enable people to cross-compile external modules as well and is a more robust solution compared to kernel-modules-headers.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
