### PR TITLE
meta-resin-common: kernel-devsrc: Generate the tar archive in WORKDIR

### DIFF
--- a/meta-resin-common/recipes-kernel/linux/kernel-devsrc.bbappend
+++ b/meta-resin-common/recipes-kernel/linux/kernel-devsrc.bbappend
@@ -1,10 +1,10 @@
 do_install_append() {
-   tar -czf ${B}/kernel_source.tar.gz -C "$kerneldir/../" .
+   tar -czf ${WORKDIR}/kernel_source.tar.gz -C "$kerneldir/../" .
 }
 
 do_deploy() {
-    cp ${B}/kernel_source.tar.gz ${DEPLOYDIR}/
-    rm ${B}/kernel_source.tar.gz
+    cp ${WORKDIR}/kernel_source.tar.gz ${DEPLOYDIR}/
+    rm ${WORKDIR}/kernel_source.tar.gz
 }
 inherit deploy
 addtask do_deploy before do_package after do_install


### PR DESCRIPTION
It is best to not create anything in ${B} even if just temporary because
it alters the directory in ways which can break other parts of the build
system. For example, if there is a leftover kernel_source.tar.gz in B,
then the current kernel-devsrc will create a hardlink of this file in
the kernel source tree and then the command

tar -czf ${B}/kernel_source.tar.gz -C "$kerneldir/../" .

will fail like:

tar: ./kernel/kernel_source.tar.gz: file changed as we read it

Change-type: patch
Changelog-entry: Generate the temporary kernel-devsrc compressed archive in WORKDIR instead of B
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
