### PR TITLE
networkmanager: Remove tun devices from unmanaged list

### DIFF
--- a/meta-resin-common/recipes-connectivity/networkmanager/resin-files/NetworkManager.conf
+++ b/meta-resin-common/recipes-connectivity/networkmanager/resin-files/NetworkManager.conf
@@ -4,7 +4,7 @@ plugins=keyfile
 autoconnect-retries-default=0
 
 [keyfile]
-unmanaged-devices=interface-name:balena*;interface-name:br*;type:tun;type:veth
+unmanaged-devices=interface-name:balena*;interface-name:resin*;interface-name:br*;type:veth
 
 [connection]
 ipv4.dhcp-timeout=2147483647


### PR DESCRIPTION
Under the current configuration we instruct NetworkManager through its
configuration to completely ignore all the tun devices. This was
enforced as an extra precation as we run an openvpn client which
connects to the balena-cloud backend. This client creates, on the host,
the interface `resin-tun` currently (rename pending). We want to loosen
up this restriction to only unmanage this specific device - `resin-tun`
- so that users can take advantage of NetworkManager managing other tun
devices.

Change-type: minor
Changelog-entry: Configure NetworkManager to only ignore our vpn interface but manage other tun devices
Signed-off-by: Andrei Gherzan <andrei@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
