### PR TITLE
kernel-resin.bbclass: Enable CONFIG_USB_SERIAL and hfs support

### DIFF
--- a/meta-balena-common/classes/kernel-resin.bbclass
+++ b/meta-balena-common/classes/kernel-resin.bbclass
@@ -92,6 +92,7 @@ RESIN_CONFIGS ?= " \
     zram \
     ${BALENA_STORAGE} \
     fatfs \
+    apple_hfs \
     nf_tables \
     dummy \
     "
@@ -157,6 +158,11 @@ RESIN_CONFIGS[aufs] = " \
 
 RESIN_CONFIGS[overlay2] = " \
     CONFIG_OVERLAY_FS=y \
+    "
+
+RESIN_CONFIGS[apple_hfs] = " \
+    CONFIG_HFS_FS=m \
+    CONFIG_HFSPLUS_FS=m \
     "
 
 #
@@ -431,10 +437,13 @@ RESIN_CONFIGS_DEPS[usb-serial] = " \
     CONFIG_USB_SERIAL_WWAN=m \
     "
 RESIN_CONFIGS[usb-serial] = " \
+    CONFIG_USB_SERIAL=m \
+    CONFIG_USB_SERIAL_GENERIC=m \
     CONFIG_USB_SERIAL_OPTION=m \
     CONFIG_USB_SERIAL_QUALCOMM=m \
     CONFIG_USB_SERIAL_CH341=m \
     CONFIG_USB_SERIAL_FTDI_SIO=m \
+    CONFIG_USB_SERIAL_PL2303=m \
     "
 
 RESIN_CONFIGS[fatfs] = " \


### PR DESCRIPTION
Fixes #1770
Fixes #1761

Change-type: patch
Changelog-entry: Enable kernel configs for USB_SERIAL and HFS for all devices


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
