### PR TITLE
balena-engine: bump to v18.9.6

### DIFF
--- a/meta-balena-common/recipes-containers/balena/balena_git.bb
+++ b/meta-balena-common/recipes-containers/balena/balena_git.bb
@@ -11,10 +11,10 @@ LIC_FILES_CHKSUM = "file://src/import/LICENSE;md5=9740d093a080530b5c5c6573df9af4
 
 inherit systemd go pkgconfig useradd
 
-BALENA_VERSION = "18.09.5-dev"
+BALENA_VERSION = "18.09.6-dev"
 BALENA_BRANCH= "master"
 
-SRCREV = "7cab3339d1c1e4ad39b5baa49f4a38d5c1eb1ad5"
+SRCREV = "95c7371304f9cef494efe93f0a8ffd53a75eac21"
 SRC_URI = "\
 	git://github.com/resin-os/balena.git;branch=${BALENA_BRANCH};destsuffix=git/src/import \
 	file://balena.service \


### PR DESCRIPTION
In preparation for warrior. Bumps containerd which works with the newer
systemd in warrior.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
