### PR TITLE
ucl: Compile with -fPIC flag

### DIFF
--- a/meta-resin-common/recipes-core/ucl/ucl_1.03.bb
+++ b/meta-resin-common/recipes-core/ucl/ucl_1.03.bb
@@ -13,6 +13,6 @@ SRC_URI[sha256sum] = "b865299ffd45d73412293369c9754b07637680e5c826915f097577cd27
 
 inherit autotools
 
-CFLAGS_append = " -std=c90"
+CFLAGS_append = " -std=c90 -fPIC"
 
 BBCLASSEXTEND = "native"


### PR DESCRIPTION
We compile ucl with -fPIC flag to fix upx-native compilation
on Ubuntu 18.04

If -fPIC flag is missing this error shows up when linking
upx-native with libucl:

"libucl.a(ucl_util.o): relocation R_X86_64_32 against `.rodata' can
not be used when making a PIE object; recompile with -fPIC"

Change-type: patch
Changelog-entry: ucl: Compile with -fPIC flag to make upx-native work on Ubuntu 18.04
Signed-off-by: Sebastian Panceac <sebastian@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ x] Changes have been tested
- [ x] `Change-type` present on at least one commit
- [ x] `Signed-off-by` is present
- [ x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
