### PR TITLE
kernel-resin: Build net/dummy as module

### DIFF
--- a/meta-balena-common/classes/kernel-resin.bbclass
+++ b/meta-balena-common/classes/kernel-resin.bbclass
@@ -93,6 +93,7 @@ RESIN_CONFIGS ?= " \
     ${BALENA_STORAGE} \
     fatfs \
     nf_tables \
+    dummy \
     "
 
 #
@@ -488,6 +489,12 @@ RESIN_CONFIGS[nf_tables] = " \
     CONFIG_NFT_DUP_IPV6=m \
     CONFIG_NFT_FIB_IPV6=m \
     CONFIG_NF_DUP_IPV6=m \
+    "
+
+# This adds support for creating
+# dummy net devices
+RESIN_CONFIGS[dummy] = " \
+    CONFIG_DUMMY=m \
     "
 
 ###########


### PR DESCRIPTION
Add dummy net driver support, which is used to
check if a container is privileged during
udev initialization.

Building it as module ensures that dummy
devices are not needlessly created during boot.

Addresses: 
- https://github.com/balena-os/meta-balena/issues/1606
- https://github.com/balena-os/balena-jetson-skx2/issues/163

Privileged checks will be improved on container side.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
