### PR TITLE
Update balena-engine and add max-download-attempts=10

### DIFF
--- a/meta-resin-common/recipes-containers/balena/balena/balena-host.service
+++ b/meta-resin-common/recipes-containers/balena/balena/balena-host.service
@@ -9,7 +9,7 @@ ConditionVirtualization=!docker
 [Service]
 Type=notify
 Restart=always
-ExecStart=/usr/bin/balenad --delta-data-root=/mnt/sysroot/active/balena --delta-storage-driver=@BALENA_STORAGE@ --log-driver=journald -s @BALENA_STORAGE@ --data-root=/mnt/sysroot/inactive/balena -H fd:// --pidfile=/var/run/balena-host.pid --exec-root=/var/run/balena-host --bip 10.114.101.1/24 --fixed-cidr=10.114.101.128/25 --iptables=false
+ExecStart=/usr/bin/balenad --delta-data-root=/mnt/sysroot/active/balena --delta-storage-driver=@BALENA_STORAGE@ --log-driver=journald -s @BALENA_STORAGE@ --data-root=/mnt/sysroot/inactive/balena -H fd:// --pidfile=/var/run/balena-host.pid --exec-root=/var/run/balena-host --bip 10.114.101.1/24 --fixed-cidr=10.114.101.128/25 --iptables=false --max-download-attempts=10
 #Adjust OOMscore to -900 to make killing unlikely
 OOMScoreAdjust=-900
 MountFlags=slave

--- a/meta-resin-common/recipes-containers/balena/balena/balena.conf.systemd
+++ b/meta-resin-common/recipes-containers/balena/balena/balena.conf.systemd
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/usr/bin/healthdog --healthcheck=/usr/lib/balena/balena-healthcheck /usr/bin/balenad --experimental --log-driver=journald -s @BALENA_STORAGE@ -H fd:// -H unix:///var/run/balena.sock -H unix:///var/run/balena-engine.sock -H tcp://0.0.0.0:2375 --dns 10.114.102.1 --bip 10.114.101.1/24 --fixed-cidr=10.114.101.0/25
+ExecStart=/usr/bin/healthdog --healthcheck=/usr/lib/balena/balena-healthcheck /usr/bin/balenad --experimental --log-driver=journald -s @BALENA_STORAGE@ -H fd:// -H unix:///var/run/balena.sock -H unix:///var/run/balena-engine.sock -H tcp://0.0.0.0:2375 --dns 10.114.102.1 --bip 10.114.101.1/24 --fixed-cidr=10.114.101.0/25 --max-download-attempts=10

--- a/meta-resin-common/recipes-containers/balena/balena/balena.service
+++ b/meta-resin-common/recipes-containers/balena/balena/balena.service
@@ -9,7 +9,7 @@ After=network.target balena-engine.socket var-lib-docker.mount bind-etc-docker.s
 Type=notify
 Restart=always
 SyslogIdentifier=balenad
-ExecStart=/usr/bin/healthdog --healthcheck=/usr/lib/balena/balena-healthcheck /usr/bin/balenad --experimental --log-driver=journald -s @BALENA_STORAGE@ -H fd:// -H unix:///var/run/balena.sock -H unix:///var/run/balena-engine.sock --dns 10.114.102.1 --bip 10.114.101.1/24 --fixed-cidr=10.114.101.0/25
+ExecStart=/usr/bin/healthdog --healthcheck=/usr/lib/balena/balena-healthcheck /usr/bin/balenad --experimental --log-driver=journald -s @BALENA_STORAGE@ -H fd:// -H unix:///var/run/balena.sock -H unix:///var/run/balena-engine.sock --dns 10.114.102.1 --bip 10.114.101.1/24 --fixed-cidr=10.114.101.0/25 --max-download-attempts=10
 #Adjust OOMscore to -900 to make killing unlikely
 OOMScoreAdjust=-900
 MountFlags=slave

--- a/meta-resin-common/recipes-containers/balena/balena_git.bb
+++ b/meta-resin-common/recipes-containers/balena/balena_git.bb
@@ -11,10 +11,10 @@ LIC_FILES_CHKSUM = "file://src/import/LICENSE;md5=9740d093a080530b5c5c6573df9af4
 
 inherit systemd go pkgconfig useradd
 
-BALENA_VERSION = "18.09.3-dev"
+BALENA_VERSION = "18.09.5-dev"
 BALENA_BRANCH= "master"
 
-SRCREV = "5f6c5ccd16a1453f0e92e611e2539ea2708be43c"
+SRCREV = "7cab3339d1c1e4ad39b5baa49f4a38d5c1eb1ad5"
 SRC_URI = "\
 	git://github.com/resin-os/balena.git;branch=${BALENA_BRANCH};destsuffix=git/src/import \
 	file://balena.service \


### PR DESCRIPTION
This PR updates balena-engine to 18.09.5 which supports the `--max-download-attempts` flag
Pass `--max-download-attempts=10` to improve performance on flaky connections.
Fixes #1493

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
