### PR TITLE
docker-disk: Reduce data partition size from 1G to 192M

### DIFF
--- a/meta-balena-common/recipes-containers/docker-disk/docker-disk.bb
+++ b/meta-balena-common/recipes-containers/docker-disk/docker-disk.bb
@@ -18,7 +18,7 @@ require recipes-containers/resin-supervisor/resin-supervisor.inc
 TARGET_REPOSITORY ?= "${SUPERVISOR_REPOSITORY}"
 TARGET_TAG ?= "${SUPERVISOR_TAG}"
 
-PARTITION_SIZE ?= "1024"
+PARTITION_SIZE ?= "192"
 
 python () {
     import re


### PR DESCRIPTION
The data partition contains the supervisor which is only about 61M on
the pi3. We compress the data partition later on so don't notice these
zeros. But lets reduce the size of the data partition to eat less
space whenever an uncompressed image is used anywhere. e.g. when
extracting the zip to dd or using balena-migrate etc.

The partition expands on first boot to fill the rest of the disk
anyways.

Change-type: minor
Changelog-entry: Reduce data partition size from 1G to 128M
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
