### PR TITLE
initramfs-framework: add watchdog module

### DIFF
--- a/meta-balena-common/recipes-core/images/resin-image-initramfs.bb
+++ b/meta-balena-common/recipes-core/images/resin-image-initramfs.bb
@@ -7,6 +7,7 @@ PACKAGE_INSTALL = " \
     base-passwd \
     busybox \
     initramfs-module-debug \
+    initramfs-module-watchdog \
     initramfs-module-prepare \
     initramfs-module-fsck \
     initramfs-module-machineid \

--- a/meta-balena-common/recipes-core/initrdscripts/files/finish
+++ b/meta-balena-common/recipes-core/initrdscripts/files/finish
@@ -19,6 +19,9 @@ finish_run() {
         mount --move /proc $ROOTFS_DIR/proc
         mount --move /sys $ROOTFS_DIR/sys
 
+        # Kill watchdog before running systemd. This variable is exported from watchdog module
+        [ -n "$INITRAMFS_WATCHDOG_PID" ] && kill "$INITRAMFS_WATCHDOG_PID" || true
+
         cd $ROOTFS_DIR
         exec switch_root -c /dev/console $ROOTFS_DIR ${bootparam_init:-/sbin/init}
     else

--- a/meta-balena-common/recipes-core/initrdscripts/files/watchdog
+++ b/meta-balena-common/recipes-core/initrdscripts/files/watchdog
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+watchdog_enabled() {
+    [ -c /dev/watchdog ] && return 0 || return 1
+}
+
+watchdog_run() {
+    watchdog -t 10 -T 60 -F /dev/watchdog &
+    export INITRAMFS_WATCHDOG_PID="$!"
+}

--- a/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -2,6 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_append = " \
     file://prepare \
+    file://watchdog \
     file://fsck \
     file://machineid \
     file://resindataexpander \
@@ -11,6 +12,7 @@ SRC_URI_append = " \
     "
 
 do_install_append() {
+    install -m 0755 ${WORKDIR}/watchdog ${D}/init.d/69-watchdog
     install -m 0755 ${WORKDIR}/prepare ${D}/init.d/70-prepare
     install -m 0755 ${WORKDIR}/fsck ${D}/init.d/87-fsck
     install -m 0755 ${WORKDIR}/rootfs ${D}/init.d/90-rootfs
@@ -27,6 +29,7 @@ PACKAGES_append = " \
     initramfs-module-resindataexpander \
     initramfs-module-rorootfs \
     initramfs-module-prepare \
+    initramfs-module-watchdog \
     "
 
 RRECOMMENDS_${PN}-base += "initramfs-module-rootfs"
@@ -54,3 +57,7 @@ FILES_initramfs-module-rootfs = "/init.d/90-rootfs"
 SUMMARY_initramfs-module-prepare = "Prepare initramfs console"
 RDEPENDS_initramfs-module-prepare = "${PN}-base"
 FILES_initramfs-module-prepare = "/init.d/70-prepare"
+
+SUMMARY_initramfs-module-watchdog = "initramfs watchdog"
+RDEPENDS_initramfs-module-watchdog = "${PN}-base busybox"
+FILES_initramfs-module-watchdog = "/init.d/69-watchdog"


### PR DESCRIPTION
In my board's default BSP enables Watchdog and its timer is 32 seconds
by default. I found that initramfs scripts takes more time than that
at initial state (mainly due to slow GNU parted operations) so that
Watchdog is triggered before entering systemd, causing infinite
rebooting.

This watchdog module will prevent unexpected rebooting by the watchdog
timer. The watchdog process should be killed before entering systemd
as systemd has own watchdogd. I use variable export approach to get
its pid than using ps command becuase ps command prints nothing because
/proc is just moved before.

Change-type: patch
Signed-off-by: Bumsik Kim k.bumsik@gmail.com


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested: Raspberry Pi 3 and STM32MP157C-DK2 (I'm currently porting this)
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/balena-os/meta-balena/1669)
<!-- Reviewable:end -->
