### PR TITLE
kernel-modules-headers: Update to v0.0.19

### DIFF
--- a/meta-balena-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
+++ b/meta-balena-common/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bb
@@ -21,7 +21,7 @@ DEPENDS += " \
 
 SRC_URI = "git://github.com/resin-os/module-headers.git;protocol=https"
 
-SRCREV = "v0.0.18"
+SRCREV = "v0.0.19"
 
 S = "${WORKDIR}/git"
 B = "${WORKDIR}"


### PR DESCRIPTION
This version fixes using wrong fixdep binary (the bug makes it use
target fixdep binary instead of cross fixdep binary) used for compiling
the target objtool binary.

Change-type: patch
Changelog-entry: Update to kernel-modules-headers v0.0.19 to fix target objtool compile issue on kernel 5.0.3
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
