### PR TITLE
Reorder systemd services to improve boot time

### DIFF
--- a/meta-resin-common/recipes-connectivity/openvpn/files/openvpn.service
+++ b/meta-resin-common/recipes-connectivity/openvpn/files/openvpn.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=OpenVPN
 Requires=prepare-openvpn.service bind-etc-openvpn.service
-After=syslog.target network.target prepare-openvpn.service bind-etc-openvpn.service time-sync.target
+After=syslog.target network.target prepare-openvpn.service bind-etc-openvpn.service time-sync.target multi-user.target
 ConditionFileNotEmpty=/etc/openvpn/openvpn.conf
 
 [Service]
@@ -15,4 +15,4 @@ ExecStart=/usr/sbin/openvpn --writepid /var/run/openvpn/openvpn.pid --cd /etc/op
 
 [Install]
 Alias=openvpn-resin.service
-WantedBy=multi-user.target
+WantedBy=os-late-init.target

--- a/meta-resin-common/recipes-connectivity/openvpn/openvpn/openvpn@.service
+++ b/meta-resin-common/recipes-connectivity/openvpn/openvpn/openvpn@.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=OpenVPN Robust And Highly Flexible Tunneling Application On %I
-After=syslog.target network.target
+After=syslog.target network.target multi-user.target
 
 [Service]
 PrivateTmp=true
@@ -9,4 +9,4 @@ PIDFile=/var/run/openvpn/%i.pid
 ExecStart=/usr/sbin/openvpn --daemon --writepid /var/run/openvpn/%i.pid --cd /etc/openvpn/ --config %i.conf
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=os-late-init.target

--- a/meta-resin-common/recipes-connectivity/resin-proxy-config/resin-proxy-config/redsocks.service
+++ b/meta-resin-common/recipes-connectivity/resin-proxy-config/resin-proxy-config/redsocks.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=redsocks transparent proxy redirector
 Requires=resin-boot.service resin-proxy-config.service
-After=resin-boot.service resin-proxy-config.service dnsmasq.service
+After=resin-boot.service resin-proxy-config.service dnsmasq.service multi-user.target
 ConditionPathExists=/mnt/boot/system-proxy/redsocks.conf
 
 [Service]
@@ -11,4 +11,4 @@ Restart=on-failure
 RestartSec=10s
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=os-late-init.target

--- a/meta-resin-common/recipes-connectivity/resin-proxy-config/resin-proxy-config/resin-proxy-config.service
+++ b/meta-resin-common/recipes-connectivity/resin-proxy-config/resin-proxy-config/resin-proxy-config.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Resin proxy configuration service
 Requires=resin-boot.service
-After=resin-boot.service dnsmasq.service
+After=resin-boot.service dnsmasq.service multi-user.target
 
 [Service]
 Type=oneshot
@@ -9,4 +9,4 @@ ExecStart=@BASE_BINDIR@/sh @BINDIR@/resin-proxy-config
 RemainAfterExit=yes
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=os-late-init.target

--- a/meta-resin-common/recipes-containers/balena/balena/balena-host.socket
+++ b/meta-resin-common/recipes-containers/balena/balena/balena-host.socket
@@ -1,5 +1,6 @@
 [Unit]
 Description=Docker Socket for the API
+After=multi-user.target
 
 [Socket]
 ListenStream=/var/run/balena-host.sock
@@ -8,5 +9,5 @@ SocketUser=root
 SocketGroup=balena-engine
 
 [Install]
-WantedBy=sockets.target
+WantedBy=os-late-init.target
 

--- a/meta-resin-common/recipes-containers/resin-supervisor/resin-supervisor/resin-supervisor.service
+++ b/meta-resin-common/recipes-containers/resin-supervisor/resin-supervisor/resin-supervisor.service
@@ -10,7 +10,6 @@ After=\
     resin\x2ddata.mount \
     balena-device-uuid.service \
     os-config-devicekey.service \
-    bind-etc-systemd-system-resin.target.wants.service \
     bind-etc-resin-supervisor.service \
     chronyd.service
 Wants=balena.service

--- a/meta-resin-common/recipes-core/balena-rollback/files/rollback-health.service
+++ b/meta-resin-common/recipes-core/balena-rollback/files/rollback-health.service
@@ -17,7 +17,7 @@ Description=Balena rollback checks health
 DefaultDependencies=no
 Requires=resin-boot.service mnt-sysroot-active.service mnt-sysroot-inactive.service
 Wants=openvpn.service balena.service
-After=resin-boot.service mnt-sysroot-active.service mnt-sysroot-inactive.service openvpn.service balena.service
+After=resin-boot.service mnt-sysroot-active.service mnt-sysroot-inactive.service openvpn.service balena.service multi-user.target
 ConditionPathExists=/mnt/state/rollback-health-breadcrumb
 
 [Service]
@@ -26,4 +26,4 @@ RemainAfterExit=yes
 ExecStart=/bin/sh /usr/bin/rollback-health
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=os-late-init.target

--- a/meta-resin-common/recipes-core/chrony/files/chronyd.conf.systemd
+++ b/meta-resin-common/recipes-core/chrony/files/chronyd.conf.systemd
@@ -1,7 +1,7 @@
 [Unit]
 Before=time-sync.target
 Wants=time-sync.target var-volatile-lib.service
-After=var-volatile-lib.service
+After=var-volatile-lib.service multi-user.target
 
 [Service]
 Type=simple
@@ -9,3 +9,6 @@ Restart=always
 RestartSec=10s
 ExecStart=
 ExecStart=/usr/sbin/chronyd -s -d
+
+[Install]
+WantedBy=os-late-init.target

--- a/meta-resin-common/recipes-core/os-config/os-config/os-config.service
+++ b/meta-resin-common/recipes-core/os-config/os-config/os-config.service
@@ -2,7 +2,7 @@
 Description=OS configuration update service
 Requires=resin-boot.service
 Wants=os-config-devicekey.service NetworkManager.service
-After=os-config-devicekey.service resin-boot.service NetworkManager.service
+After=os-config-devicekey.service resin-boot.service NetworkManager.service multi-user.target
 
 [Service]
 Type=simple
@@ -11,4 +11,4 @@ RestartSec=10
 ExecStart=/usr/bin/os-config update
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=os-late-init.target

--- a/meta-resin-common/recipes-core/systemd/systemd/os-late-init.target
+++ b/meta-resin-common/recipes-core/systemd/systemd/os-late-init.target
@@ -1,0 +1,6 @@
+# This file is part of the os
+
+[Unit]
+Description=A target after multi-user.target for non-critical systemd services
+Requires=multi-user.target
+After=multi-user.target

--- a/meta-resin-common/recipes-core/systemd/systemd/resin.target
+++ b/meta-resin-common/recipes-core/systemd/systemd/resin.target
@@ -1,3 +1,0 @@
-[Unit]
-Description=Resin Target
-Documentation=man:systemd.target(5)

--- a/meta-resin-common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-resin-common/recipes-core/systemd/systemd_%.bbappend
@@ -8,6 +8,7 @@ SRC_URI_append = " \
     file://60-resin-update-state.rules \
     file://resin_update_state_probe \
     file://0002-core-Avoid-empty-directory-warning-when-we-are-bind-.patch \
+    file://os-late-init.target \
     "
 
 python() {
@@ -58,6 +59,13 @@ do_install_append() {
     install -m 0644 ${WORKDIR}/reboot.target.conf ${D}/${sysconfdir}/systemd/system/reboot.target.d/
     install -d -m 0755 ${D}/${sysconfdir}/systemd/system/poweroff.target.d
     install -m 0644 ${WORKDIR}/poweroff.target.conf ${D}/${sysconfdir}/systemd/system/poweroff.target.d/
+
+    # Install os-late-init target
+    install -d ${D}${systemd_unitdir}/system/os-late-init.target.wants
+    install -d ${D}${sysconfdir}/systemd/system/os-late-init.target.wants
+    install -m 0644 ${WORKDIR}/os-late-init.target ${D}${systemd_unitdir}/system/os-late-init.target
+    ln -srf ${D}${systemd_unitdir}/system/os-late-init.target ${D}${sysconfdir}/systemd/system/default.target
+    ln -srf ${D}${systemd_unitdir}/system/os-late-init.target ${D}/lib/systemd/system/default.target
 
     # enable watchdog
     install -d -m 0755 ${D}/${sysconfdir}/systemd/system.conf.d

--- a/meta-resin-common/recipes-support/resin-mounts/resin-mounts.inc
+++ b/meta-resin-common/recipes-support/resin-mounts/resin-mounts.inc
@@ -57,9 +57,12 @@ do_compile () {
 		elif [ "$bindmount" = "/etc/NetworkManager/conf.d" ]; then
 			# This bind mount needs to be running before the NetworkManager service starts for os-networkmanager
 			sed -i -e "/^Before=/s/\$/ NetworkManager.service/" $servicefile
-		elif [ "$bindmount" = "/etc/udev/rules.d" ]; then
-			# This bind mount needs to be running before the udev service starts for os-udevrules
-			sed -i -e "/^Before=/s/\$/ systemd-udevd.service/" $servicefile
+		elif [ "$bindmount" = "/etc/udev/rules.d" ] || [ "$bindmount" = "/var/lib/chrony" ]; then
+			# This bind mount can easily run after multi-user.target
+			# Change WantedBy
+			sed -i -e 's/multi-user.target/os-late-init.target/g' $servicefile
+			# Add multi-user.target in After=
+			sed -i -e "/^After=/s/\$/ multi-user.target/" $servicefile
 		fi
 	done
 }

--- a/meta-resin-common/recipes-support/resin-mounts/resin-mounts/mnt-sysroot-inactive.service
+++ b/meta-resin-common/recipes-support/resin-mounts/resin-mounts/mnt-sysroot-inactive.service
@@ -2,6 +2,7 @@
 Description=Resin inactive root partition mount service
 DefaultDependencies=no
 Before=umount.target
+After=multi-user.target
 Conflicts=umount.target
 ConditionVirtualization=!docker
 
@@ -10,3 +11,6 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/resin-partition-mounter --sysroot --mount inactive
 ExecStop=/usr/bin/resin-partition-mounter --sysroot --umount inactive
+
+[Install]
+Wantedby=os-late-init.target

--- a/meta-resin-common/recipes-support/resin-vars/resin-vars/os-sshkeys.service
+++ b/meta-resin-common/recipes-support/resin-vars/resin-vars/os-sshkeys.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=OS SSH keys
 Requires=resin-boot.service bind-home-root-.ssh.service
-After=resin-boot.service bind-home-root-.ssh.service
+After=resin-boot.service bind-home-root-.ssh.service multi-user.target
 
 [Service]
 Type=oneshot
@@ -9,4 +9,4 @@ RemainAfterExit=yes
 ExecStart=@SBINDIR@/os-sshkeys
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=os-late-init.target

--- a/meta-resin-common/recipes-support/resin-vars/resin-vars/os-udevrules.service
+++ b/meta-resin-common/recipes-support/resin-vars/resin-vars/os-udevrules.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=udev rules configuration from config.json
 Requires=resin-boot.service systemd-udev-settle.service bind-etc-udev-rules.d.service
-After=resin-boot.service systemd-udev-settle.service bind-etc-udev-rules.d.service
+After=resin-boot.service systemd-udev-settle.service bind-etc-udev-rules.d.service multi-user.target
 
 [Service]
 Type=oneshot
@@ -9,4 +9,4 @@ RemainAfterExit=yes
 ExecStart=@SBINDIR@/os-udevrules
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=os-late-init.target


### PR DESCRIPTION
WIP

Basically create a new systemd target after multi-user.target. This is called os-late-init.target.
And then reorder non-critical services to run after multi-user.target.
e.g mnt-sysroot-inactive, ntp, os-sshkey, os-udevrule, proxy-config (their bind mounts), etc.

It is up for debate whether something is technical or not.

I wasted hours trying to get the default yocto systemd target to be os-late-init.target. But it is still not working so need to `mount -o remount,rw /` `systemctl set-default os-late-init.target` `reboot` before testing.

I'm thinking whether I should go the other way. i.e. try to make a target and point critical services to that instead of making a target and delaying non-critical services.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
