### PR TITLE
Fix grub hostapp-update hook

### DIFF
--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/99-resin-grub
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/99-resin-grub
@@ -24,7 +24,7 @@ else
     SYSROOT="/mnt/sysroot/active"
 fi
 
-new_part=$(findmnt --noheadings --canonicalize --output SOURCE $SYSROOT)
+new_part=$(findmnt --noheadings --canonicalize --output SOURCE $SYSROOT -t ext4)
 blockdev=$(basename "$new_part")
 new_part_idx=$(cat "/sys/class/block/$blockdev/partition")
 new_part_label=$(blkid "$new_part" | awk '{print $2}' | cut -d'"' -f 2)


### PR DESCRIPTION
Use ext4 FSTYPE to filter out automount with SOURCE "systemd-1" when determining the new parition label.

findmnt will report two sources, one being the systemd mnt-sysroot-inactive automount:

| -/mnt/sysroot/inactive    systemd-1             autofs
| `-/mnt/sysroot/inactive   /dev/mmcblk0p2   ext4


Since its output is used directly to find the new label and not filtered out by "basename" as in the u-boot hook case, an empty label will be written to the grub config file thus breaking booting after hup.

This fixes failed hostapp-update on the up-board and probably other grub based boards as well.
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
