### PR TITLE
rollback: Fix for ESR version naming scheme

### DIFF
--- a/meta-balena-common/recipes-core/balena-rollback/files/rollback-check-version
+++ b/meta-balena-common/recipes-core/balena-rollback/files/rollback-check-version
@@ -10,9 +10,15 @@ MIN_HOSTOS_VERSION=2.30.0
 old_os_release=$(find /mnt/sysroot/inactive/ | grep "etc/os-release")
 . "$old_os_release"
 
-if version_gt $VERSION $MIN_HOSTOS_VERSION; then
-	echo "rollbacks: Previous Host OS version $VERSION OK for rollbacks."
+if [ -n "$META_BALENA_VERSION" ]; then
+	VERSION_TO_CHECK="$META_BALENA_VERSION"
 else
-	echo "rollbacks: Can't rollback before $MIN_HOSTOS_VERSION"
+	VERSION_TO_CHECK="$VERSION"
+fi
+
+if version_gt "$VERSION_TO_CHECK" "$MIN_HOSTOS_VERSION"; then
+	echo "rollbacks: Previous Host OS META_BALENA_VERSION:$VERSION_TO_CHECK OK for rollbacks."
+else
+	echo "rollbacks: Can't rollback before $MIN_HOSTOS_VERSION. Previous OS version is $VERSION_TO_CHECK"
 	exit 1
 fi


### PR DESCRIPTION
PR to master is https://github.com/balena-os/meta-balena/pull/1730
This is the same commit but PR to `2.38.x`

ESR releases have the VERSION string in /etc/os-release in a date
format. 2019.10.0 etc.
We added META_BALENA_VERSION in os-release from v2.38.0 via
b0e0c77a26f3fad51e2923ab416fdd2af2a5a033

Lets use META_BALENA_VERSION if available for our os version checks.

Change-type: patch
Changelog-entry: No user impact, subtle fix in rollback version checks
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
