### PR TITLE
kernel-devsrc: Copy vdso.lds.S file in source archive if available

### DIFF
--- a/meta-balena-common/recipes-kernel/linux/kernel-devsrc.bb
+++ b/meta-balena-common/recipes-kernel/linux/kernel-devsrc.bb
@@ -150,6 +150,9 @@ do_install() {
             cp -a --parents arch/arm64/kernel/vdso/sigreturn.S $kerneldir/build/
             cp -a --parents arch/arm64/kernel/vdso/note.S $kerneldir/build/
             cp -a --parents arch/arm64/kernel/vdso/gen_vdso_offsets.sh $kerneldir/build/
+	    if [ -f "arch/arm64/kernel/vdso/vdso.lds.S" ]; then
+	        cp -a --parents arch/arm64/kernel/vdso/vdso.lds.S $kerneldir/build/
+	    fi
 	    if [ -f "arch/arm64/kernel/module.lds" ]; then
 	        cp -a --parents arch/arm64/kernel/module.lds $kerneldir/build/
 	    fi


### PR DESCRIPTION
Necessary to avoid error:
"No rule to make target 'arch/arm64/kernel/vdso/vdso.lds', needed
by 'arch/arm64/kernel/vdso/vdso.so.dbg'"
when doing "make  modules_prepare"

Change-type: patch
Changelog-entry: kernel-devsrc: Copy vdso.lds.S file in source archive if available
Signed-off-by: Sebastian Panceac <sebastian@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ x] Changes have been tested
- [ x] `Change-type` present on at least one commit
- [ x] `Signed-off-by` is present
- [ x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
