### PR TITLE
Fix for production images when console=null is passed in kernel cmdline

### DIFF
--- a/meta-balena-warrior/recipes-core/images/resin-image-initramfs.bbappend
+++ b/meta-balena-warrior/recipes-core/images/resin-image-initramfs.bbappend
@@ -1,0 +1,1 @@
+PACKAGE_INSTALL_append = "initramfs-module-console-null-workaround"

--- a/meta-balena-warrior/recipes-core/initrdscripts/files/console_null_workaround
+++ b/meta-balena-warrior/recipes-core/initrdscripts/files/console_null_workaround
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+console_null_workaround_enabled() {
+	return 0
+}
+
+console_null_workaround_run() {
+	if [ "$bootparam_console" = "null" ] ; then
+		exec 0> /dev/null
+		exec 1> /dev/null
+		exec 2> /dev/null
+	fi
+}

--- a/meta-balena-warrior/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-balena-warrior/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -1,0 +1,17 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " \
+    file://console_null_workaround \
+    "
+
+do_install_append() {
+    install -m 0755 ${WORKDIR}/console_null_workaround ${D}/init.d/000-console_null_workaround
+}
+
+PACKAGES_append = " \
+    initramfs-module-console-null-workaround \
+    "
+
+SUMMARY_initramfs-module-console-null-workaround = "Workaround needed for when console=null is passed in kernel cmdline"
+RDEPENDS_initramfs-module-console-null-workaround = "${PN}-base"
+FILES_initramfs-module-console-null-workaround = "/init.d/000-console_null_workaround"


### PR DESCRIPTION
Tested on nuc and pi warrior

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
