### PR TITLE
resin-supervisor: Ask balenaEngine to restart an unhealthy

### DIFF
--- a/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/resin-supervisor-healthcheck
+++ b/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/resin-supervisor-healthcheck
@@ -2,6 +2,6 @@
 
 set -o errexit
 
-if [ "$(balena inspect --format '{{.State.Health.Status}}' resin_supervisor)" = "unhealthy" ]; then
+if [ "$(balena images -q $SUPERVISOR_IMAGE 2> /dev/null" = "" ]; then
     exit 1
 fi

--- a/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/start-resin-supervisor
+++ b/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/start-resin-supervisor
@@ -73,6 +73,7 @@ configIsUnchanged() {
 runSupervisor() {
     balena rm --force resin_supervisor || true
     balena run --privileged --name resin_supervisor \
+        --restart=always \
         --net=host \
         --cidenv=SUPERVISOR_CONTAINER_ID \
         -v /var/run/balena-engine.sock:/var/run/balena-engine.sock \


### PR DESCRIPTION
Currently balenaEngine knows a supervisor is unhealthy but we wait for
healthdog to check the status and then restart supervisor.

Lets ask balenaEngine to restart the supervisor if it knows the
supervisor is unhealthy.

Healthdog is now restricted to checking presence of the supervisor
image itself.

Changelog-entry: Modify supervisor healthcheck. balenaEngine will restart an unhealthy supervisor if needed
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
