### PR TITLE
u-boot.bbclass: Add vardeps to regenerate config_resin.h

### DIFF
--- a/meta-balena-common/classes/resin-u-boot.bbclass
+++ b/meta-balena-common/classes/resin-u-boot.bbclass
@@ -26,17 +26,16 @@ RESIN_UBOOT_DEVICE_TYPES ?= "mmc"
 # supported bootloaders
 BASE_OS_CMDLINE ?= "${OS_KERNEL_CMDLINE}"
 
+UBOOT_VARS = "RESIN_UBOOT_DEVICES \
+              RESIN_UBOOT_DEVICE_TYPES \
+              RESIN_BOOT_PART RESIN_DEFAULT_ROOT_PART \
+              RESIN_IMAGE_FLAG_FILE \
+              RESIN_FLASHER_FLAG_FILE \
+              RESIN_ENV_FILE \
+              BASE_OS_CMDLINE"
+
 python do_generate_resin_uboot_configuration () {
-    vars = [
-        'RESIN_UBOOT_DEVICES',
-        'RESIN_UBOOT_DEVICE_TYPES',
-        'RESIN_BOOT_PART',
-        'RESIN_DEFAULT_ROOT_PART',
-        'RESIN_IMAGE_FLAG_FILE',
-        'RESIN_FLASHER_FLAG_FILE',
-        'RESIN_ENV_FILE',
-        'BASE_OS_CMDLINE',
-    ]
+    vars = d.getVar('UBOOT_VARS').split()
     with open(os.path.join(d.getVar('S'), 'include', 'config_resin.h'), 'w') as f:
         for v in vars:
             f.write("#define %s %s\n" % (v, d.getVar(v)))
@@ -48,3 +47,6 @@ python do_generate_resin_uboot_configuration () {
     bb.utils.copyfile(src, dst)
 }
 addtask do_generate_resin_uboot_configuration after do_patch before do_configure
+
+# Regenerate env_resin.h if any of these variables change.
+do_generate_resin_uboot_configuration[vardeps] += "${UBOOT_VARS}"


### PR DESCRIPTION
Currently once config_resin.h is generated, a change in these variables
doesn't regenerate the file. Add vardeps so that bitbake can regenerate
config_resin.h in case these variables are changed.

Fixes #1530

Build tested on pi3

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
