### PR TITLE
packagegroup-resin-connectivity: Add wifi firmware for wl18xx

### DIFF
--- a/meta-balena-thud/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/meta-balena-thud/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -18,4 +18,5 @@ CONNECTIVITY_FIRMWARES_append = " \
     linux-firmware-iwlwifi-8265 \
     linux-firmware-rtl8188eu \
     linux-firmware-wl12xx \
+    linux-firmware-wl18xx \
     "

--- a/meta-balena-warrior/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/meta-balena-warrior/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -18,4 +18,5 @@ CONNECTIVITY_FIRMWARES_append = " \
     linux-firmware-iwlwifi-8265 \
     linux-firmware-rtl8188eu \
     linux-firmware-wl12xx \
+    linux-firmware-wl18xx \
     "


### PR DESCRIPTION
Since poky thud, the linux-firmware recipe in poky is packaging
the wl18xx firmware in its own package rather than add it in the
linux-firmware-wl12xx package.

Change-type: patch
Changelog-entry: Make sure to add in rootfs the wifi firmware for wl18xx
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
