### PR TITLE
kernel-devsrc/thud: Fix package when kernel version < 4.10

### DIFF
--- a/meta-balena-thud/recipes-kernel/linux/kernel-devsrc.bbappend
+++ b/meta-balena-thud/recipes-kernel/linux/kernel-devsrc.bbappend
@@ -1,0 +1,13 @@
+# kernel-devsrc recipe tries to copy the arch syscall tools unconditionally.
+# These tools were added only from 4.10 so trying this on older kernel versions
+# will make the build fail.
+# This was fixed in poky but the fix is only included from warrior on. See
+# d5abdf023bbdd32cb2a35cb40e828127dd50ea3a.
+do_install_prepend () {
+    # Workaround
+    echo "# Please ignore this file" > ${S}/arch/arm/tools/syscall.ignore
+}
+do_install_append () {
+    # Workaround cleanup
+    rm ${S}/arch/arm/tools/syscall.ignore
+}


### PR DESCRIPTION
Thud breaks when building against kernel version < 4.10. This is a known
issue which is fixed in poky warrior[1]. This patch includes a
workaround for thud.

[1] http://lists.openembedded.org/pipermail/openembedded-core/2019-February/278695.html

Change-type: patch
Changelog-entry: Fix kernel-devsrc on thud when kernel version < 4.10
Signed-off-by: Andrei Gherzan <andrei@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
