### PR TITLE
initramfs-module-prepare: disable also when shell-debug is set

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/prepare
+++ b/meta-balena-common/recipes-core/initrdscripts/files/prepare
@@ -2,7 +2,7 @@
 
 prepare_enabled() {
     # Do not run when shell is passed in kernel cmdline
-    if [ "$bootparam_shell" = "true" ]; then
+    if [ -n "$bootparam_shell" ] || [ -n "$bootparam_shell_debug" ]; then
         return 1
     fi
 


### PR DESCRIPTION
shell-debug cmdline is useful when debugging initramfs scripts.
However, this effect is hidden by prepare module.

Also, disable prepare module in various shell cmdline parameters such as
shell=after:prepare. See [debug module in initramfs-framework](https://git.yoctoproject.org/cgit.cgi/poky/plain/meta/recipes-core/initrdscripts/initramfs-framework/debug).

Change-type: patch
Signed-off-by: Bumsik Kim <k.bumsik@gmail.com>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
