### PR TITLE
Increase fs.inotify.max_user_instances to 512

### DIFF
--- a/meta-balena-common/recipes-core/systemd/systemd/balena-os-sysctl.conf
+++ b/meta-balena-common/recipes-core/systemd/systemd/balena-os-sysctl.conf
@@ -1,0 +1,1 @@
+fs.inotify.max_user_instances=512

--- a/meta-balena-common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-balena-common/recipes-core/systemd/systemd_%.bbappend
@@ -8,6 +8,7 @@ SRC_URI_append = " \
     file://watchdog.conf \
     file://60-resin-update-state.rules \
     file://resin_update_state_probe \
+    file://balena-os-sysctl.conf \
     "
 
 python() {
@@ -71,6 +72,9 @@ do_install_append() {
 
     # Move udev rules into /lib as /etc/udev/rules.d is bind mounted for custom rules
     mv ${D}/etc/udev/rules.d/*.rules ${D}/lib/udev/rules.d/
+
+    install -d -m 0755 ${D}/usr/lib/sysctl.d/
+    install -m 0644 ${WORKDIR}/balena-os-sysctl.conf ${D}/usr/lib/sysctl.d/
 }
 
 FILES_udev += "${rootlibexecdir}/udev/resin_update_state_probe"


### PR DESCRIPTION
This defaults to 128. BoB hit the limit. Increase to 512
Fixes #1592

Change-type: patch
Changelog-entry: Increase fs.inotify.max_user_instances to 512
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
