### PR TITLE
 image-resin.bbclass: fixed a typo in image size sanity check

### DIFF
--- a/meta-balena-common/classes/image-resin.bbclass
+++ b/meta-balena-common/classes/image-resin.bbclass
@@ -226,7 +226,7 @@ resin_boot_dirgen_and_deploy () {
 	DIR_BYTES=$(expr $(find ${RESIN_BOOT_WORKDIR} | tail -n +2 | wc -l) \* 32)
 	DIR_BYTES=$(expr $DIR_BYTES + $(expr $(find ${RESIN_BOOT_WORKDIR} -type d | tail -n +2 | wc -l) \* 32))
 	FAT_BYTES=$(expr $DATA_SECTORS \* 4)
-	FAT_BYTES=$(expr $FAT_BYTES + $(expr $(find ${RESIN_BOOT_WOKDIR} -type d | tail -n +2 | wc -l) \* 4))
+	FAT_BYTES=$(expr $FAT_BYTES + $(expr $(find ${RESIN_BOOT_WORKDIR} -type d | tail -n +2 | wc -l) \* 4))
 	DIR_SECTORS=$(expr $(expr $DIR_BYTES + 511) / 512)
 	FAT_SECTORS=$(expr $(expr $FAT_BYTES + 511) / 512 \* 2)
 	FAT_OVERHEAD_SECTORS=$(expr $DIR_SECTORS + $FAT_SECTORS)


### PR DESCRIPTION
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
