### PR TITLE
systemd: Fixes for sysroot symlinks creation

### DIFF
--- a/meta-resin-common/recipes-core/systemd/systemd/60-resin-update-state.rules
+++ b/meta-resin-common/recipes-core/systemd/systemd/60-resin-update-state.rules
@@ -1,1 +1,1 @@
-ENV{ID_FS_LABEL_ENC}=="resin-root*", IMPORT{program}="resin_update_state_probe $devnode", SYMLINK+="disk/by-state/$env{RESIN_UPDATE_STATE}"
+ENV{ID_FS_LABEL_ENC}=="resin-root*", IMPORT{program}="/lib/udev/resin_update_state_probe $devnode", SYMLINK+="disk/by-state/$env{RESIN_UPDATE_STATE}"

--- a/meta-resin-common/recipes-core/systemd/systemd/resin_update_state_probe
+++ b/meta-resin-common/recipes-core/systemd/systemd/resin_update_state_probe
@@ -7,12 +7,12 @@ dev=$1
 
 # Only when root is mounted we can differenciate
 ROOT_MOUNTED=$(findmnt --output LABEL | grep resin-root | wc -l)
-if [ "$ROOT_MOUNTED" -eq 0]; then
+if [ "$ROOT_MOUNTED" -eq 0 ]; then
 	exit 1
 fi
 
-for mountpoint in $(findmnt --noheadings --output TARGET $dev); do
-    if [ "$mountpoint" == "/" ] || [ "$mountpoint" == "/mnt/sysroot/active" ]; then
+for mountpoint in $(findmnt --noheadings --output TARGET "$dev"); do
+    if [ "$mountpoint" = "/" ] || [ "$mountpoint" = "/mnt/sysroot/active" ]; then
         echo 'RESIN_UPDATE_STATE=active'
         exit 0
     fi


### PR DESCRIPTION
When we set the udev rule we use IMPORT{program} to know what symlinks
to create in the sysroot directory. The problem is that we don't use
absolute paths and from the documentation udev uses /usr/lib/udev as the
default path while we install the invoked script in /lib/udev.

```
  Execute an external program specified as the assigned value. If no
  absolute path is given, the program is expected to live in
  /usr/lib/udev; otherwise, the absolute path must be specified.
```

This PR changes the udev rule to use an absolute path for the
resin_update_state_probe script. Also it fixes some typos in the script
itself.

Change-type: patch
Changelog-entry: Fixes for sysroot symlinks creation
Signed-off-by: Andrei Gherzan <andrei@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
