### PR TITLE
Add timeout to chronyc online command

### DIFF
--- a/meta-resin-common/recipes-connectivity/networkmanager/resin-files/99dhcp_ntp
+++ b/meta-resin-common/recipes-connectivity/networkmanager/resin-files/99dhcp_ntp
@@ -11,7 +11,8 @@ case "$action" in
 	/usr/bin/resin-ntp-config
 
 	# Inform chrony we are online
-	/usr/bin/chronyc online
+	# We add a timeout as we have noticed this command being stuck in a loop eating cpu. Bug possibly resolved upstream. https://github.com/mlichvar/chrony/commit/6863e43269fe27ce2744eb643295f31c00ec176d#diff-50898f0cb35139d87132f4732a029213
+	/usr/bin/timeout 10 /usr/bin/chronyc online || true
 
 	if [[ -n $DHCP4_NTP_SERVERS ]]; then
 		# Tell chronyd to use this server


### PR DESCRIPTION
We have noticed devices in support that show high cpu usage because
the process chronyc online seems to be eating up 50% cpu.

This is probably fixed upstream https://github.com/mlichvar/chrony/commit/6863e43269fe27ce2744eb643295f31c00ec176d#diff-50898f0cb35139d87132f4732a029213

Add a timeout in any case as its a lower risk option

Change-type: patch
Changelog-entry: Add a workaround for a bug where the chronyc online command in network manager hook would get stuck and eat cpu cycles
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
