### PR TITLE
kernel-headers-test: Thoroughly test the headers

### DIFF
--- a/meta-balena-common/recipes-kernel/linux/kernel-headers-test.bb
+++ b/meta-balena-common/recipes-kernel/linux/kernel-headers-test.bb
@@ -37,7 +37,7 @@ do_compile() {
     cp "${WORKDIR}"/Dockerfile ${B}/work/
     cp -r "${WORKDIR}"/example_module ${B}/work/
 
-    IMAGE_ID=$(DOCKER_API_VERSION=1.22 docker build --build-arg kernel_arch=${ARCH} --build-arg cross_compile_prefix=${DEBIAN_TUPLE} ${B}/work)
+    IMAGE_ID=$(DOCKER_API_VERSION=1.22 docker build --no-cache --build-arg kernel_arch=${ARCH} --build-arg cross_compile_prefix=${DEBIAN_TUPLE} ${B}/work)
     # We don't pipe in previous line so that we can catch errors.
     IMAGE_ID=$(echo "$IMAGE_ID" | grep -o -E '[a-z0-9]{12}' | tail -n1)
     DOCKER_API_VERSION=1.22 docker rmi "$IMAGE_ID"
@@ -46,3 +46,6 @@ do_compile() {
 # Explicitly depend on the do_deploy step as we use the deployed artefacts. DEPENDS doesn't cover that
 do_compile[depends] += "kernel-devsrc:do_deploy"
 do_compile[depends] += "kernel-modules-headers:do_deploy"
+
+# Run test on every build
+do_compile[nostamp] = "1"


### PR DESCRIPTION
[ DO NOT MERGE ]
We've spotted some cases of sporadic failures of the headers that should
have been caught by the automated build test.

Either the docker cache is being re-used. Or yocto cache is not retriggering.

Poison both.

Change-type: patch
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
