### PR TITLE
initrdscripts: Improve workaround

### DIFF
--- a/meta-balena-warrior/recipes-core/initrdscripts/files/console_null_workaround
+++ b/meta-balena-warrior/recipes-core/initrdscripts/files/console_null_workaround
@@ -5,9 +5,13 @@ console_null_workaround_enabled() {
 }
 
 console_null_workaround_run() {
-	if [ "$bootparam_console" = "null" ] ; then
-		exec 0> /dev/null
-		exec 1> /dev/null
-		exec 2> /dev/null
-	fi
+       if [ ! -h /proc/self/fd/0 ] ; then
+               exec 0> /dev/null
+       fi
+       if [ ! -h /proc/self/fd/1 ] ; then
+               exec 1> /dev/null
+       fi
+       if [ ! -h /proc/self/fd/2 ] ; then
+               exec 2> /dev/null
+       fi
 }


### PR DESCRIPTION
We would just check for the existence of console=null in kernel cmdline

A better way would be to check the presence of a valid symlink for fd0,
fd1 and fd2. And assign them to /dev/null if unavailable.

Change-type: patch
Changelog-entry: A small fix in initramfs when /dev/console is invalid due to whatever reason
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
