### PR TITLE
docker-disk: Disable unnecessary docker pid check

### DIFF
--- a/meta-resin-common/recipes-containers/docker-disk/docker-disk.inc
+++ b/meta-resin-common/recipes-containers/docker-disk/docker-disk.inc
@@ -1,5 +1,4 @@
 RESIN_CHECK_CONN_URL ?= "index.docker.io"
-DOCKER_PID_FILE ?= "/var/run/docker.pid"
 
 # Check if host can reach a specific URL
 # Used for connectivity check
@@ -18,18 +17,7 @@ def connected(d):
 
 # Check if docker is running and usable for current user
 def usable_docker(d):
-    import os, subprocess
-
-    # Check docker is running
-    pid_file = d.getVar('DOCKER_PID_FILE', True)
-    try:
-        f = open(pid_file, 'r')
-    except:
-        return "no"
-    pid = f.read()
-    f.close()
-    if not os.path.exists("/proc/%s" % pid):
-        return "no"
+    import subprocess
 
     # Test docker execute permission
     cmd = "docker images > /dev/null 2>&1"


### PR DESCRIPTION
_Note: As i am not the original owner of #1419 this is a new pull request with hopefully proper commenting for the commit._
FYI: @ZubairLK @agherzan

By checking for a pid you are prevented from building Balena inside
of a privileged container with a bind mount on /var/run/docker.sock

The "Test docker execute permission" stanza is adequate for testing
if docker is operational.

Change-type: minor
Changlog-entry: Disable unnecessary docker pid check
Signed-off-by: Armin Schlegel <armin.schlegel@gmx.de>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
