### PR TITLE
os-release: Set VARIANT_ID to hostOS version too

### DIFF
--- a/meta-balena-common/recipes-core/os-release/os-release.bbappend
+++ b/meta-balena-common/recipes-core/os-release/os-release.bbappend
@@ -5,6 +5,7 @@ OS_RELEASE_FIELDS_append = " RESIN_BOARD_REV META_RESIN_REV SLUG MACHINE VARIANT
 
 # Simplify VERSION output
 VERSION = "${HOSTOS_VERSION}"
+VERSION_ID = "${HOSTOS_VERSION}"
 
 VARIANT = "${@bb.utils.contains('DEVELOPMENT_IMAGE','1','Development','Production',d)}"
 VARIANT_ID = "${@bb.utils.contains('DEVELOPMENT_IMAGE','1','dev','prod',d)}"


### PR DESCRIPTION
VERSION and VERSION_ID had a slightly different semantics in balenaOS.
VERSION was referring to the BalenaOS (host OS) version (which is coming from
device repositories) while VERSION_ID was set to the DISTRO_VERSION.
This brings confusion so we change it to adhere to
https://www.freedesktop.org/software/systemd/man/os-release.html.

Fixes #1546

Change-type: minor
Changelog-entry: Set both VARIANT_ID and VARIANT in os-release to host OS version
Signed-off-by: Andrei Gherzan <andrei@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
