### PR TITLE
resin-vars: fix typo in os-networkmanager

### DIFF
--- a/meta-resin-common/recipes-support/resin-vars/resin-vars.bb
+++ b/meta-resin-common/recipes-support/resin-vars/resin-vars.bb
@@ -95,14 +95,14 @@ runtest() {
 do_runtests() {
 	bbnote "Running os-networkmanager tests..."
 	runtest os-networkmanager.testconfig1.json 0 '# This file is generated based on os.networkManager configuration in config.json.
-[Device]
+[device]
 wifi.scan-rand-mac-address=yes'
 	runtest os-networkmanager.testconfig2.json 0 '# This file is generated based on os.networkManager configuration in config.json.
-[Device]
+[device]
 wifi.scan-rand-mac-address=no'
 	runtest os-networkmanager.testconfig3.json 0 '# This file is generated based on os.networkManager configuration in config.json.'
 	runtest os-networkmanager.testconfig4.json 0 '# This file is generated based on os.networkManager configuration in config.json.
-[Device]
+[device]
 wifi.scan-rand-mac-address=foo'
 	runtest os-networkmanager.testconfig5.json 1 'NO FILE'
 }

--- a/meta-resin-common/recipes-support/resin-vars/resin-vars/os-networkmanager
+++ b/meta-resin-common/recipes-support/resin-vars/resin-vars/os-networkmanager
@@ -74,8 +74,8 @@ log "info" "Using NetworkManager configuration fragment file in $NM_CONF_FRAGMEN
 
 nm_config="# This file is generated based on os.networkManager configuration in config.json."
 
-# [Device]
-section="Device"
+# [device]
+section="device"
 s=0
 if ! config_json_value="$(jq -r " .os.network.wifi.randomMacAddressScan" "$CONFIG_PATH")"; then
 	log "error" "Error parsing $CONFIG_PATH."


### PR DESCRIPTION
The device section in networkmanager.conf is [device] not [Device].
Fix the typo
Fixes #1448

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
