### PR TITLE
linux-firmware/thud: Cleanup iwlwifi by using balena-linux-firmware

### DIFF
--- a/meta-balena-thud/recipes-kernel/linux/linux-firmware_git.bbappend
+++ b/meta-balena-thud/recipes-kernel/linux/linux-firmware_git.bbappend
@@ -1,0 +1,17 @@
+inherit balena-linux-firmware
+
+# Cleanup iwlwifi firmware files
+IWLWIFI_PATH = "lib/firmware"
+IWLWIFI_REGEX = "^iwlwifi-([0-9a-zA-Z-]+)-([0-9]+).ucode$"
+IWLWIFI_FW_TOCLEAN ?= " \
+    7260 \
+    7265 \
+    7265D \
+    8000C \
+    8265 \
+"
+IWLWIFI_FW_MIN_API[7260] = "17"
+IWLWIFI_FW_MIN_API[7265] = "17"
+IWLWIFI_FW_MIN_API[7265D] = "29"
+IWLWIFI_FW_MIN_API[8000C] = "34"
+IWLWIFI_FW_MIN_API[8265] = "34"


### PR DESCRIPTION
This is done so we can save considerable amount of space on the root
partition.

See #810

Change-type: minor
Changelog-entry: Cleanup old versions of iwlwifi firmware files in Yocto Thud
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
