### PR TITLE
volatile-binds: Avoid overlayfs mounts

### DIFF
--- a/meta-balena-thud/recipes-core/volatile-binds/volatile-binds.bbappend
+++ b/meta-balena-thud/recipes-core/volatile-binds/volatile-binds.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"

--- a/meta-balena-thud/recipes-core/volatile-binds/volatile-binds/mount-copybind
+++ b/meta-balena-thud/recipes-core/volatile-binds/volatile-binds/mount-copybind
@@ -1,0 +1,56 @@
+#!/bin/sh
+#
+# Perform a bind mount, copying existing files as we do so to ensure the
+# overlaid path has the necessary content.
+
+if [ $# -lt 2 ]; then
+    echo >&2 "Usage: $0 spec mountpoint [OPTIONS]"
+    exit 1
+fi
+
+# e.g. /var/volatile/lib
+spec=$1
+
+# e.g. /var/lib
+mountpoint=$2
+
+if [ $# -gt 2 ]; then
+    options=$3
+else
+    options=
+fi
+
+[ -n "$options" ] && options=",$options"
+
+mkdir -p "${spec%/*}"
+
+if [ -d "$mountpoint" ]; then
+
+    if [ -d "$spec" ]; then
+        specdir_existed=yes
+    else
+        specdir_existed=no
+        mkdir "$spec"
+    fi
+
+    # Fast version of calculating `dirname ${spec}`/.`basename ${spec}`-work
+    overlay_workdir="${spec%/*}/.${spec##*/}-work"
+    mkdir "${overlay_workdir}"
+
+    # Try to mount using overlay, which is must faster than copying files.
+    # If that fails, fall back to slower copy.
+    if ! mount -t overlay overlay -olowerdir="$mountpoint",upperdir="$spec",workdir="$overlay_workdir" "$mountpoint" > /dev/null 2>&1; then
+
+        if [ "$specdir_existed" != "yes" ]; then
+            cp -pPR "$mountpoint"/. "$spec/"
+        fi
+
+        mount -o "bind$options" "$spec" "$mountpoint"
+    fi
+elif [ -f "$mountpoint" ]; then
+    if [ ! -f "$spec" ]; then
+        cp -pP "$mountpoint" "$spec"
+    fi
+
+    mount -o "bind$options" "$spec" "$mountpoint"
+fi

--- a/meta-balena-thud/recipes-core/volatile-binds/volatile-binds/mount-copybind
+++ b/meta-balena-thud/recipes-core/volatile-binds/volatile-binds/mount-copybind
@@ -39,14 +39,17 @@ if [ -d "$mountpoint" ]; then
 
     # Try to mount using overlay, which is must faster than copying files.
     # If that fails, fall back to slower copy.
-    if ! mount -t overlay overlay -olowerdir="$mountpoint",upperdir="$spec",workdir="$overlay_workdir" "$mountpoint" > /dev/null 2>&1; then
+    # FIXME:
+    # Avoid overlayfs mounts as the rootfs is a aufs on some devices which
+    # might break when reading files from lower directory.
+    #if ! mount -t overlay overlay -olowerdir="$mountpoint",upperdir="$spec",workdir="$overlay_workdir" "$mountpoint" > /dev/null 2>&1; then
 
         if [ "$specdir_existed" != "yes" ]; then
             cp -pPR "$mountpoint"/. "$spec/"
         fi
 
         mount -o "bind$options" "$spec" "$mountpoint"
-    fi
+    #fi
 elif [ -f "$mountpoint" ]; then
     if [ ! -f "$spec" ]; then
         cp -pP "$mountpoint" "$spec"

--- a/meta-balena-warrior/recipes-core/volatile-binds/volatile-binds.bbappend
+++ b/meta-balena-warrior/recipes-core/volatile-binds/volatile-binds.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"

--- a/meta-balena-warrior/recipes-core/volatile-binds/volatile-binds/mount-copybind
+++ b/meta-balena-warrior/recipes-core/volatile-binds/volatile-binds/mount-copybind
@@ -1,0 +1,56 @@
+#!/bin/sh
+#
+# Perform a bind mount, copying existing files as we do so to ensure the
+# overlaid path has the necessary content.
+
+if [ $# -lt 2 ]; then
+    echo >&2 "Usage: $0 spec mountpoint [OPTIONS]"
+    exit 1
+fi
+
+# e.g. /var/volatile/lib
+spec=$1
+
+# e.g. /var/lib
+mountpoint=$2
+
+if [ $# -gt 2 ]; then
+    options=$3
+else
+    options=
+fi
+
+[ -n "$options" ] && options=",$options"
+
+mkdir -p "${spec%/*}"
+
+if [ -d "$mountpoint" ]; then
+
+    if [ -d "$spec" ]; then
+        specdir_existed=yes
+    else
+        specdir_existed=no
+        mkdir "$spec"
+    fi
+
+    # Fast version of calculating `dirname ${spec}`/.`basename ${spec}`-work
+    overlay_workdir="${spec%/*}/.${spec##*/}-work"
+    mkdir "${overlay_workdir}"
+
+    # Try to mount using overlay, which is must faster than copying files.
+    # If that fails, fall back to slower copy.
+    if ! mount -t overlay overlay -olowerdir="$mountpoint",upperdir="$spec",workdir="$overlay_workdir" "$mountpoint" > /dev/null 2>&1; then
+
+        if [ "$specdir_existed" != "yes" ]; then
+            cp -pPR "$mountpoint"/. "$spec/"
+        fi
+
+        mount -o "bind$options" "$spec" "$mountpoint"
+    fi
+elif [ -f "$mountpoint" ]; then
+    if [ ! -f "$spec" ]; then
+        cp -pP "$mountpoint" "$spec"
+    fi
+
+    mount -o "bind$options" "$spec" "$mountpoint"
+fi

--- a/meta-balena-warrior/recipes-core/volatile-binds/volatile-binds/mount-copybind
+++ b/meta-balena-warrior/recipes-core/volatile-binds/volatile-binds/mount-copybind
@@ -39,14 +39,17 @@ if [ -d "$mountpoint" ]; then
 
     # Try to mount using overlay, which is must faster than copying files.
     # If that fails, fall back to slower copy.
-    if ! mount -t overlay overlay -olowerdir="$mountpoint",upperdir="$spec",workdir="$overlay_workdir" "$mountpoint" > /dev/null 2>&1; then
+    # FIXME:
+    # Avoid overlayfs mounts as the rootfs is a aufs on some devices which
+    # might break when reading files from lower directory.
+    #if ! mount -t overlay overlay -olowerdir="$mountpoint",upperdir="$spec",workdir="$overlay_workdir" "$mountpoint" > /dev/null 2>&1; then
 
         if [ "$specdir_existed" != "yes" ]; then
             cp -pPR "$mountpoint"/. "$spec/"
         fi
 
         mount -o "bind$options" "$spec" "$mountpoint"
-    fi
+    #fi
 elif [ -f "$mountpoint" ]; then
     if [ ! -f "$spec" ]; then
         cp -pP "$mountpoint" "$spec"


### PR DESCRIPTION
Our root filesystem is overlayfs or aufs. When latter, the system crashes when reading a lower directory file. We avoid this by always falling back to copy and mount (as if overlayfs is not available).

Fixes #1618

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
