### PR TITLE
Make balena-host daemon socket activated

### DIFF
--- a/meta-resin-common/recipes-containers/balena/balena/balena-host.service
+++ b/meta-resin-common/recipes-containers/balena/balena/balena-host.service
@@ -2,14 +2,14 @@
 Description=Balena Application Container Engine (host)
 Documentation=https://www.balena.io/docs/getting-started
 Wants=dnsmasq.service
-Requires=mnt-sysroot-active.service mnt-sysroot-inactive.service
-After=network.target mnt-sysroot-active.service mnt-sysroot-inactive.service dnsmasq.service rollback-altboot.service
+Requires=balena-host.socket mnt-sysroot-active.service mnt-sysroot-inactive.service
+After=network.target mnt-sysroot-active.service mnt-sysroot-inactive.service dnsmasq.service rollback-altboot.service balena-host.socket
 ConditionVirtualization=!docker
 
 [Service]
 Type=notify
 Restart=always
-ExecStart=/usr/bin/balenad --delta-data-root=/mnt/sysroot/active/balena --delta-storage-driver=@BALENA_STORAGE@ --log-driver=journald -s @BALENA_STORAGE@ --data-root=/mnt/sysroot/inactive/balena -H unix:///var/run/balena-host.sock --pidfile=/var/run/balena-host.pid --exec-root=/var/run/balena-host --bip 10.114.101.1/24 --fixed-cidr=10.114.101.128/25 --iptables=false
+ExecStart=/usr/bin/balenad --delta-data-root=/mnt/sysroot/active/balena --delta-storage-driver=@BALENA_STORAGE@ --log-driver=journald -s @BALENA_STORAGE@ --data-root=/mnt/sysroot/inactive/balena -H fd:// --pidfile=/var/run/balena-host.pid --exec-root=/var/run/balena-host --bip 10.114.101.1/24 --fixed-cidr=10.114.101.128/25 --iptables=false
 #Adjust OOMscore to -900 to make killing unlikely
 OOMScoreAdjust=-900
 MountFlags=slave
@@ -17,5 +17,3 @@ LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity
 
-[Install]
-WantedBy=multi-user.target

--- a/meta-resin-common/recipes-containers/balena/balena/balena-host.socket
+++ b/meta-resin-common/recipes-containers/balena/balena/balena-host.socket
@@ -1,0 +1,12 @@
+[Unit]
+Description=Docker Socket for the API
+
+[Socket]
+ListenStream=/var/run/balena-host.sock
+SocketMode=0660
+SocketUser=root
+SocketGroup=balena-engine
+
+[Install]
+WantedBy=sockets.target
+

--- a/meta-resin-common/recipes-containers/balena/balena_git.bb
+++ b/meta-resin-common/recipes-containers/balena/balena_git.bb
@@ -19,6 +19,7 @@ SRC_URI = "\
 	git://github.com/resin-os/balena.git;branch=${BALENA_BRANCH};destsuffix=git/src/import \
 	file://balena.service \
 	file://balena-host.service \
+	file://balena-host.socket \
 	file://balena-healthcheck \
 	file://var-lib-docker.mount \
 	file://balena.conf.systemd \
@@ -32,7 +33,7 @@ SECURITY_CFLAGS = "${SECURITY_NOPIE_CFLAGS}"
 SECURITY_LDFLAGS = ""
 
 SYSTEMD_PACKAGES = "${PN}"
-SYSTEMD_SERVICE_${PN} = "balena.service balena-host.service var-lib-docker.mount"
+SYSTEMD_SERVICE_${PN} = "balena.service balena-host.socket var-lib-docker.mount"
 FILES_COMPRESS = "/boot/init"
 GO_IMPORT = "import"
 USERADD_PACKAGES = "${PN}"
@@ -148,6 +149,7 @@ do_install() {
 
 	install -m 0644 ${WORKDIR}/balena-host.service ${D}/${systemd_unitdir}/system
 	sed -i "s/@BALENA_STORAGE@/${BALENA_STORAGE}/g" ${D}${systemd_unitdir}/system/balena-host.service
+	install -m 0644 ${WORKDIR}/balena-host.socket ${D}/${systemd_unitdir}/system
 
 	install -m 0644 ${WORKDIR}/var-lib-docker.mount ${D}/${systemd_unitdir}/system
 


### PR DESCRIPTION
Fixes #1405

We'd like the balena-host daemon to be socket activated so that it does
not consume any cpu/memory resource until used.


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
