### PR TITLE
systemd: Vacuum journald on boot

### DIFF
--- a/meta-balena-common/recipes-core/systemd/systemd/vacuum.conf
+++ b/meta-balena-common/recipes-core/systemd/systemd/vacuum.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPost=/bin/journalctl --vacuum-size=8M

--- a/meta-balena-common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-balena-common/recipes-core/systemd/systemd_%.bbappend
@@ -5,6 +5,7 @@ SRC_URI_append = " \
     file://reboot.target.conf \
     file://poweroff.target.conf \
     file://journald-balena-os.conf \
+    file://vacuum.conf \
     file://watchdog.conf \
     file://60-resin-update-state.rules \
     file://resin_update_state_probe \
@@ -67,6 +68,10 @@ do_install_append() {
 
     # We take care of journald flush ourselves
     rm ${D}/lib/systemd/system/sysinit.target.wants/systemd-journal-flush.service
+
+    # Vacuum the journal to catch a corner case bug where the log bloats above limit
+    install -d -m 0755 ${D}/${sysconfdir}/systemd/system/systemd-journald.service.d/
+    install -m 0644 ${WORKDIR}/vacuum.conf ${D}/${sysconfdir}/systemd/system/systemd-journald.service.d/vacuum.conf
 
     install -m 0755 ${WORKDIR}/resin_update_state_probe ${D}/lib/udev/resin_update_state_probe
 


### PR DESCRIPTION
We have found a rare corner case bug where the journal bloats beyond
its limit and fills the state partition. Triggering a vacuum on reboot
helps a bit in case the device is restarted to recover its function.

Fixes #1423

Change-type: patch
Changelog-entry: Workaround for a cornercase bug in PersistentLogging where journalctl filled the state partition. Vacuum the journal on boot.
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
