### PR TITLE
dnsmasq: Enable dbus interface

### DIFF
--- a/meta-resin-common/recipes-connectivity/dnsmasq/dnsmasq_%.bbappend
+++ b/meta-resin-common/recipes-connectivity/dnsmasq/dnsmasq_%.bbappend
@@ -19,3 +19,5 @@ ALTERNATIVE_${PN} = "resolv-conf"
 ALTERNATIVE_TARGET[resolv-conf] = "${sysconfdir}/resolv-conf.dnsmasq"
 ALTERNATIVE_LINK_NAME[resolv-conf] = "${sysconfdir}/resolv.conf"
 ALTERNATIVE_PRIORITY[resolv-conf] = "60"
+
+PACKAGECONFIG_append = "dbus"

--- a/meta-resin-common/recipes-connectivity/dnsmasq/files/dnsmasq.conf
+++ b/meta-resin-common/recipes-connectivity/dnsmasq/files/dnsmasq.conf
@@ -292,7 +292,5 @@ bogus-priv
 # Include a another lot of configuration options.
 #conf-file=/etc/dnsmasq.more.conf
  
- 
-
-
-
+# Enable dbus
+enable-dbus


### PR DESCRIPTION
The dbus interface is useful for containers to qeury dnsmasq if needed.
Fixes #1453 

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
