### PR TITLE
Enable building in container with host docker daemon usage

### DIFF
--- a/meta-balena-common/classes/image_types_resin.bbclass
+++ b/meta-balena-common/classes/image_types_resin.bbclass
@@ -69,15 +69,14 @@ python() {
     # Check if we are running on a poky version which deploys to IMGDEPLOYDIR
     # instead of DEPLOY_DIR_IMAGE (poky morty introduced this change)
     if d.getVar('IMGDEPLOYDIR', True):
-        d.setVar('RESIN_ROOT_FS', '${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${RESIN_ROOT_FSTYPE}')
-        d.setVar('RESIN_RAW_IMG', '${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.resinos-img')
-        d.setVar('RESIN_DOCKER_IMG', '${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.docker')
-        d.setVar('RESIN_HOSTAPP_IMG', '${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.hostapp-ext4')
+        d.setVar('RESIN_IMAGE_DEPLOY_DIR', '${IMGDEPLOYDIR}')
     else:
-        d.setVar('RESIN_ROOT_FS', '${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.${RESIN_ROOT_FSTYPE}')
-        d.setVar('RESIN_RAW_IMG', '${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.resinos-img')
-        d.setVar('RESIN_DOCKER_IMG', '${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.docker')
-        d.setVar('RESIN_HOSTAPP_IMG', '${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.hostapp-ext4')
+        d.setVar('RESIN_IMAGE_DEPLOY_DIR', '${DEPLOY_DIR_IMAGE}')
+
+    d.setVar('RESIN_ROOT_FS', '${RESIN_IMAGE_DEPLOY_DIR}/${IMAGE_LINK_NAME}.${RESIN_ROOT_FSTYPE}')
+    d.setVar('RESIN_RAW_IMG', '${RESIN_IMAGE_DEPLOY_DIR}/${IMAGE_NAME}.rootfs.resinos-img')
+    d.setVar('RESIN_DOCKER_IMG', '${RESIN_IMAGE_DEPLOY_DIR}/${IMAGE_NAME}.rootfs.docker')
+    d.setVar('RESIN_HOSTAPP_IMG', '${RESIN_IMAGE_DEPLOY_DIR}/${IMAGE_NAME}.rootfs.hostapp-ext4')
 
     d.setVar('RESIN_IMAGE_BOOTLOADER_DEPLOY_TASK', ' '.join(bootloader + ':do_populate_sysroot' for bootloader in d.getVar("RESIN_IMAGE_BOOTLOADER", True).split()))
 }

--- a/meta-balena-common/classes/image_types_resin.bbclass
+++ b/meta-balena-common/classes/image_types_resin.bbclass
@@ -360,5 +360,13 @@ do_image_hostapp_ext4[depends] = " \
 
 IMAGE_CMD_hostapp-ext4 () {
     dd if=/dev/zero of=${RESIN_HOSTAPP_IMG} seek=$ROOTFS_SIZE count=0 bs=1024
-    mkfs.hostapp-ext4 -t "${TMPDIR}" -s "${STAGING_DIR_NATIVE}" -i ${RESIN_DOCKER_IMG} -o ${RESIN_HOSTAPP_IMG}
+
+    shared_volume_options=""
+    if ! [ -z "${BUILD_DOCKER_SHARED_VOLUME}" ] && ! [ -z "${BUILD_DOCKER_SHARED_VOLUME_MOUNT_PATH}" ]; then
+        if (docker volume inspect ${BUILD_DOCKER_SHARED_VOLUME} > /dev/null 2>/dev/null); then
+            shared_volume_options="-v ${BUILD_DOCKER_SHARED_VOLUME} -p ${BUILD_DOCKER_SHARED_VOLUME_MOUNT_PATH}"
+        fi
+    fi
+
+    mkfs.hostapp-ext4 -t "${TMPDIR}" -s "${STAGING_DIR_NATIVE}" -i ${RESIN_DOCKER_IMG} -o ${RESIN_HOSTAPP_IMG} ${shared_volume_options}
 }

--- a/meta-balena-common/recipes-containers/docker-disk/files/entry.sh
+++ b/meta-balena-common/recipes-containers/docker-disk/files/entry.sh
@@ -1,12 +1,18 @@
 #!/bin/sh
 
 set -o errexit
-set -o nounset
 
 DOCKER_TIMEOUT=20 # Wait 20 seconds for docker to start
 DATA_VOLUME=/resin-data
 BUILD=/build
 PARTITION_SIZE=${PARTITION_SIZE:-1024}
+
+if ! [ -z "$BUILD_DOCKER_SHARED_VOLUME_MOUNT_PATH" ] && ! [ -z "$BUILD_DOCKER_SHARED_VOLUME_BUILD_PATH" ]; then
+  echo "Build result will be written to a shared Docker volume. Making a sym link."
+  ln -s ${BUILD_DOCKER_SHARED_VOLUME_BUILD_PATH} ${BUILD}
+fi
+
+set -o nounset
 
 finish() {
 	# Make all files owned by the build system

--- a/meta-balena-common/recipes-containers/mkfs-hostapp-native/files/create
+++ b/meta-balena-common/recipes-containers/mkfs-hostapp-native/files/create
@@ -2,15 +2,22 @@
 
 set -ex
 
+if [ -z "$BUILD_INPUT" ]; then
+  BUILD_INPUT="/input"
+fi
+if [ -z "$BUILD_OUTPUT" ]; then
+  BUILD_OUTPUT="/output"
+fi
+
 SYSROOT="/mnt/sysroot/inactive"
 
 balenad -s=@BALENA_STORAGE@ --data-root="$SYSROOT/balena" -H unix:///var/run/balena-host.sock &
 pid=$!
 sleep 5
 
-hostapp-update -f /input -n
+hostapp-update -f ${BUILD_INPUT} -n
 
 kill $pid
 wait $pid
 
-mkfs.ext4 -F -E lazy_itable_init=0,lazy_journal_init=0 -i 8192 -d "$SYSROOT" /output
+mkfs.ext4 -F -E lazy_itable_init=0,lazy_journal_init=0 -i 8192 -d "$SYSROOT" ${BUILD_OUTPUT}

--- a/meta-balena-common/recipes-containers/mkfs-hostapp-native/files/mkfs.hostapp-ext4
+++ b/meta-balena-common/recipes-containers/mkfs-hostapp-native/files/mkfs.hostapp-ext4
@@ -43,4 +43,8 @@ cleanup_docker() {
 $DOCKER load -i "$sysroot/usr/share/mkfs-hostapp-ext4-image.tar"
 trap cleanup_docker EXIT
 
+echo "PATH=$PATH"
+echo "tmpdir=$tmpdir"
+echo "input=$input"
+echo "output=$output"
 $DOCKER run --privileged --rm -v "$input:/input:ro" -v "$tmpdir:$tmpdir:ro" -v "$output:/output" -e "PATH=$PATH:$HOST_PATH" @IMAGE@

--- a/meta-balena-common/recipes-containers/mkfs-hostapp-native/files/mkfs.hostapp-ext4
+++ b/meta-balena-common/recipes-containers/mkfs-hostapp-native/files/mkfs.hostapp-ext4
@@ -10,13 +10,17 @@ DOCKER=$(PATH="$HOST_PATH" which docker)
 
 sysroot="/"
 tmpdir=""
+shared_volume=""
+shared_volume_path=""
 
-while getopts 'i:o:s:t:' flag; do
+while getopts 'i:o:s:t:v:p:' flag; do
 	case "${flag}" in
         i) input=$(realpath "${OPTARG}") ;;
         o) output=$(realpath "${OPTARG}") ;;
         s) sysroot=$(realpath "${OPTARG}") ;;
         t) tmpdir=$(realpath "${OPTARG}") ;;
+        v) shared_volume=${OPTARG} ;;
+        p) shared_volume_path=$(realpath "${OPTARG}") ;;
         *) error "Unexpected option ${flag}" ;;
 	esac
 done
@@ -43,8 +47,15 @@ cleanup_docker() {
 $DOCKER load -i "$sysroot/usr/share/mkfs-hostapp-ext4-image.tar"
 trap cleanup_docker EXIT
 
-echo "PATH=$PATH"
-echo "tmpdir=$tmpdir"
-echo "input=$input"
-echo "output=$output"
-$DOCKER run --privileged --rm -v "$input:/input:ro" -v "$tmpdir:$tmpdir:ro" -v "$output:/output" -e "PATH=$PATH:$HOST_PATH" @IMAGE@
+mount_options="-v $input:/input:ro -v $tmpdir:$tmpdir:ro -v $output:/output"
+if ! [ -z "${shared_volume}" ] && ! [ -z "${shared_volume_path}" ]; then
+	if ($DOCKER volume inspect ${shared_volume} > /dev/null 2>/dev/null); then
+		echo "mkfs.hostapp-ext4: Shared Docker volume option detected."
+
+		mount_options="-v ${shared_volume}:${shared_volume_path}"
+		mount_options="${mount_options} -e BUILD_INPUT=${input}"
+		mount_options="${mount_options} -e BUILD_OUTPUT=${output}"
+	fi
+fi
+
+$DOCKER run --privileged --rm ${mount_options} -e "PATH=$PATH:$HOST_PATH" @IMAGE@


### PR DESCRIPTION
These changes modify places where we call `docker run` with bind mounts to support
a case when build is run in a container with host docker daemon usage.

Such a build container uses a docker volume to store sources and build results.
`docker run` calls are tweaked to detect such situation 
(assuming it's configured with environment variables `BUILD_DOCKER_SHARED_VOLUME` and `BUILD_DOCKER_SHARED_VOLUME_MOUNT_PATH`).

Here's the build environment configuration:
https://gist.github.com/roman-mazur/4ab90dcfc8e4f8a38f8809f1809d0f8b

These changes allowed me to build balena OS on my MacBook Pro, and I'm extremely satisfied with build performance.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
