### PR TITLE
Fix Huawei E3372 modem not working after v2.32

### DIFF
--- a/meta-balena-common/recipes-support/usb-modeswitch-data/patches/huawei-e3372.patch
+++ b/meta-balena-common/recipes-support/usb-modeswitch-data/patches/huawei-e3372.patch
@@ -1,0 +1,21 @@
+Customer reported Huawei E3372 not working
+anymore starting with balenaOS v2.32.
+Fix for this appears to be switching Huawei E3372
+modem with vendor and product numbers 12d1:1f01
+from the cdc_ether legacy mode to the faster mbim mode.
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+
+Index: usb-modeswitch-data-20170806/usb_modeswitch.d/12d1:1f01
+===================================================================
+--- usb-modeswitch-data-20170806.orig/usb_modeswitch.d/12d1:1f01
++++ usb-modeswitch-data-20170806/usb_modeswitch.d/12d1:1f01
+@@ -1,6 +1,6 @@
+ # Huawei E353 (3.se) and others
+ TargetVendor=0x12d1
+ TargetProductList="14db,14dc"
+-HuaweiNewMode=1
+-
++#HuaweiNewMode=1
++MessageContent="55534243123456780000000000000011063000000100010000000000000000"

--- a/meta-balena-common/recipes-support/usb-modeswitch-data/usb-modeswitch-data_%.bbappend
+++ b/meta-balena-common/recipes-support/usb-modeswitch-data/usb-modeswitch-data_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
+
+SRC_URI_append = " file://huawei-e3372.patch;patch=1;"


### PR DESCRIPTION
Customer reported Huawei E3372 not working
anymore starting with balenaOS v2.32.

The fix for this appears to be switching the modem with
vid and pid 12d1:1f01 from the cdc_ether legacy mode to
the faster mbim mode and setting mtu=1460 in the modem
connection file.

Fixes https://github.com/balena-os/meta-balena/issues/1599
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
