### PR TITLE
networkmanager: Remove redundant https warning

### DIFF
--- a/meta-balena-common/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/meta-balena-common/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -10,6 +10,7 @@ SRC_URI_append = " \
     file://resin-sample.ignore \
     file://nm-tmpfiles.conf \
     file://balena-client-id.patch \
+    file://remove-https-warning.patch \
     "
 
 RDEPENDS_${PN}_append = " \

--- a/meta-balena-common/recipes-connectivity/networkmanager/resin-files/remove-https-warning.patch
+++ b/meta-balena-common/recipes-connectivity/networkmanager/resin-files/remove-https-warning.patch
@@ -1,0 +1,29 @@
+From d4501fa7aaff9f70d9bba86cbc9651480f8d37c6 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah Kakakhel <zubair@balena.io>
+Date: Wed, 24 Jul 2019 11:35:19 +0000
+Subject: [PATCH] nm-connectivity: Remove redundant https warning
+
+This warning doesn't apply to our use-case. See https://github.com/balena-os/meta-balena/issues/1597
+for more detail.
+
+Upstream-Status: Inappropriate [configuration]
+Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>
+---
+ src/nm-connectivity.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/nm-connectivity.c b/src/nm-connectivity.c
+index 2816e76..e420e94 100644
+--- a/src/nm-connectivity.c
++++ b/src/nm-connectivity.c
+@@ -1019,7 +1019,6 @@ update_config (NMConnectivity *self, NMConfigData *config_data)
+ 				_LOGE ("invalid URI '%s' for connectivity check.", new_uri);
+ 				new_uri_valid = FALSE;
+ 			} else if (g_ascii_strcasecmp (scheme, "https") == 0) {
+-				_LOGW ("use of HTTPS for connectivity checking is not reliable and is discouraged (URI: %s)", new_uri);
+ 				is_https = TRUE;
+ 			} else if (g_ascii_strcasecmp (scheme, "http") != 0) {
+ 				_LOGE ("scheme of '%s' uri doesn't use a scheme that is allowed for connectivity check.", new_uri);
+-- 
+2.7.4
+


### PR DESCRIPTION
Fixes #1597

The warning doesn't apply for our use case and confuses customers

Change-type: patch
Changelog-entry: Remove confusing networkmanager https connectivity warning
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>

Tested on NUC in a VM

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
