### PR TITLE
systemd: Use a conf.d file for journald configuration

### DIFF
--- a/meta-resin-common/recipes-core/systemd/systemd/journald-balena-os.conf
+++ b/meta-resin-common/recipes-core/systemd/systemd/journald-balena-os.conf
@@ -1,0 +1,6 @@
+# we disable forwarding to syslog; in the future we will have rsyslog which can
+# read the journal independently of this forwarding
+ForwardToSyslog=no
+RuntimeMaxUse=8M
+SystemMaxUse=8M
+Storage=auto

--- a/meta-resin-common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-resin-common/recipes-core/systemd/systemd_%.bbappend
@@ -4,6 +4,7 @@ SRC_URI_append = " \
     file://coredump.conf \
     file://reboot.target.conf \
     file://poweroff.target.conf \
+    file://journald-balena-os.conf \
     file://watchdog.conf \
     file://60-resin-update-state.rules \
     file://resin_update_state_probe \
@@ -35,23 +36,10 @@ FILES_${PN} += " \
     "
 
 do_install_append() {
-    # we disable forwarding to syslog; in the future we will have rsyslog which can read the journal
-    # independently of this forwarding
-    sed -i -e 's/.*ForwardToSyslog.*/#ForwardToSyslog=yes/' ${D}${sysconfdir}/systemd/journald.conf
-    sed -i -e 's/.*RuntimeMaxUse.*/RuntimeMaxUse=8M/' ${D}${sysconfdir}/systemd/journald.conf
-    sed -i -e 's/.*SystemMaxUse.*/SystemMaxUse=8M/' ${D}${sysconfdir}/systemd/journald.conf
-    sed -i -e 's/.*Storage.*/Storage=auto/' ${D}${sysconfdir}/systemd/journald.conf
-
-    if ${@bb.utils.contains('DISTRO_FEATURES','development-image','false','true',d)}; then
-        # Non-development image
-        if $(readlink autovt@.service) == "getty@*.service"; then
-            rm ${D}/lib/systemd/system/autovt@.service
-        fi
-        find ${D} -name "getty@*.service" -delete
-    fi
+    install -d -m 0755 ${D}/${sysconfdir}/systemd/journald.conf.d
+    install -m 06444 ${WORKDIR}/journald-balena-os.conf ${D}/${sysconfdir}/systemd/journald.conf.d
 
     install -d -m 0755 ${D}/srv
-    install -d -m 0755 ${D}/${sysconfdir}/systemd/journald.conf.d
 
     # shorten reboot/poweroff timeouts
     install -d -m 0755 ${D}/${sysconfdir}/systemd/system/reboot.target.d


### PR DESCRIPTION
Since yocto thud systemd main configuration files are part of another
recipe - systemd-conf. See poky commit:
28c2f0dfe3ae06d87772b2a88fcace5a03e09143

This commit prepares meta-balena for thud support.

Change-type: patch
Signed-off-by: Andrei Gherzan <andrei@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
