### PR TITLE
systemd: Make directory warning patch yocto version specific

### DIFF
--- a/meta-resin-common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-resin-common/recipes-core/systemd/systemd_%.bbappend
@@ -7,7 +7,6 @@ SRC_URI_append = " \
     file://watchdog.conf \
     file://60-resin-update-state.rules \
     file://resin_update_state_probe \
-    file://0002-core-Avoid-empty-directory-warning-when-we-are-bind-.patch \
     "
 
 python() {

--- a/meta-resin-krogoth/recipes-core/systemd/systemd/0004-core-Avoid-empty-directory-warning-when-we-are-bind-.patch
+++ b/meta-resin-krogoth/recipes-core/systemd/systemd/0004-core-Avoid-empty-directory-warning-when-we-are-bind-.patch
@@ -1,11 +1,11 @@
 From 9f991dc5f74172d5b12753ea8d35425c6935be9f Mon Sep 17 00:00:00 2001
-From: Andrei Gherzan <andrei@resin.io>
+From: Andrei Gherzan <andrei@balena.io>
 Date: Thu, 1 Feb 2018 15:54:41 +0000
 Subject: [PATCH] core: Avoid empty directory warning when we are bind-mounting
  a file
 
-Upstream-Status: Submitted [https://github.com/systemd/systemd/pull/8069]
-Signed-off-by: Andrei Gherzan <andrei@resin.io>
+Upstream-Status: Backported
+Signed-off-by: Andrei Gherzan <andrei@balena.io>
 
 ---
  src/core/unit.c | 2 +-

--- a/meta-resin-krogoth/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-resin-krogoth/recipes-core/systemd/systemd_%.bbappend
@@ -4,5 +4,6 @@ SRC_URI_append = " \
 	file://0001-rules-add-dev-disk-by-partuuid-symlinks-also-for-dos.patch \
 	file://0002-remove_systemd-getty-generator.patch \
 	file://0003-Don-t-run-specific-services-in-container.patch \
+	file://0004-core-Avoid-empty-directory-warning-when-we-are-bind-.patch \
 	"
 

--- a/meta-resin-morty/recipes-core/systemd/systemd/0003-core-Avoid-empty-directory-warning-when-we-are-bind-.patch
+++ b/meta-resin-morty/recipes-core/systemd/systemd/0003-core-Avoid-empty-directory-warning-when-we-are-bind-.patch
@@ -1,0 +1,29 @@
+From 9f991dc5f74172d5b12753ea8d35425c6935be9f Mon Sep 17 00:00:00 2001
+From: Andrei Gherzan <andrei@balena.io>
+Date: Thu, 1 Feb 2018 15:54:41 +0000
+Subject: [PATCH] core: Avoid empty directory warning when we are bind-mounting
+ a file
+
+Upstream-Status: Backported
+Signed-off-by: Andrei Gherzan <andrei@balena.io>
+
+---
+ src/core/unit.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/core/unit.c b/src/core/unit.c
+index e664e23..6dfdb2f 100644
+--- a/src/core/unit.c
++++ b/src/core/unit.c
+@@ -4012,7 +4012,7 @@ void unit_warn_if_dir_nonempty(Unit *u, const char* where) {
+         assert(where);
+
+         r = dir_is_empty(where);
+-        if (r > 0)
++        if (r > 0 || r == -ENOTDIR)
+                 return;
+         if (r < 0) {
+                 log_unit_warning_errno(u, r, "Failed to check directory %s: %m", where);
+--
+2.7.4
+

--- a/meta-resin-morty/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-resin-morty/recipes-core/systemd/systemd_%.bbappend
@@ -3,5 +3,6 @@ FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
 SRC_URI_append = " \
 	file://0001-Don-t-run-specific-services-in-container.patch \
 	file://0002-remove_systemd-getty-generator.patch \
+	file://0003-core-Avoid-empty-directory-warning-when-we-are-bind-.patch \
 	"
 

--- a/meta-resin-pyro/recipes-core/systemd/systemd/0004-core-Avoid-empty-directory-warning-when-we-are-bind-.patch
+++ b/meta-resin-pyro/recipes-core/systemd/systemd/0004-core-Avoid-empty-directory-warning-when-we-are-bind-.patch
@@ -1,0 +1,29 @@
+From 9f991dc5f74172d5b12753ea8d35425c6935be9f Mon Sep 17 00:00:00 2001
+From: Andrei Gherzan <andrei@balena.io>
+Date: Thu, 1 Feb 2018 15:54:41 +0000
+Subject: [PATCH] core: Avoid empty directory warning when we are bind-mounting
+ a file
+
+Upstream-Status: Backported
+Signed-off-by: Andrei Gherzan <andrei@balena.io>
+
+---
+ src/core/unit.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/core/unit.c b/src/core/unit.c
+index e664e23..6dfdb2f 100644
+--- a/src/core/unit.c
++++ b/src/core/unit.c
+@@ -4012,7 +4012,7 @@ void unit_warn_if_dir_nonempty(Unit *u, const char* where) {
+         assert(where);
+
+         r = dir_is_empty(where);
+-        if (r > 0)
++        if (r > 0 || r == -ENOTDIR)
+                 return;
+         if (r < 0) {
+                 log_unit_warning_errno(u, r, "Failed to check directory %s: %m", where);
+--
+2.7.4
+

--- a/meta-resin-pyro/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-resin-pyro/recipes-core/systemd/systemd_%.bbappend
@@ -4,5 +4,6 @@ SRC_URI_append = " \
 	file://0001-core-Don-t-redirect-stdio-to-null-when-running-in-co.patch \
 	file://0002-remove_systemd-getty-generator.patch \
 	file://0003-Don-t-run-specific-services-in-container.patch \
+	file://0004-core-Avoid-empty-directory-warning-when-we-are-bind-.patch \
 	"
 

--- a/meta-resin-rocko/recipes-core/systemd/systemd/0004-core-Avoid-empty-directory-warning-when-we-are-bind-.patch
+++ b/meta-resin-rocko/recipes-core/systemd/systemd/0004-core-Avoid-empty-directory-warning-when-we-are-bind-.patch
@@ -1,0 +1,29 @@
+From 9f991dc5f74172d5b12753ea8d35425c6935be9f Mon Sep 17 00:00:00 2001
+From: Andrei Gherzan <andrei@balena.io>
+Date: Thu, 1 Feb 2018 15:54:41 +0000
+Subject: [PATCH] core: Avoid empty directory warning when we are bind-mounting
+ a file
+
+Upstream-Status: Backported
+Signed-off-by: Andrei Gherzan <andrei@balena.io>
+
+---
+ src/core/unit.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/core/unit.c b/src/core/unit.c
+index e664e23..6dfdb2f 100644
+--- a/src/core/unit.c
++++ b/src/core/unit.c
+@@ -4012,7 +4012,7 @@ void unit_warn_if_dir_nonempty(Unit *u, const char* where) {
+         assert(where);
+
+         r = dir_is_empty(where);
+-        if (r > 0)
++        if (r > 0 || r == -ENOTDIR)
+                 return;
+         if (r < 0) {
+                 log_unit_warning_errno(u, r, "Failed to check directory %s: %m", where);
+--
+2.7.4
+

--- a/meta-resin-rocko/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-resin-rocko/recipes-core/systemd/systemd_%.bbappend
@@ -4,5 +4,6 @@ SRC_URI_append = " \
 	file://0001-core-Don-t-redirect-stdio-to-null-when-running-in-co.patch \
 	file://0002-remove_systemd-getty-generator.patch \
 	file://0003-Don-t-run-specific-services-in-container.patch \
+	file://0004-core-Avoid-empty-directory-warning-when-we-are-bind-.patch \
 	"
 

--- a/meta-resin-sumo/recipes-core/systemd/systemd/0011-core-Avoid-empty-directory-warning-when-we-are-bind-.patch
+++ b/meta-resin-sumo/recipes-core/systemd/systemd/0011-core-Avoid-empty-directory-warning-when-we-are-bind-.patch
@@ -1,0 +1,29 @@
+From 9f991dc5f74172d5b12753ea8d35425c6935be9f Mon Sep 17 00:00:00 2001
+From: Andrei Gherzan <andrei@balena.io>
+Date: Thu, 1 Feb 2018 15:54:41 +0000
+Subject: [PATCH] core: Avoid empty directory warning when we are bind-mounting
+ a file
+
+Upstream-Status: Backported
+Signed-off-by: Andrei Gherzan <andrei@balena.io>
+
+---
+ src/core/unit.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/core/unit.c b/src/core/unit.c
+index e664e23..6dfdb2f 100644
+--- a/src/core/unit.c
++++ b/src/core/unit.c
+@@ -4012,7 +4012,7 @@ void unit_warn_if_dir_nonempty(Unit *u, const char* where) {
+         assert(where);
+
+         r = dir_is_empty(where);
+-        if (r > 0)
++        if (r > 0 || r == -ENOTDIR)
+                 return;
+         if (r < 0) {
+                 log_unit_warning_errno(u, r, "Failed to check directory %s: %m", where);
+--
+2.7.4
+

--- a/meta-resin-sumo/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-resin-sumo/recipes-core/systemd/systemd_%.bbappend
@@ -12,4 +12,5 @@ SRC_URI_append = " \
 	file://0008-umount-Try-unmounting-even-if-remounting-read-only-f.patch \
 	file://0009-umount-Don-t-bother-remounting-api-and-ro-filesystem.patch \
 	file://0010-shutdown-Reduce-log-level-of-unmounts.patch \
+	file://0011-core-Avoid-empty-directory-warning-when-we-are-bind-.patch \
 	"


### PR DESCRIPTION
We used to have this patch applied for all the supported yocto versions.
Since thud, this patch is included by default so this change backports
it on all the rest of the supported mate-balena yocto version specific
layers.

Change-type: patch
Signed-off-by: Andrei Gherzan <andrei@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
