### PR TITLE
resin-u-boot: make devtool-compatible

### DIFF
--- a/meta-resin-common/classes/resin-u-boot.bbclass
+++ b/meta-resin-common/classes/resin-u-boot.bbclass
@@ -22,17 +22,24 @@ RESIN_ENV_FILE = "resinOS_uEnv.txt"
 RESIN_UBOOT_DEVICES ?= "0 1 2"
 RESIN_UBOOT_DEVICE_TYPES ?= "mmc"
 
-do_generate_resin_uboot_configuration () {
-    cat > ${S}/include/config_resin.h <<EOF
-#define RESIN_UBOOT_DEVICES ${RESIN_UBOOT_DEVICES}
-#define RESIN_UBOOT_DEVICE_TYPES ${RESIN_UBOOT_DEVICE_TYPES}
-#define RESIN_BOOT_PART ${RESIN_BOOT_PART}
-#define RESIN_DEFAULT_ROOT_PART ${RESIN_DEFAULT_ROOT_PART}
-#define RESIN_IMAGE_FLAG_FILE ${RESIN_IMAGE_FLAG_FILE}
-#define RESIN_FLASHER_FLAG_FILE ${RESIN_FLASHER_FLAG_FILE}
-#define RESIN_ENV_FILE ${RESIN_ENV_FILE}
-EOF
+python do_generate_resin_uboot_configuration () {
+    vars = [
+        'RESIN_UBOOT_DEVICES',
+        'RESIN_UBOOT_DEVICE_TYPES',
+        'RESIN_BOOT_PART',
+        'RESIN_DEFAULT_ROOT_PART',
+        'RESIN_IMAGE_FLAG_FILE',
+        'RESIN_FLASHER_FLAG_FILE',
+        'RESIN_ENV_FILE',
+    ]
+    with open(os.path.join(d.getVar('S'), 'include', 'config_resin.h'), 'w') as f:
+        for v in vars:
+            f.write("#define %s %s\n" % (v, d.getVar(v)))
 
-    cp ${WORKDIR}/env_resin.h ${S}/include/env_resin.h
+    src = bb.utils.which(d.getVar('FILESPATH'), 'env_resin.h')
+    if not src:
+        raise Exception('env_resin.h not found')
+    dst = os.path.join(d.getVar('S'), 'include', 'env_resin.h')
+    bb.utils.copyfile(src, dst)
 }
 addtask do_generate_resin_uboot_configuration after do_patch before do_configure


### PR DESCRIPTION
devtool moves the files from the WORKDIR into ${S}/oe-local-files which makes
copying of env_resin.h fail if the u-boot source is being modified using
devtool. Since devtool also alters FILESPATH to include said oe-local-files
directory, we can iterate over those paths instead of relying on WORKDIR.

Changelog-entry: Make resin-u-boot.bbclass devtool-compatible
Signed-off-by: Sven Schwermer <sven.schwermer@disruptive-technologies.com>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
