### PR TITLE
os-release: Introduce META_BALENA_VERSION

### DIFF
--- a/meta-balena-common/recipes-core/os-release/os-release.bbappend
+++ b/meta-balena-common/recipes-core/os-release/os-release.bbappend
@@ -1,7 +1,7 @@
 inherit deploy
 
 # Add custom resin fields
-OS_RELEASE_FIELDS_append = " RESIN_BOARD_REV META_RESIN_REV SLUG MACHINE VARIANT VARIANT_ID"
+OS_RELEASE_FIELDS_append = " RESIN_BOARD_REV META_RESIN_REV SLUG MACHINE VARIANT VARIANT_ID META_BALENA_VERSION"
 
 # Simplify VERSION output
 VERSION = "${HOSTOS_VERSION}"
@@ -9,6 +9,7 @@ VERSION_ID = "${HOSTOS_VERSION}"
 
 VARIANT = "${@bb.utils.contains('DEVELOPMENT_IMAGE','1','Development','Production',d)}"
 VARIANT_ID = "${@bb.utils.contains('DEVELOPMENT_IMAGE','1','dev','prod',d)}"
+META_BALENA_VERSION = "${DISTRO_VERSION}"
 
 #
 # Add quotes around values not matching [A-Za-z0-9]*


### PR DESCRIPTION
Since #1550, os-release doesn't reference meta-balena distro version anymore. Restore
that by providing this information in a new variable called META_BALENA_VERSION.

Fixes #1558

Change-type: minor
Changelog-entry: Introduce META_BALENA_VERSION in os-release


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
