### PR TITLE
resin-supervisor: Recreate on start if config has changed

### DIFF
--- a/meta-resin-common/recipes-containers/resin-supervisor/resin-supervisor/start-resin-supervisor
+++ b/meta-resin-common/recipes-containers/resin-supervisor/resin-supervisor/start-resin-supervisor
@@ -100,7 +100,7 @@ runSupervisor() {
 if [ -z "$SUPERVISOR_IMAGE_ID" ]; then
     # No supervisor image exists on the device, try to pull it
     systemctl start update-resin-supervisor
-elif configIsUnchanged && [ "$SUPERVISOR_IMAGE_ID" = "$SUPERVISOR_CONTAINER_IMAGE_ID" ]; then
+elif [ "$SUPERVISOR_IMAGE_ID" = "$SUPERVISOR_CONTAINER_IMAGE_ID" ] && configIsUnchanged; then
     # Supervisor image exists, and the current supervisor container is created from
     balena start --attach resin_supervisor
 else


### PR DESCRIPTION
Fix the ordering of the conditional check when starting the supervisor container;
only check that the values being passed into the environment match the ones held
in the config IF the container already exists.

Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>
