### PR TITLE
networkmanager: fix ntp server hook if there are no custom ntp servers

### DIFF
--- a/meta-resin-common/recipes-connectivity/networkmanager/resin-files/99dhcp_ntp
+++ b/meta-resin-common/recipes-connectivity/networkmanager/resin-files/99dhcp_ntp
@@ -25,20 +25,22 @@ case "$action" in
 	;;
 	down)
 		# Read ntp server information from file into env variables
-		. $added_servers_file
-		eval ntp_connection=\$"resin_$interface"
+		if [ -f $added_servers_file ]; then
+			. $added_servers_file
+			eval ntp_connection=\$"resin_$interface"
 
-		# Delete the ntp server for that interface from file
-		sed -i "/resin_$interface/d" $added_servers_file
+			# Delete the ntp server for that interface from file
+			sed -i "/resin_$interface/d" $added_servers_file
 
-		# Tell chronyd to remove this server
-		for ntp in ${ntp_connection}; do
-			# Only delete the server if it isn't being added by some other interface
-			if ! grep -q "$ntp" $added_servers_file; then
-				/usr/bin/chronyc delete $ntp || true
-			fi
+			# Tell chronyd to remove this server
+			for ntp in ${ntp_connection}; do
+				# Only delete the server if it isn't being added by some other interface
+				if ! grep -q "$ntp" $added_servers_file; then
+					/usr/bin/chronyc delete $ntp || true
+				fi
 
-		done
+			done
+		fi
 
 	;;
 	*)


### PR DESCRIPTION
Fixes #1362

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
