### PR TITLE
resin-supervisor: Expose container ID

### DIFF
--- a/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/start-resin-supervisor
+++ b/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/start-resin-supervisor
@@ -71,13 +71,18 @@ configIsUnchanged() {
 }
 
 runSupervisor() {
+    local host_data_dir=/resin-data/resin-supervisor
+    local cid_filename=container-id
+
     balena rm --force resin_supervisor || true
     balena run --privileged --name resin_supervisor \
         --net=host \
+        --cidfile="$host_data_dir/$cid_filename" \
+        -e "CONTAINER_ID_FILE_PATH=/data/$cid_filename" \
         -v /var/run/balena-engine.sock:/var/run/balena-engine.sock \
         -v "$CONFIG_PATH:/boot/config.json"  \
         -v /mnt/data/apps.json:/boot/apps.json \
-        -v /resin-data/resin-supervisor:/data \
+        -v "$host_data_dir:/data" \
         -v /proc/net/fib_trie:/mnt/fib_trie \
         -v /var/log/supervisor-log:/var/log \
         -v /:/mnt/root \


### PR DESCRIPTION
In some usecases, it's very helpful for supervisor to know its container ID.
For instance, when supervisor leaves local mode, it removes all the engine objects
that didn't not exist before entering local mode.
Supervisor needs to know its own container ID to not delete itself.

Using info in `/proc` files seems to be engine implementation dependant
and may not work in some cases. So this way seems to be the most reliable to expose
container ID to the application.

Change-type: minor
Signed-off-by: Roman Mazur <roman@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
