### PR TITLE
image-resin.bbclass: Mark do_populate_lic_deploy with nostamp

### DIFF
--- a/meta-balena-common/classes/image-resin.bbclass
+++ b/meta-balena-common/classes/image-resin.bbclass
@@ -28,6 +28,7 @@ deploy_image_license_manifest () {
     cp -f ${IMAGE_LICENSE_MANIFEST} ${DEPLOY_IMAGE_LICENSE_MANIFEST}
     ln -sf ${IMAGE_NAME}.rootfs.license.manifest ${DEPLOY_SYMLINK_IMAGE_LICENSE_MANIFEST}
 }
+do_populate_lic_deploy[nostamp] = "1"
 
 # _remove_old_symlinks removes the hddimg symlink
 # Recreate it after image is created


### PR DESCRIPTION
We inherit do_populate_lic_deploy from poky. It uses IMAGE_NAME
which includes DATETIME

DATETIME changes between runs so we can sometimes get into a state
where the do_populate_lic_deploy task has its stamp file set.

But when our subsequent deploy_image_license_manifest task runs, the
DATETIME is different. Hence we get into a state where we have to
run cleanall on the resin-image-flasher recipe to clean up directories.

Lets mark do_populate_lic_deploy with nostamp. This should make it
run every time we need to run deploy_image_license_manifest with the
most up to date DATETIME variable to prevent any hiccups

Change-type: patch
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
