### PR TITLE
systemd: Fix journald configuration file

### DIFF
--- a/meta-resin-common/recipes-core/systemd/systemd/journald-balena-os.conf
+++ b/meta-resin-common/recipes-core/systemd/systemd/journald-balena-os.conf
@@ -1,5 +1,6 @@
 # we disable forwarding to syslog; in the future we will have rsyslog which can
 # read the journal independently of this forwarding
+[Journal]
 ForwardToSyslog=no
 RuntimeMaxUse=8M
 SystemMaxUse=8M


### PR DESCRIPTION
9a8f1f1b744248964d4d1b2eb2c8dd732a753980 switched to a config file
fragment but when doing so the section was missed. This patch fixes
that.

Change-type: patch
Signed-off-by: Andrei Gherzan <andrei@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
