### PR TITLE
usb-modeswitch: Switch Huawei E3372 12d1:1f01 to mbim mode

### DIFF
--- a/meta-balena-common/recipes-support/usb-modeswitch/files/huawei_e3372
+++ b/meta-balena-common/recipes-support/usb-modeswitch/files/huawei_e3372
@@ -1,0 +1,4 @@
+# Huawei E353 (3.se) and others
+TargetVendor=0x12d1
+TargetProductList="14db,14dc"
+MessageContent="55534243123456780000000000000011063000000100010000000000000000"

--- a/meta-balena-common/recipes-support/usb-modeswitch/usb-modeswitch_2.5.0.bb
+++ b/meta-balena-common/recipes-support/usb-modeswitch/usb-modeswitch_2.5.0.bb
@@ -4,7 +4,10 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 
 DEPENDS = "libusb1"
 
-SRC_URI = "http://www.draisberghof.de/usb_modeswitch/${BP}.tar.bz2"
+SRC_URI = " \
+    http://www.draisberghof.de/usb_modeswitch/${BP}.tar.bz2 \
+    file://huawei_e3372 \
+"
 SRC_URI[md5sum] = "38ad5c9d70e06227a00361bdc2b1e568"
 SRC_URI[sha256sum] = "31c0be280d49a99ec3dc0be3325bef320d9c04b50714ef0ce1e36a614d687633"
 
@@ -22,4 +25,7 @@ do_install() {
         install -m 644 ${S}/usb_modeswitch@.service ${D}/${systemd_unitdir}/system
     fi
     install -m 755 ${S}/usb_modeswitch_dispatcher ${D}/${sbindir}
+
+    install -d ${D}/etc/usb_modeswitch.d/
+    install -m 0644 ${WORKDIR}/huawei_e3372 ${D}/etc/usb_modeswitch.d/12d1\:1f01
 }


### PR DESCRIPTION
This modem works in cdc_ether legacy mode so let's switch it
to faster mbim mode.

Change-type: patch
Changelog-entry: Switch Huawei E3372 modem 12d1:1f01 to mbim mode
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
