### PR TITLE
systemd_%.bbappend: Do not spawn getty in production images

### DIFF
--- a/meta-resin-common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-resin-common/recipes-core/systemd/systemd_%.bbappend
@@ -35,6 +35,14 @@ FILES_${PN} += " \
     "
 
 do_install_append() {
+    if ${@bb.utils.contains('DISTRO_FEATURES','development-image','false','true',d)}; then
+	# Non-development image
+	if $(readlink autovt@.service) == "getty@*.service"; then
+            rm ${D}/lib/systemd/system/autovt@.service
+        fi
+        find ${D} -name "getty@*.service" -delete
+    fi
+
     install -d -m 0755 ${D}/${sysconfdir}/systemd/journald.conf.d
     install -m 06444 ${WORKDIR}/journald-balena-os.conf ${D}/${sysconfdir}/systemd/journald.conf.d
 


### PR DESCRIPTION
This code was deleted by mistake so let's add it back.

Change-type: patch
Changelog-entry: Do not spawn getty in production images
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
