### PR TITLE
Log all messages in initramfs to dev-kmsg

### DIFF
--- a/meta-resin-common/recipes-core/images/resin-image-initramfs.bb
+++ b/meta-resin-common/recipes-core/images/resin-image-initramfs.bb
@@ -7,6 +7,7 @@ PACKAGE_INSTALL = " \
     base-passwd \
     busybox \
     initramfs-module-debug \
+    initramfs-module-prepare \
     initramfs-module-fsck \
     initramfs-module-machineid \
     initramfs-module-resindataexpander \

--- a/meta-resin-common/recipes-core/initrdscripts/files/prepare
+++ b/meta-resin-common/recipes-core/initrdscripts/files/prepare
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+prepare_enabled() {
+    # Do not run when shell is passed in kernel cmdline
+    if [ "$bootparam_shell" = "true" ]; then
+        return 1
+    fi
+
+    return 0
+}
+
+prepare_run() {
+    # We would like the output of stdout/stderr in kernel messages to
+    # read them from userspace for debugging purposes.
+    exec >/dev/kmsg 2>&1
+}

--- a/meta-resin-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-resin-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -1,6 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_append = " \
+    file://prepare \
     file://fsck \
     file://machineid \
     file://resindataexpander \
@@ -10,6 +11,7 @@ SRC_URI_append = " \
     "
 
 do_install_append() {
+    install -m 0755 ${WORKDIR}/prepare ${D}/init.d/70-prepare
     install -m 0755 ${WORKDIR}/fsck ${D}/init.d/87-fsck
     install -m 0755 ${WORKDIR}/rootfs ${D}/init.d/90-rootfs
     install -m 0755 ${WORKDIR}/finish ${D}/init.d/99-finish
@@ -24,6 +26,7 @@ PACKAGES_append = " \
     initramfs-module-machineid \
     initramfs-module-resindataexpander \
     initramfs-module-rorootfs \
+    initramfs-module-prepare \
     "
 
 RRECOMMENDS_${PN}-base += "initramfs-module-rootfs"
@@ -47,3 +50,7 @@ FILES_initramfs-module-rorootfs = "/init.d/89-rorootfs"
 SUMMARY_initramfs-module-rootfs = "initramfs support for locating and mounting the root partition"
 RDEPENDS_initramfs-module-rootfs = "${PN}-base"
 FILES_initramfs-module-rootfs = "/init.d/90-rootfs"
+
+SUMMARY_initramfs-module-prepare = "Prepare initramfs console"
+RDEPENDS_initramfs-module-prepare = "${PN}-base"
+FILES_initramfs-module-prepare = "/init.d/70-prepare"


### PR DESCRIPTION
We run some operations in the initramfs. fsck, expand partitions etc.
Any error messages or warnings printed here are invisible in production
images. This line from debian initramfs-tools configures the initramfs
shell to log all output in /dev/kmsg so dmesg shows the output of
initramfs commands as well.
Fixes #1459

With this PR, on a pi3, we see the initramfs output like this in dmesg. (the fsck lines are from initramfs)

```
[    2.950758] usb 1-1.1: New USB device strings: Mfr=0, Product=0, SerialNumber=0
[    2.961012] hub 1-1.1:1.0: USB hub found
[    2.967212] hub 1-1.1:1.0: 3 ports detected
[    2.970071] CP437: Invalid argument
[    3.063691] fsck.fat 4.1 (2017-01-24)
               0x41: Dirty bit is set. Fs was not properly unmounted and some data may be corrupt.
                Automatically removing dirty bit.
               Performing changes.
               /dev/disk/by-label/resin-boot: 153 files, 16762/80628 clusters
[    3.115240] resin-rootA: recovering journal
[    3.135470] resin-rootA: clean, 5825/39936 files, 254911/319488 blocks

[    3.192810] resin-rootB: recovering journal
[    3.238307] resin-rootB: clean, 5827/39936 files, 254928/319488 blocks

[    3.293140] resin-state: recovering journal
[    3.326675] dwc_otg_handle_wakeup_detected_intr lxstate = 2
[    3.353674] resin-state: clean, 57/5136 files, 1894/20480 blocks
[    3.818966] EXT4-fs (mmcblk0p3): mounted filesystem with ordered data mode. Opts: (null)
[    3.838579] usb 1-1.1.1: new high-speed USB device number 4 using dwc_otg
[    3.951778] EXT4-fs (mmcblk0p5): mounted filesystem with ordered data mode. Opts: (null)
[    3.971818] usb 1-1.1.1: New USB device found, idVendor=0424, idProduct=7800
[    3.980001] usb 1-1.1.1: New USB device strings: Mfr=0, Product=0, SerialNumber=0
[    4.031240] switch_root: 1 output lines suppressed due to ratelimiting
[    4.356840] EXT4-fs (mmcblk0p3): re-mounted. Opts: (null)
```

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
