### PR TITLE
busybox: Use glibc's resolver as opposed to the internal one

### DIFF
--- a/meta-resin-common/recipes-core/busybox/busybox/balenaos.cfg
+++ b/meta-resin-common/recipes-core/busybox/busybox/balenaos.cfg
@@ -1,0 +1,6 @@
+# NSLOOKUP
+# Don't use the internal implementation of NSLOOKUP so that we can use MDNS
+# module in NSS.
+CONFIG_NSLOOKUP=y
+CONFIG_FEATURE_NSLOOKUP_BIG=n
+CONFIG_FEATURE_NSLOOKUP_LONG_OPTIONS=n

--- a/meta-resin-common/recipes-core/busybox/busybox_%.bbappend
+++ b/meta-resin-common/recipes-core/busybox/busybox_%.bbappend
@@ -1,4 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI_append = " \
     file://defconfig \
+    file://balenaos.cfg \
     "


### PR DESCRIPTION
Since 1.29, busybox switched to an internal implementation of the
resolver based on a feature config, NSLOOKUP_BIG. This is enabled by
default and it's meant to be musl compatible. In BalenaOS we use glibc
and we rely on it for being able to resolve names using NSS modules
(libmdns).

Change-type: patch
Changelog-entry: Fix busybox nslookup mdns lookups
Signed-off-by: Andrei Gherzan <andrei@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
