### PR TITLE
initramfs: add support for GPT on SD Card and flexible partition numbers

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/fsck
+++ b/meta-balena-common/recipes-core/initrdscripts/files/fsck
@@ -24,4 +24,14 @@ fsck_run() {
     fsck.ext4 -p /dev/disk/by-label/resin-rootA
     fsck.ext4 -p /dev/disk/by-label/resin-rootB
     fsck.ext4 -p /dev/disk/by-label/resin-state
+
+    # Correct GPT secondary header
+    datapart=$(readlink -f /dev/disk/by-label/resin-data)
+    datadev=$(lsblk $datapart -n -o PKNAME)
+    if [ "gpt" = "$(blkid -o value -s PTTYPE /dev/$datadev)" ] &&
+            ( sgdisk --verify /dev/$datadev | grep -q "[T|t]he secondary header" ) ; then
+        msg "Moving secondary GPT header to the end of the disk."
+        sgdisk --move-second-header /dev/$datadev
+        partprobe
+    fi
 }

--- a/meta-balena-common/recipes-core/initrdscripts/files/resindataexpander
+++ b/meta-balena-common/recipes-core/initrdscripts/files/resindataexpander
@@ -3,6 +3,8 @@
 FREESPACE_LIMIT=10
 datapart=$(readlink -f /dev/disk/by-label/resin-data)
 datadev=$(lsblk $datapart -n -o PKNAME)
+# Parted print is slow. Use Parted print only once to reduce boot time.
+parted_print=$(parted -m /dev/$datadev -s unit MiB print free)
 
 resindataexpander_enabled() {
     # On flasher avoid expanding partition
@@ -11,7 +13,7 @@ resindataexpander_enabled() {
         return 1
     fi
 
-    for freespace in $(parted -m /dev/$datadev unit MiB print free | grep free | cut -d: -f4 | sed 's/MiB//g'); do
+    for freespace in $(echo "$parted_print" | grep free | tail -1 | cut -d: -f4 | sed 's/MiB//g'); do
         if [ $(echo $freespace \> $FREESPACE_LIMIT | bc -l) == "1" ]; then
             return 0
         fi
@@ -20,11 +22,26 @@ resindataexpander_enabled() {
 }
 
 resindataexpander_run() {
-    info "resindataexpander: Expand extended partition... "
-    parted -s /dev/$datadev -- resizepart 4 -1s
-    info "resindataexpander: Finished expanding extended partition."
+    case "$(blkid -o value -s PTTYPE /dev/$datadev)" in
+        dos)
+            extpart_num=$(echo "$parted_print"  | grep ":::lba" | tail -1 | cut -d: -f1)
+            datapart_num=$(expr $extpart_num \+ 2)
+            ;;
+        gpt)
+            datapart_num=$(echo "$parted_print"  | grep "resin-data" | tail -1 | cut -d: -f1)
+            ;;
+        *)
+            fatal "Unrecognized partition table type."
+            ;;
+    esac
+
+    if [ -n "$extpart_num" ]; then
+        info "resindataexpander: Expand extended partition... "
+        parted -s /dev/$datadev -- resizepart $extpart_num 100%
+        info "resindataexpander: Finished expanding extended partition."
+    fi
     info "resindataexpander: Expand data partition... "
-    parted -s /dev/$datadev -- resizepart 6 -1s
+    parted -s /dev/$datadev -- resizepart $datapart_num 100%
     info "resindataexpander: Finished expanding data partition."
 
     partprobe

--- a/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -32,7 +32,7 @@ PACKAGES_append = " \
 RRECOMMENDS_${PN}-base += "initramfs-module-rootfs"
 
 SUMMARY_initramfs-module-fsck = "Filesystem check for partitions"
-RDEPENDS_initramfs-module-fsck = "${PN}-base e2fsprogs-e2fsck dosfstools-fsck"
+RDEPENDS_initramfs-module-fsck = "${PN}-base e2fsprogs-e2fsck dosfstools-fsck util-linux-lsblk gptfdisk"
 FILES_initramfs-module-fsck = "/init.d/87-fsck"
 
 SUMMARY_initramfs-module-machineid = "Bind mount machine-id to rootfs"
@@ -40,7 +40,7 @@ RDEPENDS_initramfs-module-machineid = "${PN}-base initramfs-module-udev"
 FILES_initramfs-module-machineid = "/init.d/91-machineid"
 
 SUMMARY_initramfs-module-resindataexpander = "Expand the data partition to the end of device"
-RDEPENDS_initramfs-module-resindataexpander = "${PN}-base initramfs-module-udev busybox parted util-linux-lsblk"
+RDEPENDS_initramfs-module-resindataexpander = "${PN}-base initramfs-module-udev busybox parted util-linux-lsblk util-linux-blkid"
 FILES_initramfs-module-resindataexpander = "/init.d/88-resindataexpander"
 
 SUMMARY_initramfs-module-rorootfs = "Mount our rootfs"


### PR DESCRIPTION
STM32MP157C-DK2 requires special partition configurations on a SD card
that it must be GPT formatted and it must have two extra partitions for
U-Boot FSBL and SSBL. The current resindataexpander script has some
problems with this configurations:

  1. The board is stucked at "parted print free" command in
resindataexpander_enabled(), printing the following and requiring the
user to type "Fix" in interactive mode:

> Warning: Not all of the space available to /dev/mmcblk0 appears to be
used, you can fix the GPT to use all of the space (an extra 60694528
blocks) or continue with the current setting? Fix/Ignore?

To solve this issue, commands to fix the backup GPT header are added in
fsck script and "-s" flag is added to prevent prompts for user
intervention.

  2. Hardcoded partition numbers for extended partition and resin-data
should be fixed because there is no extended partition on GPT and the
SD card for this board has two extra partitions. resindataexpander is
fixed to get the partition numbers in a more flexible way.

  3. "-1s" in parted command doesn't work with GPT because of the backup
GPT header located at the end of the disk. Use "100%" instead.

Change-type: patch
Signed-off-by: Bumsik Kim k.bumsik@gmail.com


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested: Raspberry Pi3 (with MBR-formatted SD card) and STM32MP157C-DK2 (with GPT-formatted SD card, I'm currently porting this).
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/balena-os/meta-balena/1670)
<!-- Reviewable:end -->
