### PR TITLE
balena-vacuum-logs: Periodic vacuuming of log files

### DIFF
--- a/meta-balena-common/recipes-core/systemd/periodic-vacuum-logs.bb
+++ b/meta-balena-common/recipes-core/systemd/periodic-vacuum-logs.bb
@@ -1,0 +1,27 @@
+DESCRIPTION = "Periodic vacuum of log files"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = " \
+    file://periodic-vacuum-logs.timer \
+    file://periodic-vacuum-logs.service \
+    "
+
+inherit allarch systemd
+
+SYSTEMD_SERVICE_${PN} = " \
+    periodic-vacuum-logs.service \
+    periodic-vacuum-logs.timer \
+"
+
+do_patch[noexec] = "1"
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+do_build[noexec] = "1"
+
+do_install() {
+        install -d ${D}${systemd_unitdir}/system/
+        install -d ${D}${sysconfdir}/systemd/system/multi-user.target.wants/
+        install -m 0644 ${WORKDIR}/periodic-vacuum-logs.service ${D}${systemd_unitdir}/system/
+        install -m 0644 ${WORKDIR}/periodic-vacuum-logs.timer ${D}${systemd_unitdir}/system/
+}

--- a/meta-balena-common/recipes-core/systemd/periodic-vacuum-logs/periodic-vacuum-logs.service
+++ b/meta-balena-common/recipes-core/systemd/periodic-vacuum-logs/periodic-vacuum-logs.service
@@ -1,0 +1,5 @@
+[Unit]
+After=systemd-journald.service
+
+[Service]
+ExecStart=/bin/journalctl --vacuum-size=32M

--- a/meta-balena-common/recipes-core/systemd/periodic-vacuum-logs/periodic-vacuum-logs.timer
+++ b/meta-balena-common/recipes-core/systemd/periodic-vacuum-logs/periodic-vacuum-logs.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Periodic vacuum of journald logs
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-balena-common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-balena-common/recipes-core/systemd/systemd_%.bbappend
@@ -89,7 +89,7 @@ do_install_append() {
 
 FILES_udev += "${rootlibexecdir}/udev/resin_update_state_probe"
 
-RDEPENDS_${PN}_append = " resin-ntp-config util-linux"
+RDEPENDS_${PN}_append = " resin-ntp-config util-linux periodic-vacuum-logs"
 
 # Network configuration is managed by NetworkManager. ntp is managed by chronyd
 PACKAGECONFIG_remove = "resolved networkd timesyncd"


### PR DESCRIPTION
Daily vacuuming of log files to avoid the partition filling up if
corrupted files appear.

Fixes #1792

Change-type: patch
Changelog-entry: Add periodic vacuuming of journald log files
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
