### PR TITLE
contributing-device-support.md: update old names and URL links

### DIFF
--- a/contributing-device-support.md
+++ b/contributing-device-support.md
@@ -1,27 +1,27 @@
-# Contributing New Board Support to Resin.io
+# Contributing New Board Support to Balena.io
 
-Pre-requisites: a [Yocto](https://www.yoctoproject.org) Board Support Package (BSP) layer for your particular board. It should be compatible to the Yocto releases resinOS supports.
+Pre-requisites: a [Yocto](https://www.yoctoproject.org) Board Support Package (BSP) layer for your particular board. It should be compatible to the Yocto releases balenaOS supports.
 
-Repositories used to build resinOS host Operating System (OS) are typically named resin-`<board-family>`. For example, consider [resin-raspberrypi](https://github.com/resin-os/resin-raspberrypi) which is used for building the OS for [Raspberryi Pi](https://raspberrypi.org), or [resin-intel][resin-intel repo] repository which can be used to build a resin.io image for the Intel NUC boards.
+Repositories used to build balenaOS host Operating System (OS) are typically named balena-`<board-family>`. For example, consider [balena-raspberrypi](https://github.com/balena-os/balena-raspberrypi) which is used for building the OS for [Raspberryi Pi](https://raspberrypi.org), or [balena-intel][balena-intel repo] repository which can be used to build a balena.io image for the Intel NUC boards.
 
 Contributing support for a new board consists of creating a Yocto layer that includes:
 
 * general hardware support for the specific board,
-* the resinOS-specific software features,
+* the balenaOS-specific software features,
 * deployment-specific features (i.e. settings to create SD card, USB thumb drive, or self-flashing images)
 
 The following documentations walks you through the steps of creating such a Yocto package. Because of the substantial difference between the hardware of many boards, this document provides general directions, and often it might be helpful to see the examples of already supported boards. The list of the relevant repositories is found at the end of this document.
 
 ## Board Support Repository Breakout
 
-The resin-`<board-family>` repositories use [git submodules](https://git-scm.com/docs/git-submodule) for including required Yocto layers from the relevant sub-projects.
+The balena-`<board-family>` repositories use [git submodules](https://git-scm.com/docs/git-submodule) for including required Yocto layers from the relevant sub-projects.
 
 The root directory contains:
 
 |Directories|
 |:-----------------:|
 |  `layers` |
-| [resin-yocto-scripts][resin-yocto-scripts] (git submodule)|
+| [balena-yocto-scripts][balena-yocto-scripts] (git submodule)|
 
 and
 
@@ -39,7 +39,7 @@ _Note: you add submodules by `git submodule add <url> <directory>`, see the git 
 
 ### About coffee file(s)
 
-One or more files named `<board-name>.coffee`, where `<board-name>` is equal to the corresponding `yocto-machine-name`. Should add one for each of the boards that the repository adds support for (eg. [`raspberry-pi3.coffee`](https://github.com/resin-os/resin-raspberrypi/blob/master/raspberrypi3.coffee) for Raspberry Pi 3 in `resin-raspberrypi`). This file contains information on the Yocto build for the specific board, in [CoffeeScript](http://coffeescript.org/) format. A minimal version of this file, using [Raspberry Pi 3 as the example](https://github.com/resin-os/resin-raspberrypi/), would be:
+One or more files named `<board-name>.coffee`, where `<board-name>` is equal to the corresponding `yocto-machine-name`. Should add one for each of the boards that the repository adds support for (eg. [`raspberrypi3.coffee`](https://github.com/balena-os/balena-raspberrypi/blob/master/raspberrypi3.coffee) for Raspberry Pi 3 in `balena-raspberrypi`). This file contains information on the Yocto build for the specific board, in [CoffeeScript](http://coffeescript.org/) format. A minimal version of this file, using [Raspberry Pi 3 as the example](https://github.com/balena-os/balena-raspberrypi/), would be:
 
 ```
 module.exports =
@@ -67,28 +67,28 @@ The layout for the `layers` directory:
 ├── layers
 │   ├── meta-openembedded
 │   ├── meta-<vendor>
-│   ├── meta-resin
-│   ├── meta-resin-<board-family>
+│   ├── meta-balena
+│   ├── meta-balena-<board-family>
 │   ├── oe-meta-go
 │   └── poky
 ├── <board-name-1>.coffee
 ├── <board-name-2>.coffee
 ...
-└── resin-yocto-scripts
+└── balena-yocto-scripts
 ```
 
 The `layers` directory contains the git submodules of the yocto layers used in the build process. This normally means the following components are present:
 
 - [poky][poky]  at the version/revision required by the board BSP
 - [meta-openembedded][meta-openembedded] at the revision poky uses
-- [meta-resin][meta-resin] using the master branch
+- [meta-balena][meta-balena] using the master branch
 - [meta-rust][meta-rust] at the revision poky uses
 - Yocto BSP layer for the board (for example, the BSP layer for Raspberry Pi is [meta-raspberrypi](https://github.com/agherzan/meta-raspberrypi))
 - any additional Yocto layers required by the board BSP (check the Yocto BSP layer of the respective board for instructions on how to build the BSP and what are the Yocto dependencies of that particular BSP layer)
 
-In addition to the above git submodules, the `layers` directory requires a meta-resin-`<board-family>` directory (please note this directory is _not_ a git submodule). This directory contains the required customization for making a board resin.io enabled. For example, the [resin-raspberrypi](https://github.com/resin-os/resin-raspberrypi) repository contains the directory `layers/meta-resin-raspberrypi` to supplement the BSP from `layers/meta-raspberrypi` git submodule, with any changes that might be required by resinOS.
+In addition to the above git submodules, the `layers` directory requires a meta-balena-`<board-family>` directory (please note this directory is _not_ a git submodule). This directory contains the required customization for making a board balena.io enabled. For example, the [balena-raspberrypi](https://github.com/balena-os/balena-raspberrypi) repository contains the directory `layers/meta-balena-raspberrypi` to supplement the BSP from `layers/meta-raspberrypi` git submodule, with any changes that might be required by balenaOS.
 
-## meta-resin-`<board-family>` breakout
+## meta-balena-`<board-family>` breakout
 
 This directory contains optional and mandatory directories:
 
@@ -102,27 +102,27 @@ This directory contains optional and mandatory directories:
 
 ###  `conf` directory - contains the following files:
 
-  1. `layer.conf`, see the [layer.conf](https://github.com/resin-os/resin-raspberrypi/blob/master/layers/meta-resin-raspberrypi/conf/layer.conf) from `meta-resin-raspberrypi` for an example, and see [Yocto documentation](http://www.yoctoproject.org/docs/2.0/mega-manual/mega-manual.html#bsp-filelayout-layer)
-   2. `samples/bblayers.conf.sample` file in which all the required Yocto layers are listed, see this [bblayers.conf.sample](https://github.com/resin-os/resin-raspberrypi/blob/master/layers/meta-resin-raspberrypi/conf/samples/bblayers.conf.sample) from `meta-resin-raspberrypi` for an example, and see the [Yocto documentation](http://www.yoctoproject.org/docs/2.0/mega-manual/mega-manual.html#var-BBLAYERS)
-   3. `samples/local.conf.sample` file which defines part of the build configuration (see the meta-resin [README.md][meta-resin-readme] for an overview of some of the variables use in the `local.conf.sample` file). An existing file can be used (e.g. [local.conf.sample](https://github.com/resin-os/resin-raspberrypi/blob/master/layers/meta-resin-raspberrypi/conf/samples/local.conf.sample)) but making sure the "Supported machines" area lists the appropriate machines this repository is used for. See also the [Yocto documentation](http://www.yoctoproject.org/docs/2.0/mega-manual/mega-manual.html#structure-build-conf-local.conf).
+  1. `layer.conf`, see the [layer.conf](https://github.com/balena-os/balena-raspberrypi/blob/master/layers/meta-balena-raspberrypi/conf/layer.conf) from `meta-balena-raspberrypi` for an example, and see [Yocto documentation](http://www.yoctoproject.org/docs/current/mega-manual/mega-manual.html#bsp-filelayout-layer)
+   2. `samples/bblayers.conf.sample` file in which all the required Yocto layers are listed, see this [bblayers.conf.sample](https://github.com/balena-os/balena-raspberrypi/blob/master/layers/meta-balena-raspberrypi/conf/samples/bblayers.conf.sample) from `meta-balena-raspberrypi` for an example, and see the [Yocto documentation](http://www.yoctoproject.org/docs/current/mega-manual/mega-manual.html#var-BBLAYERS)
+   3. `samples/local.conf.sample` file which defines part of the build configuration (see the meta-balena [README.md][meta-balena-readme] for an overview of some of the variables use in the `local.conf.sample` file). An existing file can be used (e.g. [local.conf.sample](https://github.com/balena-os/balena-raspberrypi/blob/master/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample)) but making sure the "Supported machines" area lists the appropriate machines this repository is used for. See also the [Yocto documentation](http://www.yoctoproject.org/docs/current/mega-manual/mega-manual.html#structure-build-conf-local.conf).
 
 
 ### `recipes-core/images` directory
 
-Which contains at least a `resin-image.bbappend` file. Depending on the type of board you are adding support for, you should have your device support either just `resin-image` or both `resin-image-flasher` and `resin-image`. Generally, `resin-image` is for boards that boot directly from external storage (these boards do not have internal storage to install resin.io on). `resin-image-flasher` is used when the targeted board has internal storage so this flasher image is burned onto an SD card or USB stick that is used for the initial boot. When booted, this flasher image will automatically install resin.io on internal storage.
+Which contains at least a `resin-image.bbappend` file. Depending on the type of board you are adding support for, you should have your device support either just `resin-image` or both `resin-image-flasher` and `resin-image`. Generally, `resin-image` is for boards that boot directly from external storage (these boards do not have internal storage to install resin.io on). `resin-image-flasher` is used when the targeted board has internal storage so this flasher image is burned onto an SD card or USB stick that is used for the initial boot. When booted, this flasher image will automatically install balena.io on internal storage.
 
   The `resin-image.bbappend` file shall define the following variables:
 
 ***
 - `IMAGE_FSTYPES_<yocto-machine-name>`: this variable is used to declare the type of the produced image. It can be ext3, ext4, resinos-img etc. The usual type for a board that can boot from SD card, USB, is "resinos-img".
 
-- `RESIN_BOOT_PARTITION_FILES_<yocto-machine-name>`: this allows adding files from the build's deploy directory into the vfat formatted resin-boot partition (can be used to add bootloader config files, first stage bootloader, initramfs or anything else needed for the booting process to take place for your particular board). If the board uses different bootloader configuration files when booting from either external media (USB thumb drive, SD card etc.) or from internal media (mSATA, eMMC etc) then you would want to make use of this variable to make sure the different bootloader configuration files get copied over and further manipulated as needed (see `INTERNAL_DEVICE_BOOTLOADER_CONFIG_<yocto-machine-name>` and `INTERNAL_DEVICE_BOOTLOADER_CONFIG_PATH_<yocto-machine-name>` below). Please note that you only reference these files here, it is the responsibility of a `.bb` or `.bbappend` to provide and deploy them (for bootloader config files this is done with an append typically in `recipes-bsp/<your board's bootloader>/<your board's bootloader>.bbappend`, see [resin-intel grub bbappend][resin-intel grub append] for an example).
+- `RESIN_BOOT_PARTITION_FILES_<yocto-machine-name>`: this allows adding files from the build's deploy directory into the vfat formatted resin-boot partition (can be used to add bootloader config files, first stage bootloader, initramfs or anything else needed for the booting process to take place for your particular board). If the board uses different bootloader configuration files when booting from either external media (USB thumb drive, SD card etc.) or from internal media (mSATA, eMMC etc) then you would want to make use of this variable to make sure the different bootloader configuration files get copied over and further manipulated as needed (see `INTERNAL_DEVICE_BOOTLOADER_CONFIG_<yocto-machine-name>` and `INTERNAL_DEVICE_BOOTLOADER_CONFIG_PATH_<yocto-machine-name>` below). Please note that you only reference these files here, it is the responsibility of a `.bb` or `.bbappend` to provide and deploy them (for bootloader config files this is done with an append typically in `recipes-bsp/<your board's bootloader>/<your board's bootloader>.bbappend`, see [balena-intel grub bbappend][balena-intel grub append] for an example).
 
  It is a space separated list of items with the following format: *FilenameRelativeToDeployDir:FilenameOnTheTarget*. If *FilenameOnTheTarget* is omitted then the *FilenameRelativeToDeployDir* will be used.
 
-  For example to have the Intel NUC `bzImage-intel-corei7-64.bin` copied from deploy directory over to the boot partition, renamed to `vmlinuz`:
+  For example to have the Intel NUC `bzImage-genericx86-64.bin` copied from deploy directory over to the boot partition, renamed to `vmlinuz`:
 
-    ```sh   RESIN_BOOT_PARTITION_FILES_nuc =  "bzImage-intel-corei7-64.bin:vmlinuz"    ```
+    ```sh   RESIN_BOOT_PARTITION_FILES_nuc =  "bzImage-genericx86-64.bin:vmlinuz"    ```
 ***
 
   The `resin-image-flasher.bbappend` file shall define the following variables:
@@ -135,17 +135,17 @@ Which contains at least a `resin-image.bbappend` file. Depending on the type of 
 
 ### `recipes-kernel/linux directory`
 
- Shall contain a `.bbappend` to the kernel recipe used by the respective board. This kernel `.bbappend` must "inherit kernel-resin" in order to add the necessary kernel configs for using with resin.io
+ Shall contain a `.bbappend` to the kernel recipe used by the respective board. This kernel `.bbappend` must "inherit kernel-resin" in order to add the necessary kernel configs for using with balena.io
 
 ### `recipes-support/resin-init` directory
 
-Shall contain a `resin-init-flasher.bbappend` file if you intend to install resin.io to internal storage and hence use the flasher image.
+Shall contain a `resin-init-flasher.bbappend` file if you intend to install balena.io to internal storage and hence use the flasher image.
 
 
 `resin-init-flasher.bbappend` should define the following variables:
 
 ***
-  - `INTERNAL_DEVICE_KERNEL_<yocto-machine-name>`: used to identify the internal storage where resin.io will be written to.
+  - `INTERNAL_DEVICE_KERNEL_<yocto-machine-name>`: used to identify the internal storage where balena.io will be written to.
 
   - `INTERNAL_DEVICE_BOOTLOADER_CONFIG_<yocto-machine-name>`: used to specify the filename of the bootloader configuration file used by your board when booting from internal media. Must be the same as the *FilenameOnTheTarget* parameter of the bootloader internal config file used in the `RESIN_BOOT_PARTITION_FILES_<yocto-machine-name>` variable from `recipes-core/images/resin-image-flasher.bbappend`.
 
@@ -153,9 +153,9 @@ Shall contain a `resin-init-flasher.bbappend` file if you intend to install resi
 
     For example, setting
 
-    ```sh    INTERNAL_DEVICE_BOOTLOADER_CONFIG_intel-corei7-64 = "grub.cfg_internal"    ````
+    ```sh    INTERNAL_DEVICE_BOOTLOADER_CONFIG_genericx86-64 = "grub.cfg_internal"    ````
     and
-    ```sh    INTERNAL_DEVICE_BOOTLOADER_CONFIG_PATH_intel-corei7-64 = "/EFI/BOOT/grub.cfg"    ```
+    ```sh    INTERNAL_DEVICE_BOOTLOADER_CONFIG_PATH_genericx86-64 = "/EFI/BOOT/grub.cfg"    ```
     will result that after flashing the file `grub.cfg`_internal is copied with the name `grub.cfg` to the /EFI/BOOT/ directory on the resin-boot partition.
 
 
@@ -224,7 +224,7 @@ The directory structure then looks similar to this:
 
 ## Building
 
-See the [meta-resin Readme](https://github.com/resin-os/meta-resin/blob/master/README.md) on how to build the new resinOS image after setting up the new board package as defined above.
+See the [meta-balena Readme](https://github.com/balena-os/meta-balena/blob/master/README.md) on how to build the new balenaOS image after setting up the new board package as defined above.
 
 ## Troubleshooting
 
@@ -234,39 +234,39 @@ For specific examples on how board support is provided for existing devices, see
 
 ### ARM
 
-* [Beaglebone](http://beagleboard.org/bone): [resin-beaglebone](https://github.com/resin-os/resin-beaglebone)
-* [Raspberry Pi](https://raspberrypi.org): [resin-raspberrypi](https://github.com/resin-os/resin-raspberrypi)
-* [Freescale/NXP](http://www.nxp.com/): [resin-fsl-arm](https://github.com/resin-os/resin-fsl-arm)
-* [ODROID](http://www.hardkernel.com/main/main.php): [resin-odroid](https://github.com/resin-os/resin-odroid)
-* [Parallella](https://www.parallella.org/): [resin-parallella](https://github.com/resin-os/resin-parallella)
-* [Technologic Systems](https://www.embeddedarm.com/): [resin-ts](https://github.com/resin-os/resin-ts)
-* [Toradex](https://www.toradex.com/): [resin-toradex](https://github.com/resin-os/resin-toradex)
-* [VIA](http://www.viatech.com/en/): [resin-via-arm](https://github.com/resin-os/resin-via-arm)
-* [Zynq](http://www.xilinx.com/products/silicon-devices/soc/zynq-7000.html): [resin-zc702](https://github.com/resin-os/resin-zc702)
-* [Samsung Artik](https://www.artik.io/): [resin-artik](https://github.com/resin-os/resin-artik)
+* [Beaglebone](http://beagleboard.org/bone): [balena-beaglebone](https://github.com/balena-os/balena-beaglebone)
+* [Raspberry Pi](https://raspberrypi.org): [balena-raspberrypi](https://github.com/balena-os/balena-raspberrypi)
+* [Freescale/NXP](http://www.nxp.com/): [balena-fsl-arm](https://github.com/balena-os/balena-fsl-arm)
+* [ODROID](http://www.hardkernel.com/main/main.php): [balena-odroid](https://github.com/balena-os/balena-odroid)
+* [Parallella](https://www.parallella.org/): [balena-parallella](https://github.com/balena-os/balena-parallella)
+* [Technologic Systems](https://www.embeddedarm.com/): [balena-ts](https://github.com/balena-os/balena-ts)
+* [Toradex](https://www.toradex.com/): [balena-toradex](https://github.com/balena-os/balena-toradex)
+* [VIA](http://www.viatech.com/en/): [balena-via-arm](https://github.com/balena-os/balena-via-arm)
+* [Zynq](http://www.xilinx.com/products/silicon-devices/soc/zynq-7000.html): [balena-zc702](https://github.com/balena-os/balena-zc702)
+* [Samsung Artik](https://www.artik.io/): [balena-artik](https://github.com/balena-os/balena-artik)
 
 ### x86
 
-* [Intel Edison](http://www.intel.com/content/www/us/en/do-it-yourself/edison.html): [resin-edison](https://github.com/resin-os/resin-edison)
-* [Intel NUC](http://www.intel.com/content/www/us/en/nuc/overview.html): [resin-intel](https://github.com/resin-os/resin-intel)
+* [Intel Edison](http://www.intel.com/content/www/us/en/do-it-yourself/edison.html): [balena-edison](https://github.com/balena-os/balena-edison)
+* [Intel NUC](http://www.intel.com/content/www/us/en/nuc/overview.html): [balena-intel](https://github.com/balena-os/balena-intel)
 
 ### Other
 
-* [QEMU](http://wiki.qemu.org/Main_Page): [resin-qemu](https://github.com/resin-os/resin-qemu)
+* [QEMU](http://wiki.qemu.org/Main_Page): [balena-qemu](https://github.com/balena-os/balena-qemu)
 
-[resin-intel repo]: https://github.com/resin-os/resin-intel
-[resin-intel grub append]: https://github.com/resin-os/resin-intel/tree/master/layers/meta-resin-intel/recipes-bsp/grub
+[balena-intel repo]: https://github.com/balena-os/balena-intel
+[balena-intel grub append]: https://github.com/balena-os/balena-intel/tree/master/layers/meta-balena-genericx86/recipes-bsp/grub
 [meta-intel repo]: http://git.yoctoproject.org/cgit/cgit.cgi/meta-intel
-[intel-corei7-64 coffee]: https://github.com/resin-os/resin-intel/blob/master/intel-corei7-64.coffee
-[resin-yocto-scripts]: https://github.com/resin-os/resin-yocto-scripts
+[genericx86-64 coffee]: https://github.com/balena-os/balena-intel/blob/master/genericx86-64.coffee
+[balena-yocto-scripts]: https://github.com/balena-os/balena-yocto-scripts
 [poky]: http://git.yoctoproject.org/cgit/cgit.cgi/poky
 [meta-openembedded]: https://github.com/openembedded/meta-openembedded
-[meta-resin]: https://github.com/resin-os/meta-resin
+[meta-balena]: https://github.com/balena-os/meta-balena
 [meta-rust]: https://github.com/meta-rust/meta-rust
-[layer.conf intel]: https://github.com/resin-os/resin-intel/blob/master/layers/meta-resin-intel/conf/layer.conf
-[meta-resin-readme]: https://github.com/resin-os/meta-resin/blob/master/README.md
-[local.conf.sample intel]: https://github.com/resin-os/resin-intel/blob/master/layers/meta-resin-intel/conf/samples/local.conf.sample
-[bblayers.conf.sample intel]: https://github.com/resin-os/resin-intel/blob/master/layers/meta-resin-intel/conf/samples/bblayers.conf.sample
+[layer.conf intel]: https://github.com/balena-os/balena-intel/blob/master/layers/meta-balena-genericx86/conf/layer.conf
+[meta-balena-readme]: https://github.com/balena-os/meta-balena/blob/master/README.md
+[local.conf.sample intel]: https://github.com/balena-os/balena-intel/blob/master/layers/meta-balena-genericx86/conf/samples/local.conf.sample
+[bblayers.conf.sample intel]: https://github.com/balena-os/balena-intel/blob/master/layers/meta-balena-genericx86/conf/samples/bblayers.conf.sample
 
 ## FAQ
 


### PR DESCRIPTION
This updates old resin names to balena in the document.
This includes changing "intel" to genericx86-64. Some names like
resin-image is left unchanged because they are not updated in the
source code.

Also updates URL links to Yocto documentations to the "current" version.

Change-type: patch
Signed-off-by: Bumsik Kim k.bumsik@gmail.com


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/balena-os/meta-balena/1672)
<!-- Reviewable:end -->
