### PR TITLE
resin-proxy-config: add missing reserved ip ranges to default noproxy

### DIFF
--- a/meta-balena-common/recipes-connectivity/resin-proxy-config/resin-proxy-config/resin-proxy-config
+++ b/meta-balena-common/recipes-connectivity/resin-proxy-config/resin-proxy-config/resin-proxy-config
@@ -75,6 +75,7 @@ fi
 # Setup a new user chain for redsocks
 $IPTABLES -t nat -A REDSOCKS -d 0.0.0.0/8 -j RETURN
 $IPTABLES -t nat -A REDSOCKS -d 10.0.0.0/8 -j RETURN
+$IPTABLES -t nat -A REDSOCKS -d 100.64.0.0/10 -j RETURN
 $IPTABLES -t nat -A REDSOCKS -d 127.0.0.0/8 -j RETURN
 $IPTABLES -t nat -A REDSOCKS -d 169.254.0.0/16 -j RETURN
 $IPTABLES -t nat -A REDSOCKS -d 172.16.0.0/12 -j RETURN


### PR DESCRIPTION
There are still a more [rfc5735](https://tools.ietf.org/html/rfc5735) ranges not in the default here (192.0.2.0/24, 198.18.0.0/15, 198.51.100.0/24, 203.0.113.0/24 - 192.18/15 being the only one of which is listed in the [redsocks example configuration](https://github.com/darkk/redsocks#iptables-example)), and while they should not be routed to the internet I think there is an argument to let users control the proxying of these (obscure) subnets themselves should they want to do some interesting things with their internal networks.

Change-type: patch
Signed-off-by: Will Boyce \<will@balena.io\>

---

### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [X] `Change-type` present on at least one commit
- [X] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)