### PR TITLE
systemd: Trim udev hwdb source files

### DIFF
--- a/meta-resin-common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-resin-common/recipes-core/systemd/systemd_%.bbappend
@@ -91,3 +91,9 @@ PACKAGECONFIG_remove = "polkit"
 # In this time we avoid creating these at first boot
 USERADD_PARAM_${PN} += "; --system systemd-bus-proxy; --system -d / -M --shell /bin/nologin -u 65534 nobody;"
 GROUPADD_PARAM_${PN} += "; -r wheel; -r nobody;"
+
+# Clean up udev hardware database source files
+pkg_postinst_udev-hwdb_append () {
+    # These files have already been used to generate /etc/udev/hwdb.bin which is the only file used at runtime
+    rm $D/lib/udev/hwdb.d/*
+}


### PR DESCRIPTION
During build, we generate the binary `/etc/udev/hwdb.bin` that is used at runtime. The source rules are still left in `/lib/udev/hwdb.d`. These are useful for distros that want to regenerate the `hwdb.bin` at runtime. but we don't really do that. 

We can remove the source files to conserve 5.9Mb.

#810 

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
