### PR TITLE
chrony: Switch to using rtcfile instead of rtcsync

### DIFF
--- a/meta-resin-common/recipes-core/chrony/files/chrony.conf
+++ b/meta-resin-common/recipes-core/chrony/files/chrony.conf
@@ -8,4 +8,5 @@ makestep 1 -1
 logchange 1
 maxdistance 16
 hwtimestamp *
-rtcsync
+rtcfile /var/lib/chrony/rtc
+rtcautotrim 600


### PR DESCRIPTION
The rtcsync directive results in chronyd writing to the rtc every 11
minutes.

We'd rather avoid writing to the RTC every 11 minutes. This can
sometimes mess up the rtc.

Switch to using `rtcfile /var/lib/chrony/rtc`. Chrony will let the rtc
drift and save the drift to disk whenever it reads the rtc.

rtcautotrim 600 will ensure the rtc never drifts outside 10 minutes.

Change-type: minor
Changelog-entry: Tweak chrony.conf to avoid writing to the rtc every 11 minutes
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
