### PR TITLE
Add OS_KERNEL_CMDLINE option

### DIFF
--- a/meta-resin-common/conf/distro/include/balena-os.inc
+++ b/meta-resin-common/conf/distro/include/balena-os.inc
@@ -55,6 +55,9 @@ INHERIT += "image-buildinfo resin-sanity"
 RESIN_IMAGE_FLAG_FILE = "resin-image"
 RESIN_FLASHER_FLAG_FILE = "resin-image-flasher"
 
+# Kernel command line
+OS_KERNEL_CMDLINE ?= "${@bb.utils.contains('DEVELOPMENT_IMAGE','1','','console=null quiet splash vt.global_cursor_default=0 consoleblank=0',d)}"
+
 # Initramfs
 INITRAMFS_IMAGE = "resin-image-initramfs"
 INITRAMFS_IMAGE_BUNDLE = "1"


### PR DESCRIPTION
balenaOS comes in two flavours, production/development. production
images have various options passed to the kernel cmdline.
Currently some devices BSPs have those options passed and some dont.
It'll be hard to keep the common options consistent.
e.g. consoleblank=0 is passed for some devices and not for others.

We'd like the extra options we pass to be in one place. All BSPs can
then append this variable in their respective recipe/bootloader config
etc.

Fixes #1464

Tested by modifying `DEVELOPMENT_IMAGE`  in local.conf,
running `bitbake -e resin-image > tmp.log` and then grepping for the parameter.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
