### PR TITLE
resin-supervisor: Configure systemd tmpfiles exceptions

### DIFF
--- a/meta-resin-common/recipes-containers/resin-supervisor/resin-supervisor.bb
+++ b/meta-resin-common/recipes-containers/resin-supervisor/resin-supervisor.bb
@@ -16,6 +16,7 @@ SRC_URI += " \
 	file://update-resin-supervisor.service \
 	file://update-resin-supervisor.timer \
 	file://resin-supervisor-healthcheck \
+	file://tmpfiles-supervisor.conf \
 	"
 
 SYSTEMD_SERVICE_${PN} = " \
@@ -81,6 +82,10 @@ do_install () {
 
 	install -d ${D}/usr/lib/resin-supervisor
 	install -m 0755 ${WORKDIR}/resin-supervisor-healthcheck ${D}/usr/lib/resin-supervisor/resin-supervisor-healthcheck
+
+	# systemd tmpfiles configuration for supervisor
+	mkdir -p ${D}${sysconfdir}/tmpfiles.d
+	install -m 0644 ${WORKDIR}/tmpfiles-supervisor.conf ${D}${sysconfdir}/tmpfiles.d/supervisor.conf
 }
 
 do_deploy () {

--- a/meta-resin-common/recipes-containers/resin-supervisor/resin-supervisor/tmpfiles-supervisor.conf
+++ b/meta-resin-common/recipes-containers/resin-supervisor/resin-supervisor/tmpfiles-supervisor.conf
@@ -1,0 +1,4 @@
+# Supervisor stores runtime persistent files in these directories
+# For example: update lock files.
+x /tmp/resin-supervisor
+x /tmp/balena-supervisor


### PR DESCRIPTION
There are tmp directories supervisor assumes nobody touches in which
things like update lock files are stored. This patch configures systemd
tmpfiles to ignore these tmp paths.

Fixes #1377

Change-type: patch
Changelog-entry: Configure systemd tmpfiles to ignore supervisor tmp directories
Signed-off-by: Andrei Gherzan <andrei@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)


<img src="https://frontapp.com/assets/img/icons/favicon-32x32.png" height="16" width="16" alt="Front logo" /> [Front conversations](https://app.frontapp.com/open/top_gybv)