### PR TITLE
Disable password authentication when ssh keys have been set

### DIFF
--- a/meta-balena-common/recipes-connectivity/openssh/balena-files/sshd@.service
+++ b/meta-balena-common/recipes-connectivity/openssh/balena-files/sshd@.service
@@ -5,10 +5,11 @@ Requires=resin-state.service
 After=resin-state.service sshdgenkeys.service os-sshkeys.service
 
 [Service]
-Environment="SSHD_OPTS="
+Environment="SSHD_OPTS=" "SSHD_EXTRA_OPTS="
 EnvironmentFile=-/etc/default/ssh
+EnvironmentFile=-/home/root/.ssh/sshd.env
 ExecStartPre=-@SBINDIR@/ssh_keys_merger
-ExecStart=-/usr/sbin/sshd -i $SSHD_OPTS
+ExecStart=-/usr/sbin/sshd -i $SSHD_OPTS $SSHD_EXTRA_OPTS
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=10s

--- a/meta-balena-common/recipes-support/resin-vars/resin-vars/os-sshkeys
+++ b/meta-balena-common/recipes-support/resin-vars/resin-vars/os-sshkeys
@@ -61,8 +61,6 @@ if [ -n "$ssh_keys" ]; then
 		"$authorized_keys_path")" != "$authorized_keys" ]; then
 		echo "${authorized_keys}" > "$authorized_keys_path"
 		chmod "$authorized_keys_perm" "$authorized_keys_path"
-		echo 'SSHD_EXTRA_OPTS=-o PasswordAuthentication=no' > "$sshd_env_path"
-		chmod "$sshd_env_perm" "$sshd_env_path"
 		log "Done."
 	else
 		log "Custom SSH public keys already in place."
@@ -70,5 +68,15 @@ if [ -n "$ssh_keys" ]; then
 else
 	log "No custom SSH public keys configured."
 	[ ! -f "$authorized_keys_path" ] || rm -f "$authorized_keys_path"
+fi
+
+ssh_without_password="$(jq -r ".os.sshWithoutPassword" "$CONFIG_PATH")"
+
+if [ "$ssh_without_password" = "false" ]; then
+	log "Disabling SSH Password(less) Authentication..."
+	echo 'SSHD_EXTRA_OPTS=-o PasswordAuthentication=no' > "$sshd_env_path"
+	chmod "$sshd_env_perm" "$sshd_env_path"
+	log "Done."
+else
 	[ ! -f "$sshd_env_path" ] || rm -f "$sshd_env_path"
 fi

--- a/meta-balena-common/recipes-support/resin-vars/resin-vars/os-sshkeys
+++ b/meta-balena-common/recipes-support/resin-vars/resin-vars/os-sshkeys
@@ -21,6 +21,8 @@ tool=$(basename "$0")
 custom_ssh_public_keys=".os.sshKeys"
 authorized_keys_path=/home/root/.ssh/authorized_keys_local
 authorized_keys_perm="600"
+sshd_env_path=/home/root/.ssh/sshd.env
+sshd_env_perm="644"
 
 log () {
 	echo "$tool: $1"
@@ -59,6 +61,8 @@ if [ -n "$ssh_keys" ]; then
 		"$authorized_keys_path")" != "$authorized_keys" ]; then
 		echo "${authorized_keys}" > "$authorized_keys_path"
 		chmod "$authorized_keys_perm" "$authorized_keys_path"
+		echo 'SSHD_EXTRA_OPTS=-o PasswordAuthentication=no' > "$sshd_env_path"
+		chmod "$sshd_env_perm" "$sshd_env_path"
 		log "Done."
 	else
 		log "Custom SSH public keys already in place."
@@ -66,4 +70,5 @@ if [ -n "$ssh_keys" ]; then
 else
 	log "No custom SSH public keys configured."
 	[ ! -f "$authorized_keys_path" ] || rm -f "$authorized_keys_path"
+	[ ! -f "$sshd_env_path" ] || rm -f "$sshd_env_path"
 fi


### PR DESCRIPTION
Fixes #1058. The ssh daemon is started with the `PasswordAuthentication=no` option when an ssh key has been added to the config.json.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
