### PR TITLE
resin-persistent-logs: Add boot and state partition dependency

### DIFF
--- a/meta-resin-common/recipes-support/resin-persistent-logs/resin-persistent-logs/resin-persistent-logs.service
+++ b/meta-resin-common/recipes-support/resin-persistent-logs/resin-persistent-logs/resin-persistent-logs.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Resin persistent logs
-Requires=systemd-journald.service
-After=systemd-journald.service
+Requires=resin-boot.service resin-state.service systemd-journald.service
+After=resin-boot.service resin-state.service systemd-journald.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Found while looking at https://github.com/balena-os/meta-balena/issues/1367

We need the state partition and boot partition ready before we try to run the persistent logging service.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
