### PR TITLE
os-release: Make sure VERSION_ID is semver compliant

### DIFF
--- a/meta-balena-common/recipes-core/os-release/os-release.bbappend
+++ b/meta-balena-common/recipes-core/os-release/os-release.bbappend
@@ -26,7 +26,13 @@ python do_fix_quotes () {
             match_quoted = re.match(r"^\".*\"$", value)
             if not match and not match_quoted:
                 value = '"' + value + '"'
+            if field == "VERSION_ID":
+                # poky does the right thing (converts '+' to '-' in VERSION ID)
+                # as per os-release(5) documentation. We want this reverted as
+                # we need VERSION_ID to be semver compliant.
+                value = value.replace('-rev', '+rev')
             f.write('{0}={1}\n'.format(field, value))
+
 }
 addtask fix_quotes after do_compile before do_install
 


### PR DESCRIPTION
Poky, following os-release(5), sanitizes VERSION_ID accordingly but in
doing so it produces a nonisemver compliant version. For example:

    VERSION="2.37.0+rev1"
    VERSION_ID="2.37.0-rev1"

This patch reverts that to make sure rev is a build tag.

Fixes #1560

Change-type: patch
Changelog-entry: Fix VERSION_ID os-release to be semver complient
Signed-off-by: Andrei Gherzan <andrei@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
