### PR TITLE
Improve ntp dhcp server sync time

### DIFF
--- a/meta-resin-common/recipes-connectivity/networkmanager/resin-files/99dhcp_ntp
+++ b/meta-resin-common/recipes-connectivity/networkmanager/resin-files/99dhcp_ntp
@@ -18,6 +18,7 @@ case "$action" in
 		# Tell chronyd to use this server
 		for ntp in ${DHCP4_NTP_SERVERS}; do
 			/usr/bin/chronyc add server $ntp || true
+			/usr/bin/chronyc burst 4/10 "$ntp" || true
 		done
 		# Save the ntp server we received and interface information to a file
 		echo "resin_$interface=\""""$DHCP4_NTP_SERVERS""\" >> $added_servers_file

--- a/meta-resin-common/recipes-connectivity/resin-ntp-config/resin-ntp-config/resin-ntp-config
+++ b/meta-resin-common/recipes-connectivity/resin-ntp-config/resin-ntp-config/resin-ntp-config
@@ -17,6 +17,7 @@ fi
 if [ ! -z "$NTP_SERVERS" ]; then
 	for ntp in ${NTP_SERVERS}; do
 		/usr/bin/chronyc add server $ntp || true
+		/usr/bin/chronyc burst 4/10 "$ntp" || true
 	done
 fi
 


### PR DESCRIPTION
A few subtle improvements for custom ntp servers

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
