### PR TITLE
packagegroup-resin-connectivity: Add rtl8192su firmware

### DIFF
--- a/meta-resin-common/recipes-core/packagegroups/packagegroup-resin-connectivity.bb
+++ b/meta-resin-common/recipes-core/packagegroups/packagegroup-resin-connectivity.bb
@@ -14,6 +14,7 @@ CONNECTIVITY_FIRMWARES ?= " \
     linux-firmware-ath9k \
     linux-firmware-ralink \
     linux-firmware-rtl8192cu \
+    linux-firmware-rtl8192su \
     "
 
 CONNECTIVITY_PACKAGES = " \


### PR DESCRIPTION
Fixes: #1511

Add wifi firmware for rtl8192su

Only tested to see if the firmware file appears in the right place

```
bash-4.4# ls  /lib/firmware/rtlwifi/rtl8712u.bin -al
-rw-r--r-- 1 root root 122328 May 20 12:23 /lib/firmware/rtlwifi/rtl8712u.bin
bash-4.4#
```

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
