### PR TITLE
un-upx binaries

### DIFF
--- a/meta-resin-common/recipes-containers/balena/balena_git.bb
+++ b/meta-resin-common/recipes-containers/balena/balena_git.bb
@@ -9,7 +9,7 @@ pulling."
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://src/import/LICENSE;md5=9740d093a080530b5c5c6573df9af45a"
 
-inherit systemd go pkgconfig binary-compress useradd
+inherit systemd go pkgconfig useradd
 
 BALENA_VERSION = "17.12.0-dev"
 BALENA_BRANCH= "17.12-resin"
@@ -34,7 +34,6 @@ SECURITY_LDFLAGS = ""
 
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE_${PN} = "balena.service balena-host.socket var-lib-docker.mount"
-FILES_COMPRESS = "/boot/init"
 GO_IMPORT = "import"
 USERADD_PACKAGES = "${PN}"
 GROUPADD_PARAM_${PN} = "-r balena-engine"

--- a/meta-resin-common/recipes-core/os-config/os-config.inc
+++ b/meta-resin-common/recipes-core/os-config/os-config.inc
@@ -1,8 +1,6 @@
-inherit systemd cargo-dyn binary-compress
+inherit systemd cargo-dyn
 
 DEPENDS += "dbus openssl"
-
-FILES_COMPRESS = "/usr/bin/os-config"
 
 SRC_URI += " \
 	file://os-config.json \


### PR DESCRIPTION
We currently upx `os-config` and `mobynit`. runtime decompression slows down the binaries. This becomes evident for slow devices like the pi0/beagle pocket etc.

We have space in the OS at the moment. Lets un-upx binaries to speed things up.

On a pi3, with this PR.

```
root@8e1b3fb:~# df -kh .
Filesystem      Size  Used Avail Use% Mounted on
none            300M  239M   41M  86% /
root@8e1b3fb:~# du -hs /usr/bin/os-config
2.5M    /usr/bin/os-config
root@8e1b3fb:~# du -hs /mnt/sysroot/active/current/boot/init
5.6M    /mnt/sysroot/active/current/boot/init
root@8e1b3fb:~# 
```


```
root@62d0b9a:/mnt/data# du -hs os-config*
2.6M    os-config
700K    os-config_upxed
root@62d0b9a:/mnt/data# du -hs mobynit*
5.7M    mobynit
1.7M    mobynit_upxed
root@62d0b9a:/mnt/data#
```

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
