### PR TITLE
docker-disk: disable the default bridge network to avoid warnings

### DIFF
--- a/meta-resin-common/recipes-containers/docker-disk/files/entry.sh
+++ b/meta-resin-common/recipes-containers/docker-disk/files/entry.sh
@@ -24,7 +24,7 @@ mkdir -p $DATA_VOLUME/resin-data
 
 # Start docker
 echo "Starting docker daemon with $BALENA_STORAGE storage driver."
-dockerd -g $DATA_VOLUME/docker -s "$BALENA_STORAGE" &
+dockerd -g $DATA_VOLUME/docker -s "$BALENA_STORAGE" -b none &
 echo "Waiting for docker to become ready.."
 STARTTIME="$(date +%s)"
 ENDTIME="$STARTTIME"


### PR DESCRIPTION
By default, the supervisor container is created with the default bridge
network docker0. Which causes spurious warnings in balenaOS.

Disable the bridge network during build as we don't need it

Addresses one of warnings in https://github.com/balena-os/balena-engine/issues/153

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
