### PR TITLE
kernel-resin.bbclass: Disable in-tree rtl8192cu driver

### DIFF
--- a/meta-resin-common/classes/kernel-resin.bbclass
+++ b/meta-resin-common/classes/kernel-resin.bbclass
@@ -68,6 +68,7 @@ RESIN_CONFIGS ?= " \
     brcmfmac \
     cdc-acm \
     ralink \
+    rtl8192cu \
     r8188eu \
     systemd \
     leds-gpio \


### PR DESCRIPTION
We will only have the out of tree module which allegedly
is more stable:
https://github.com/raspberrypi/linux/issues/1866

The configs for disabling it were added but apparently
they were never applied.

Change-type: patch
Changelog-entry: Disable in-tree rtl8192cu driver
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
