### PR TITLE
resolv.conf: Increase DNS client's timeout to 15 seconds

### DIFF
--- a/meta-balena-common/recipes-connectivity/dnsmasq/balena-files/resolv-conf.dnsmasq
+++ b/meta-balena-common/recipes-connectivity/dnsmasq/balena-files/resolv-conf.dnsmasq
@@ -1,2 +1,3 @@
 # we use dnsmasq at 127.0.0.2 so that user containers can run their own dns cache and forwarder and not conflict with dnsmasq on the host
 nameserver 127.0.0.2
+options timeout:15


### PR DESCRIPTION
The DNS clients (applications) resolver libraries use the timeout value in
/etc/resolv.conf to set the time between DNS attempts. The default is 5
secs which for slow networks like cellular mean lots of DNS requests on
a bandwidth sensitive channel.

This change modifies the default to 15 secs. This timeout only applies
when DNS servers are unresponsive so it will not affect the normal
functionality.

Fixes #1800

Change-type: patch
Changelog-entry: Increase DNS clients timeout to 15 seconds
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
