### PR TITLE
bluez5: Persist storage directory over reboots

### DIFF
--- a/meta-balena-common/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/meta-balena-common/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -1,10 +1,16 @@
 FILESEXTRAPATHS_append := ":${THISDIR}/files"
 
 SRC_URI += " \
-	file://10-local-bt-hci-up.rules \
-	file://run-bluetoothd-with-experimental-flag.patch \
-	"
+    file://10-local-bt-hci-up.rules \
+    file://bluetooth.conf.systemd \
+    file://run-bluetoothd-with-experimental-flag.patch \
+    "
 
 do_install_append() {
     install -D -m 0755 ${WORKDIR}/10-local-bt-hci-up.rules ${D}/lib/udev/rules.d/10-local-bt-hci-up.rules
+
+    install -d ${D}${sysconfdir}/systemd/system/bluetooth.service.d
+    install -m 0644 ${WORKDIR}/bluetooth.conf.systemd ${D}${sysconfdir}/systemd/system/bluetooth.service.d/bluetooth.conf
+
+    install -d ${D}/var/lib/bluetooth
 }

--- a/meta-balena-common/recipes-connectivity/bluez5/files/bluetooth.conf.systemd
+++ b/meta-balena-common/recipes-connectivity/bluez5/files/bluetooth.conf.systemd
@@ -1,0 +1,3 @@
+[Unit]
+Requires=bind-var-lib-bluetooth.service
+After=bind-var-lib-bluetooth.service

--- a/meta-balena-common/recipes-support/resin-mounts/resin-mounts.inc
+++ b/meta-balena-common/recipes-support/resin-mounts/resin-mounts.inc
@@ -23,6 +23,7 @@ BINDMOUNTS += " \
 	/etc/NetworkManager/system-connections \
 	/etc/udev/rules.d \
 	/home/root/.rnd \
+	/var/lib/bluetooth \
 	/var/lib/NetworkManager \
 	/home/root/.ssh \
 	"


### PR DESCRIPTION
Currently, bluez's storage data is set to /var/lib/bluetooth which
in turn is a tmpfs location. We want this location persistent so we can
save paired devices over reboot. We do that by adding the corresponding
bind mount to the state partition and setting bluez to depend on this
mount unit.

Fixes #1544

Change-type: minor
Changelog-entry: Persist bluetooth storage data over reboots
Signed-off-by: Andrei Gherzan <andrei@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
