### PR TITLE
resin-supervisor: Bind mount using --mount

### DIFF
--- a/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/start-resin-supervisor
+++ b/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/start-resin-supervisor
@@ -77,12 +77,12 @@ runSupervisor() {
         --net=host \
         --cidenv=SUPERVISOR_CONTAINER_ID \
         --mount type=bind,source=/var/run/balena-engine.sock,target=/var/run/balena-engine.sock \
-        -v "$CONFIG_PATH:/boot/config.json"  \
-        -v /mnt/data/apps.json:/boot/apps.json \
-        -v /resin-data/resin-supervisor:/data \
-        -v /proc/net/fib_trie:/mnt/fib_trie \
-        -v /var/log/supervisor-log:/var/log \
-        -v /:/mnt/root \
+        --mount type=bind,source="$CONFIG_PATH",target=/boot/config.json \
+        --mount type=bind,source=/mnt/data/apps.json,target=/boot/apps.json \
+        --mount type=bind,source=/resin-data/resin-supervisor,target=/data \
+        --mount type=bind,source=/proc/net/fib_trie,target=/mnt/fib_trie \
+        --mount type=bind,source=/var/log/supervisor-log,target=/var/log \
+        --mount type=bind,source=/,target=/mnt/root \
         -e DOCKER_ROOT=/mnt/root/var/lib/docker \
         -e DOCKER_SOCKET=/var/run/balena-engine.sock \
         -e "BOOT_MOUNTPOINT=$BOOT_MOUNTPOINT" \


### PR DESCRIPTION
This makes sure the source path refers to an existing file/directory on
the host.

https://docs.docker.com/engine/reference/commandline/service_create/#differences-between---mount-and---volume

This avoids situations where --volume implicitely creates a directory (see #1748)

Fixes #1754

Change-type: patch
Changelog-entry: Use --mount instead of --volume for bind mounts to the supervisor container.
Signed-off-by: Robert Günzler <robertg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
