### PR TITLE
hostapp-update-hooks: Filter out automount for inactive sysroot

### DIFF
--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/99-resin-uboot
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/99-resin-uboot
@@ -14,7 +14,7 @@ else
 	SYSROOT="/mnt/sysroot/active"
 fi
 
-new_part=$(findmnt --noheadings --canonicalize --output SOURCE $SYSROOT)
+new_part=$(findmnt --noheadings --canonicalize --output SOURCE $SYSROOT -t ext4)
 blockdev=$(basename "$new_part")
 new_part_idx=$(cat "/sys/class/block/$blockdev/partition")
 


### PR DESCRIPTION
Use ext4 FSTYPE to filter out automount with source "systemd-1" when determining the new parition label in the u-boot hook, just like we already do for grub.

findmnt will report two sources, one being the systemd mnt-sysroot-inactive automount:

| -/mnt/sysroot/inactive systemd-1 autofs
| `-/mnt/sysroot/inactive /dev/mmcblk0p2 ext4

Currently there's no failure observed because the output is filtered trough 'basename':
root@81dd8a3:~# findmnt --noheadings --canonicalize --output SOURCE /mnt/sysroot/inactive       
systemd-1
/dev/mmcblk0p14

Fix this so it doesn't become a possible point of failure at a later time.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
