### PR TITLE
balena-engine: Fix version string

### DIFF
--- a/meta-resin-common/recipes-containers/balena/balena_git.bb
+++ b/meta-resin-common/recipes-containers/balena/balena_git.bb
@@ -11,8 +11,8 @@ LIC_FILES_CHKSUM = "file://src/import/LICENSE;md5=9740d093a080530b5c5c6573df9af4
 
 inherit systemd go pkgconfig useradd
 
-BALENA_VERSION = "17.12.0-dev"
-BALENA_BRANCH= "17.12-resin"
+BALENA_VERSION = "17.13.3-dev"
+BALENA_BRANCH= "master"
 
 SRCREV = "fe78e2c9a69313007c53c83fff4b5525fbc2ba45"
 SRC_URI = "\


### PR DESCRIPTION
The version is 17.13.3. We'll need to bump the version string as well
now that versionbot is being used in the balena-engine repo.
Fixes #1433 

Change-type: patch
Changelog-entry: Fix the balena version string reported by balena-engine info
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
