### PR TITLE
Deprecate Krogoth and Morty layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,6 @@ The following Yocto versions are supported:
  * Pyro (2.3)
   * **TESTED**
  * Morty (2.2)
-  * **TESTED**
+  * **DEPRECATED**
  * Krogoth (2.1)
-  * **TESTED**
+  * **DEPRECATED**

--- a/meta-resin-common/classes/resin-sanity.bbclass
+++ b/meta-resin-common/classes/resin-sanity.bbclass
@@ -17,6 +17,8 @@ def resinos_build_configuration():
 		success = False
 	if d.getVar('RESIN_CONNECTABLE', True) or d.getVar('RESIN_CONNECTABLE_SERVICES', True) or d.getVar('RESIN_CONNECTABLE_ENABLE_SERVICES', True):
 		bb.warn("Your build configuration uses RESIN_CONNECTABLE* variables. These variables are no longer used. There is only one type of resinOS image type which is unconnected by default. The os-config tool is used to configure the resinOS image for connectivity to a resin instance.")
+	if d.getVar('BALENA_DEPRECATED_YOCTO_LAYER', True) == "1":
+		bb.warn("Your build configuration is using a poky layer that has been deprecated by meta-balena. Please update and use a newer poky version.")
 	return success
 
 python resinos_sanity_handler() {

--- a/meta-resin-common/conf/layer.conf
+++ b/meta-resin-common/conf/layer.conf
@@ -7,7 +7,9 @@ BBFILE_COLLECTIONS += "resin-common"
 BBFILE_PATTERN_resin-common := "^${LAYERDIR}/"
 BBFILE_PRIORITY_resin-common = "1337"
 
-LAYERSERIES_COMPAT_resin-common = "jethro krogoth morty pyro rocko sumo"
+LAYERSERIES_COMPAT_resin-common = "krogoth morty pyro rocko sumo"
+
+BALENA_DEPRECATED_YOCTO_LAYER ?= "0"
 
 RESIN_COREBASE := '${@os.path.normpath("${LAYERDIR}/")}'
 

--- a/meta-resin-krogoth/conf/layer.conf
+++ b/meta-resin-krogoth/conf/layer.conf
@@ -6,3 +6,5 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "resin-krogoth"
 BBFILE_PATTERN_resin-krogoth := "^${LAYERDIR}/"
 BBFILE_PRIORITY_resin-krogoth = "1337"
+
+BALENA_DEPRECATED_YOCTO_LAYER = "1"

--- a/meta-resin-morty/conf/layer.conf
+++ b/meta-resin-morty/conf/layer.conf
@@ -6,3 +6,5 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "resin-morty"
 BBFILE_PATTERN_resin-morty := "^${LAYERDIR}/"
 BBFILE_PRIORITY_resin-morty = "1337"
+
+BALENA_DEPRECATED_YOCTO_LAYER = "1"


### PR DESCRIPTION
All of the devices supported by balenaCloud run pyro or above.
Deprecate krogoth and morty

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
