### PR TITLE
resin-image-initramfs.bbappend: Add leading new line for PACKAGE_INSTALL

### DIFF
--- a/meta-balena-warrior/recipes-core/images/resin-image-initramfs.bbappend
+++ b/meta-balena-warrior/recipes-core/images/resin-image-initramfs.bbappend
@@ -1,1 +1,1 @@
-PACKAGE_INSTALL_append = "initramfs-module-console-null-workaround"
+PACKAGE_INSTALL_append = " initramfs-module-console-null-workaround"


### PR DESCRIPTION
Without the new line, the last package name is
concatenated with the oneadded in this recipe resulting
in the following error
opkg_prepare_url_for_install
Couldn't find anything to satisfy
'kernel-module-sdhci-pciinitramfs-module-console-null-workaround'

Change-type: patch
Changelog-entry: Add leading new line for PACKAGE_INSTALL variable
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
