### PR TITLE
resindataexpander: Fix typo in Resin Flasher detection

### DIFF
--- a/meta-resin-common/recipes-core/initrdscripts/files/resindataexpander
+++ b/meta-resin-common/recipes-core/initrdscripts/files/resindataexpander
@@ -16,13 +16,13 @@ resindataexpander_enabled() {
 			root_link="/dev/disk/by-partuuid/$root_puuid"
 		elif [ "`echo ${bootparam_root} | cut -c1-6`" = "LABEL=" ]; then
 			root_label=`echo $bootparam_root | cut -c7-`
-			root_link="/dev/disk/by-label/$root_link"
+			root_link="/dev/disk/by-label/$root_label"
 		fi
-		if [ "$(readlink -f "$root_link")" == "$flash-root" ]; then
+		if [ "$(readlink -f "$root_link")" == "$flash_root" ]; then
 			echo "[INFO] Flasher detected. Avoiding expand partition mechanism."
 			return 1
 		fi
-    fi
+	fi
 
     for freespace in $(parted -m /dev/$datadev unit MiB print free | grep free | cut -d: -f4 | sed 's/MiB//g'); do
         if [ $(echo $freespace \> $FREESPACE_LIMIT | bc -l) == "1" ]; then


### PR DESCRIPTION
Fixed typo that caused flashing process to block
on some corrupted eMMCs due to parted command failure.

Flashing process hanged during boot with this log:
- Error: Can't have overlapping partitions.

Change-type: patch
Changelog-entry: Fixed "Can't have overlapping partitions." error in flasher
Signed-off-by: Alexandru Costache <alexandru@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
