### PR TITLE
openssh: Disable PasswordAuthentication on production images

### DIFF
--- a/meta-balena-common/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-balena-common/recipes-connectivity/openssh/openssh_%.bbappend
@@ -19,8 +19,8 @@ FILES_${PN}-sshd += " \
 "
 
 do_install_append () {
-    # Advertise SSH service using an avahi service file                                                                                                                                                                                                                                                                                                                   
-    mkdir -p ${D}/etc/avahi/services/                                                                                                                                                                                                                                                                                                                                                    
+    # Advertise SSH service using an avahi service file
+    mkdir -p ${D}/etc/avahi/services/
     install -m 0644 ${WORKDIR}/ssh.service ${D}/etc/avahi/services
 
     # SSH keys merger tool for custom SSH keys
@@ -41,6 +41,11 @@ do_install_append () {
     echo "AuthorizedKeysCommandUser sshd-authcommands" >> ${D}${sysconfdir}/ssh/sshd_config_readonly
 
     install -D -m 0755 ${WORKDIR}/cloud-public-sshkeys ${D}${libexecdir}/${BPN}/cloud-public-sshkeys
+
+    # Disable PasswordAuthentication for production builds.
+    if ${@bb.utils.contains('DISTRO_FEATURES','development-image','false','true',d)}; then
+        sed -i 's/^[#[:space:]]*PasswordAuthentication yes*/PasswordAuthentication no/' ${D}${sysconfdir}/ssh/sshd_config_readonly
+    fi
 }
 
 # We need dropbear to be able to migrate host keys in the update hooks


### PR DESCRIPTION
PasswordAuthentication defaults to yes. Make it no for production
images.

Fixes #1678

Change-type: patch
Changelog-entry: Disable PasswordAuthentication in sshd in production images as an extra precautionary measure.
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
