### PR TITLE
kernel-resin.bbclass: Enable some common serial device drivers

### DIFF
--- a/meta-resin-common/classes/kernel-resin.bbclass
+++ b/meta-resin-common/classes/kernel-resin.bbclass
@@ -87,6 +87,7 @@ RESIN_CONFIGS ?= " \
     redsocks \
     reduce-size \
     security \
+    usb-serial \
     zram \
     ${BALENA_STORAGE} \
     "
@@ -418,6 +419,15 @@ RESIN_CONFIGS[zram] = " \
 # USB Modem (CDC ACM) support
 RESIN_CONFIGS[cdc-acm] = " \
     CONFIG_USB_ACM=m \
+    "
+
+# USB serial device drivers
+RESIN_CONFIGS_DEPS[usb-serial] = " \
+    CONFIG_USB_SERIAL_WWAN=m \
+    "
+RESIN_CONFIGS[usb-serial] = " \
+    CONFIG_USB_SERIAL_OPTION=m \
+    CONFIG_USB_SERIAL_QUALCOMM=m \
     "
 
 ###########


### PR DESCRIPTION
Fixes #1327

Change-type: minor
Changelog-entry: Enable some common linux kernel serial device drivers
Signed-off-by: Andrei Gherzan <andrei@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
