### PR TITLE
layer.conf/common: Add warrior to compatible layers 

### DIFF
--- a/meta-balena-common/conf/layer.conf
+++ b/meta-balena-common/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILE_COLLECTIONS += "balena-common"
 BBFILE_PATTERN_balena-common := "^${LAYERDIR}/"
 BBFILE_PRIORITY_balena-common = "1337"
 
-LAYERSERIES_COMPAT_balena-common = "krogoth morty pyro rocko sumo thud"
+LAYERSERIES_COMPAT_balena-common = "pyro rocko sumo thud warrior"
 
 BALENA_DEPRECATED_YOCTO_LAYER ?= "0"
 


### PR DESCRIPTION
In addition we delete krogoth and morty from the supported list
as we also removed the actual layers from the repository.

Change-type: patch
Changelog-entry: Add warrior to compatible layers for meta-balena-common
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
