### PR TITLE
Increase the NTP poll rate

### DIFF
--- a/meta-balena-common/recipes-connectivity/networkmanager/resin-files/99dhcp_ntp
+++ b/meta-balena-common/recipes-connectivity/networkmanager/resin-files/99dhcp_ntp
@@ -17,7 +17,7 @@ case "$action" in
 	if [[ -n $DHCP4_NTP_SERVERS ]]; then
 		# Tell chronyd to use this server
 		for ntp in ${DHCP4_NTP_SERVERS}; do
-			/usr/bin/chronyc add server $ntp || true
+			/usr/bin/chronyc add server $ntp minpoll 14 maxpoll 14 || true
 			/usr/bin/chronyc burst 4/10 "$ntp" || true
 		done
 		# Save the ntp server we received and interface information to a file

--- a/meta-balena-common/recipes-connectivity/resin-ntp-config/resin-ntp-config/resin-ntp-config
+++ b/meta-balena-common/recipes-connectivity/resin-ntp-config/resin-ntp-config/resin-ntp-config
@@ -16,7 +16,7 @@ fi
 
 if [ ! -z "$NTP_SERVERS" ]; then
 	for ntp in ${NTP_SERVERS}; do
-		/usr/bin/chronyc add server $ntp || true
+		/usr/bin/chronyc add server $ntp minpoll 14 maxpoll 14 || true
 		/usr/bin/chronyc burst 4/10 "$ntp" || true
 	done
 fi

--- a/meta-balena-common/recipes-core/chrony/files/chrony.conf
+++ b/meta-balena-common/recipes-core/chrony/files/chrony.conf
@@ -1,7 +1,7 @@
-server 0.resinio.pool.ntp.org iburst
-server 1.resinio.pool.ntp.org iburst
-server 2.resinio.pool.ntp.org iburst
-server 3.resinio.pool.ntp.org iburst
+server 0.resinio.pool.ntp.org iburst minpoll 14 maxpoll 14
+server 1.resinio.pool.ntp.org iburst minpoll 14 maxpoll 14
+server 2.resinio.pool.ntp.org iburst minpoll 14 maxpoll 14
+server 3.resinio.pool.ntp.org iburst minpoll 14 maxpoll 14
 driftfile /var/lib/chrony/drift
 maxupdateskew 100
 makestep 1 -1


### PR DESCRIPTION
This commit increases the default NTP poll rate to around 4 hours.

BalenaOS uses chronyd for time synchronization, and it allows to specify
a minpoll and maxpoll values per server with a power of two number of
seconds for the minimum and maximum polling time respectively.

With those constraints, the change set both limits to 2^14s (4.55h) for
all servers.

To allow fo backwards compatibility, when setting custom NTP servers the
maxpoll and minpoll rates can be configured in config.json for those
users who require the previous values.

Fixes #1780.

Change-type: patch
Changelog-entry: Increase NTP polling time to around 4.5 hours.
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
