### PR TITLE
docker-disk: Update to still supported dind container

### DIFF
--- a/meta-balena-common/recipes-containers/docker-disk/files/Dockerfile
+++ b/meta-balena-common/recipes-containers/docker-disk/files/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:18.06-dind
+FROM docker:18.09.8-dind
 RUN apk add --update util-linux shadow e2fsprogs && rm -rf /var/cache/apk/*
 ADD entry.sh /entry.sh
 RUN chmod a+x /entry.sh

--- a/meta-balena-common/recipes-containers/docker-disk/files/Dockerfile
+++ b/meta-balena-common/recipes-containers/docker-disk/files/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:18.09.8-dind
+FROM docker:19.03.10-dind
 RUN apk add --update util-linux shadow e2fsprogs && rm -rf /var/cache/apk/*
 ADD entry.sh /entry.sh
 RUN chmod a+x /entry.sh

--- a/meta-balena-common/recipes-containers/docker-disk/files/entry.sh
+++ b/meta-balena-common/recipes-containers/docker-disk/files/entry.sh
@@ -7,6 +7,7 @@ DOCKER_TIMEOUT=20 # Wait 20 seconds for docker to start
 DATA_VOLUME=/resin-data
 BUILD=/build
 PARTITION_SIZE=${PARTITION_SIZE:-1024}
+DOCKER_HOST=unix:///var/run/docker.sock
 
 finish() {
 	# Make all files owned by the build system
@@ -24,7 +25,7 @@ mkdir -p $DATA_VOLUME/resin-data
 
 # Start docker
 echo "Starting docker daemon with $BALENA_STORAGE storage driver."
-dockerd -g $DATA_VOLUME/docker -s "$BALENA_STORAGE" -b none --experimental &
+dockerd -H "$DOCKER_HOST" --data-root="$DATA_VOLUME/docker" -s "$BALENA_STORAGE" -b none --experimental &
 echo "Waiting for docker to become ready.."
 STARTTIME="$(date +%s)"
 ENDTIME="$STARTTIME"


### PR DESCRIPTION
The `docker` Docker Hub repository lists what versions of the image are supported and 18.6 is not among them at all. Use the current stable line of 18.09 instead, to stay on supported versions. See more info at: https://hub.docker.com/_/docker

Also add a required parameter to run images from 18.09.8-dind onwards, due to this change: https://github.com/docker-library/docker/pull/166

Update the test checking for docker being up, too.

Change-type: minor
Signed-off-by: Gergely Imreh <gergely@balena.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
