### PR TITLE
Avoid uselessly running fsck on the data partition

### DIFF
--- a/meta-resin-common/recipes-core/initrdscripts/files/fsck
+++ b/meta-resin-common/recipes-core/initrdscripts/files/fsck
@@ -6,6 +6,12 @@ fsck_enabled() {
         echo "[INFO] Flasher detected. We don't run fsck on the partitions when provisioning."
         return 1
     fi
+
+    cat > "/etc/e2fsck.conf" <<EOF
+[options]
+broken_system_clock=1
+EOF
+
     return 0
 }
 

--- a/meta-resin-common/recipes-devtools/e2fsprogs/e2fsprogs_%.bbappend
+++ b/meta-resin-common/recipes-devtools/e2fsprogs/e2fsprogs_%.bbappend
@@ -1,2 +1,12 @@
 ALTERNATIVE_${PN} += "mke2fs"
 ALTERNATIVE_LINK_NAME[mke2fs] = "${base_sbindir}/mke2fs"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/os-files:"
+SRC_URI += "file://e2fsck.conf"
+
+do_install_append() {
+	install -m 644 ${WORKDIR}/e2fsck.conf ${D}${sysconfdir}
+}
+
+CONFFILES_${PN} += "${sysconfdir}/e2fsck.conf"
+FILES_e2fsprogs-e2fsck += "${sysconfdir}/e2fsck.conf"

--- a/meta-resin-common/recipes-devtools/e2fsprogs/os-files/e2fsck.conf
+++ b/meta-resin-common/recipes-devtools/e2fsprogs/os-files/e2fsck.conf
@@ -1,0 +1,2 @@
+[options]
+broken_system_clock=1

--- a/meta-resin-common/recipes-support/resin-expand/resin-filesystem-expand.bb
+++ b/meta-resin-common/recipes-support/resin-expand/resin-filesystem-expand.bb
@@ -15,6 +15,7 @@ SYSTEMD_SERVICE_${PN} = "resin-filesystem-expand.service"
 RDEPENDS_${PN} = " \
     coreutils \
     e2fsprogs-resize2fs \
+    e2fsprogs-e2fsck \
     util-linux \
     "
 


### PR DESCRIPTION
```
Mar 11 15:29:58 localhost sh[476]: Superblock last mount time (Thu Mar 14 17:13:02 2019,
Mar 11 15:29:58 localhost sh[476]:         now = Mon Mar 11 15:29:56 2019) is in the future.
Mar 11 15:29:58 localhost sh[476]: Fix? yes
```
when `resin-filesystem-expand` runs fsck on the data partition, the system time is older than the previous boots time. This causes a full fsck to run on the data partitoin which slows down boot.

This PR prevents this from happening by passing `broken_system_time` in `/etc/e2fsck.conf`

Fixes #1438 
Linked with #946 

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
