### PR TITLE
balena-rollback: Fix service dependency

### DIFF
--- a/meta-balena-common/recipes-core/balena-rollback/files/rollback-altboot.service
+++ b/meta-balena-common/recipes-core/balena-rollback/files/rollback-altboot.service
@@ -17,7 +17,7 @@ Description=Balena rollback checks altboot
 DefaultDependencies=no
 Requires=resin-boot.service
 Before=balena-host.service balena.service
-After=resin-boot.service
+After=resin-boot.service systemd-udev-settle.service
 ConditionPathExists=/mnt/state/rollback-altboot-breadcrumb
 
 [Service]

--- a/meta-balena-common/recipes-core/balena-rollback/files/rollback-health.service
+++ b/meta-balena-common/recipes-core/balena-rollback/files/rollback-health.service
@@ -17,7 +17,7 @@ Description=Balena rollback checks health
 DefaultDependencies=no
 Requires=resin-boot.service mnt-sysroot-active.service
 Wants=openvpn.service balena.service
-After=resin-boot.service mnt-sysroot-active.service openvpn.service balena.service
+After=resin-boot.service mnt-sysroot-active.service openvpn.service balena.service systemd-udev-settle.service
 ConditionPathExists=/mnt/state/rollback-health-breadcrumb
 
 [Service]


### PR DESCRIPTION
Fixes bug introduced by #1441 
Add systemd-udev-settle.service to the rollback services.

Tested on pi3.
Fixes #1635

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
