### PR TITLE
balena-os.inc: Don't include security flags by default

### DIFF
--- a/meta-resin-common/conf/distro/include/balena-os.inc
+++ b/meta-resin-common/conf/distro/include/balena-os.inc
@@ -1,6 +1,6 @@
 # Poky based distro file
 require conf/distro/poky.conf
-require conf/distro/include/security_flags.inc
+include conf/distro/include/balena-os-yocto-version.inc
 
 DISTRO = "balena-os"
 DISTRO_NAME = "balenaOS"

--- a/meta-resin-krogoth/conf/distro/include/balena-os-yocto-version.inc
+++ b/meta-resin-krogoth/conf/distro/include/balena-os-yocto-version.inc
@@ -1,0 +1,1 @@
+include conf/distro/include/security_flags.inc

--- a/meta-resin-morty/conf/distro/include/balena-os-yocto-version.inc
+++ b/meta-resin-morty/conf/distro/include/balena-os-yocto-version.inc
@@ -1,0 +1,1 @@
+include conf/distro/include/security_flags.inc

--- a/meta-resin-pyro/conf/distro/include/balena-os-yocto-version.inc
+++ b/meta-resin-pyro/conf/distro/include/balena-os-yocto-version.inc
@@ -1,0 +1,1 @@
+include conf/distro/include/security_flags.inc

--- a/meta-resin-rocko/conf/distro/include/balena-os-yocto-version.inc
+++ b/meta-resin-rocko/conf/distro/include/balena-os-yocto-version.inc
@@ -1,0 +1,1 @@
+include conf/distro/include/security_flags.inc

--- a/meta-resin-sumo/conf/distro/include/balena-os-yocto-version.inc
+++ b/meta-resin-sumo/conf/distro/include/balena-os-yocto-version.inc
@@ -1,0 +1,1 @@
+include conf/distro/include/security_flags.inc


### PR DESCRIPTION
Since thud, poky distro file on which balena OS is based, already
includes security_flags.inc. Because of this change, this version throws
a build warning similar to:

WARNING: Duplicate inclusion for /build/../layers/poky/meta/conf/distro/include/security_flags.inc
in
/build/../layers/meta-resin/meta-balena-thud/conf/distro/include/balena-os-yocto-version.inc

This happens because again, we import `poky` and `security_flags` but
since thud, poky includes security_flags by default. In order to avoid
this warning we import it (security_flags) now using an .inc file at the
level of the yocto version meta-balena layer. There is as well a small
additional wrinkle here. We switch the include statement from `require`
to `include` so new layers (like thud) don't have to carry this hack in
the future.

This commit prepares meta-balena for thud support.

Change-type: patch
Changelog-entry: Make security flags inclusion yocto version specific
Signed-off-by: Andrei Gherzan <andrei@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
