### PR TITLE
resin-init-flasher: Tweak detection of internal media

### DIFF
--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -123,7 +123,7 @@ for d in $INTERNAL_DEVICE_KERNEL; do
         inform "$d is our install media, skip it..."
         continue
     fi
-    if [ -b "/dev/$d" ]; then
+    if fdisk -l | grep -q "$d"; then
         internal_dev=$d
         break
     fi


### PR DESCRIPTION
It is better to use fdisk to check that an internal media
is a suitable block device rather than using the shell
internal block testing feature. This is because there is
at least a case when the kernel lists an ASMT 2115 controller
as /dev/sda but that is not an actual drive so it cannot be
written to and the flashing procedure will error out.

Change-type: patch
Changelog-entry: Tweak how the flasher asserts that internal media is valid for being installed balena OS on
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
