### PR TITLE
image-resin.bbclass: Fix cases where RESIN_BOOT_PARTITION_FILES contains invalid entries

### DIFF
--- a/meta-resin-common/classes/image-resin.bbclass
+++ b/meta-resin-common/classes/image-resin.bbclass
@@ -136,6 +136,9 @@ resin_boot_dirgen_and_deploy () {
 
         # Compute src and dst
         src="$(echo ${RESIN_BOOT_PARTITION_FILE} | awk -F: '{print $1}')"
+        if [ -z "${src}" ]; then
+            bbfatal "An entry in RESIN_BOOT_PARTITION_FILES has no source. Entries need to be in the \"src:dst\" format where only \"dst\" is optional. Failed entry: \"$RESIN_BOOT_PARTITION_FILE\"."
+        fi
         dst="$(echo ${RESIN_BOOT_PARTITION_FILE} | awk -F: '{print $2}')"
         if [ -z "${dst}" ]; then
             dst="/${src}" # dst was omitted


### PR DESCRIPTION

Fixes #1330

Change-type: patch
Changelog-entry: Fix cases where RESIN_BOOT_PARTITION_FILES includes invalid entries
Signed-off-by: Andrei Gherzan <andrei@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
