### PR TITLE
Add support to update a connectivity section in NetworkManager via config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,32 @@ See below an example of a config.json snippet which disables MAC address randomi
 }
 ```
 
+##### connectivity
+
+This object defines configuration related to networking connectivity checks:
+   * "uri" string where the value is the url to query for connectivity checks
+   * "interval" string where the value is the interval between connectivity checks in seconds.
+   * "response" string. If set, controls what body content is checked for when requesting the URI for connectivity. If it is an empty value, the HTTP server is expected to answer with status code 204 or send no data.
+
+The default values are
+```
+uri=$API_ENDPOINT/connectivity-check
+interval=3600
+response=
+```
+
+See below an example of a config.json snippet which configures the connectivity check by passing the balena cloud connectivity endpoint with a 5 minute interval.
+```
+"os": {
+  "network" : {
+    "connectivity": {
+        "uri" : "https://api.balena-cloud.com/connectivity-check",
+        "interval" : "300"
+      }
+  }
+}
+```
+
 #### udevRules
 
 String. Custom udev rules can be passed via config.json.

--- a/meta-resin-common/recipes-support/resin-vars/resin-vars.bb
+++ b/meta-resin-common/recipes-support/resin-vars/resin-vars.bb
@@ -13,6 +13,7 @@ SRC_URI = " \
     file://os-networkmanager.testconfig3.json \
     file://os-networkmanager.testconfig4.json \
     file://os-networkmanager.testconfig5.json \
+    file://os-networkmanager.testconfig6.json \
     file://os-udevrules \
     file://os-udevrules.service \
     file://os-sshkeys \
@@ -92,6 +93,7 @@ runtest() {
 	fi
 }
 
+# Build time sanity tests checking various config.json fragments.
 do_runtests() {
 	bbnote "Running os-networkmanager tests..."
 	runtest os-networkmanager.testconfig1.json 0 '# This file is generated based on os.networkManager configuration in config.json.
@@ -105,5 +107,11 @@ wifi.scan-rand-mac-address=no'
 [device]
 wifi.scan-rand-mac-address=foo'
 	runtest os-networkmanager.testconfig5.json 1 'NO FILE'
+	runtest os-networkmanager.testconfig6.json 0 '# This file is generated based on os.networkManager configuration in config.json.
+[connectivity]
+uri=http://www.example.com/connectivity-check
+interval=7200
+response=Am I online'
+
 }
 addtask runtests before do_package after do_install

--- a/meta-resin-common/recipes-support/resin-vars/resin-vars/os-networkmanager
+++ b/meta-resin-common/recipes-support/resin-vars/resin-vars/os-networkmanager
@@ -70,7 +70,7 @@ log "info" "Using $CONFIG_PATH config.json."
 if [ -n "$NM_CONF_FRAGMENT" ]; then
         nm_conf_fragment="$NM_CONF_FRAGMENT"
 fi
-log "info" "Using NetworkManager configuration fragment file in $NM_CONF_FRAGMENT."
+log "info" "Using NetworkManager configuration fragment file in $nm_conf_fragment."
 
 nm_config="# This file is generated based on os.networkManager configuration in config.json."
 
@@ -89,6 +89,49 @@ if [ "$config_json_value" != "null" ]; then
 		s=1
 	fi
 	nm_config="$(printf "%s\nwifi.scan-rand-mac-address=%s" "$nm_config" "$value")"
+fi
+
+# [connectivity]
+section="connectivity"
+DEFAULT_INTERVAL=3600
+DEFAULT_RESPONSE=""
+config_json_uri="$(jq -r " .os.network.connectivity.uri" "$CONFIG_PATH")"
+disable_connectvity_check=0
+
+if [ "$config_json_uri" = "null" ] ; then
+	log "info" ".os.network.connectivity.uri not defined. Trying default"
+	if [ -n "$API_ENDPOINT" ]; then
+		config_json_uri="$API_ENDPOINT/connectivity-check"
+		log "info" "Using default os.network.connectivity.uri configuration : $config_json_uri"
+	else
+		disable_connectvity_check=1
+		log "info" "API_ENDPOINT not found in config.json. Disabling connectivity check"
+	fi
+else
+	log "info" "Found os.network.connectivity.uri configuration : $config_json_uri"
+fi
+
+if [ "$disable_connectvity_check" -eq 0 ]; then
+	config_json_interval="$(jq -r " .os.network.connectivity.interval" "$CONFIG_PATH")"
+	if [ "$config_json_interval" = null ] ; then
+		config_json_interval=$DEFAULT_INTERVAL
+		log "info" "Using default os.network.connectivity.interval : $config_json_interval"
+	else
+		log "info" "Found os.network.connectivity.interval : $config_json_interval"
+	fi
+
+	config_json_response="$(jq -r " .os.network.connectivity.response" "$CONFIG_PATH")"
+	if [ "$config_json_response" = null ] ; then
+		config_json_response=$DEFAULT_RESPONSE
+		log "info" "Using default os.network.connectivity.response : \"\""
+	else
+		log "info" "Found os.network.connectivity.response : $config_json_response"
+	fi
+
+	nm_config="$(printf "%s\n[%s]" "$nm_config" "$section")"
+	nm_config="$(printf "%s\nuri=%s" "$nm_config" "$config_json_uri")"
+	nm_config="$(printf "%s\ninterval=%s" "$nm_config" "$config_json_interval")"
+	nm_config="$(printf "%s\nresponse=%s" "$nm_config" "$config_json_response")"
 fi
 
 # Write final NM configuation fragment

--- a/meta-resin-common/recipes-support/resin-vars/resin-vars/os-networkmanager.testconfig6.json
+++ b/meta-resin-common/recipes-support/resin-vars/resin-vars/os-networkmanager.testconfig6.json
@@ -1,0 +1,11 @@
+{
+  "os": {
+    "network": {
+        "connectivity": {
+            "uri": "http://www.example.com/connectivity-check",
+            "interval": "7200",
+            "response": "Am I online"
+    	}
+    }
+  }
+}


### PR DESCRIPTION
We don't have a connectivity section configured in NetworkManager config at the moment.
This causes issues for devices with multiple interfaces that are active but only one has actual internet connectivity. NM doesn't know and does not adjust route metrics.

We now default to having the following in NetworkManager.conf

```
[connectivity]
uri=https://api.balena-cloud.com/connectivity-check
interval=3600
request=
```

The uri and interval are editable via config.json. See readme.md

Fixes #1199 

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
