### PR TITLE
Enable memory overcommit

### DIFF
--- a/meta-balena-common/recipes-core/systemd/systemd/balena-os-sysctl.conf
+++ b/meta-balena-common/recipes-core/systemd/systemd/balena-os-sysctl.conf
@@ -1,2 +1,3 @@
 fs.inotify.max_user_instances=512
 net.ipv4.ip_local_port_range=49152 65535
+vm.overcommit_memory=1


### PR DESCRIPTION
Move the memory overcommit settings from the Raspberry Pi integration
layer to meta-balena so it applies to all device types.

Fixes #1791

Change-type: patch
Changelog-entry: Enable memory overcommit
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
Related to https://github.com/balena-os/balena-raspberrypi/tree/alexgg/%23440-mem-overcommit