### PR TITLE
update-resin-supervisor: Add support for offline update of supervisor

### DIFF
--- a/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/update-resin-supervisor
+++ b/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/update-resin-supervisor
@@ -17,6 +17,9 @@ Options:
 
   -t <SUPERVISOR TAG>, --supervisor-tag <SUPERVISOR TAG>
         Set supervisor tag to update to.
+
+  -f <FILE>, --file <FILE>
+        Update supervisor from docker image file.
 EOF
 }
 
@@ -43,6 +46,18 @@ while [ $# -gt 0 ]; do
                 exit 1
             fi
             UPDATER_SUPERVISOR_TAG=$2
+            shift
+            ;;
+        -f|--file)
+            if [ -z "$2" ]; then
+                echo "ERROR: \"$1\" argument needs a value."
+                exit 1
+            fi
+            if [ ! -s "$2" ]; then
+                echo "ERROR: \"$2\" file is invalid."
+                exit 1
+            fi
+            UPDATER_FILE=$2
             shift
             ;;
         *)
@@ -91,7 +106,16 @@ fi
 # The script will exit if curl does not get a valid response.
 # Getting data separately before reading it fixes error handling.
 echo "Getting image name and tag..."
-if [ -n "$API_ENDPOINT" ] && [ -n "$DEVICE_ID" ] && [ -n "$_device_api_key" ] && data=$(curl --silent --header "Authorization: Bearer $_device_api_key" --header "User-Agent:" --compressed "$API_ENDPOINT/v4/supervisor_release?\$select=supervisor_version,image_name&\$filter=should_manage__device/any(d:d/id%20eq%20$DEVICE_ID)" | jq -e -r '.d[0].supervisor_version,.d[0].image_name'); then
+if [ -f "$UPDATER_FILE" ]; then
+    echo "Loading supervisor image from file: $UPDATER_FILE."
+    loaded_image=$(balena load --quiet -i "$UPDATER_FILE" | cut -d: -f1 --complement | tr -d ' ')
+    image_name=${loaded_image%:*}
+    tag=${loaded_image##*:}
+    if [ -z "$tag" ] || [ -z "$image_name" ]; then
+        echo "ERROR: Failure in loading supervisor image from file."
+        error_handler "failure in loading supervisor image from file"
+    fi
+elif [ -n "$API_ENDPOINT" ] && [ -n "$DEVICE_ID" ] && [ -n "$_device_api_key" ] && data=$(curl --silent --header "Authorization: Bearer $_device_api_key" --header "User-Agent:" --compressed "$API_ENDPOINT/v4/supervisor_release?\$select=supervisor_version,image_name&\$filter=should_manage__device/any(d:d/id%20eq%20$DEVICE_ID)" | jq -e -r '.d[0].supervisor_version,.d[0].image_name'); then
     echo "Supervisor configuration found from API."
 
     if [ -n "$UPDATER_SUPERVISOR_TAG" ] || [ -n "$UPDATER_SUPERVISOR_IMAGE" ]; then
@@ -131,22 +155,21 @@ else
     tag=$UPDATER_SUPERVISOR_TAG
 fi
 
+# Try to stop old supervisor to prevent it deleting the intermediate images while downloading the new one
+echo "Stop supervisor..."
+systemctl stop resin-supervisor
+
 # Get image id of tag. This will be non-empty only in case it's already downloaded.
 echo "Getting image id..."
 imageid=$($DOCKER inspect -f '{{.Id}}' "$image_name:$tag") || imageid=""
 
 if [ -n "$imageid" ]; then
     echo "Supervisor $image_name:$tag already downloaded."
-    exit 0
+else
+    # Pull target version.
+    echo "Pulling supervisor $image_name:$tag..."
+    $DOCKER pull "$image_name:$tag"
 fi
-
-# Try to stop old supervisor to prevent it deleting the intermediate images while downloading the new one
-echo "Stop supervisor..."
-systemctl stop resin-supervisor
-
-# Pull target version.
-echo "Pulling supervisor $image_name:$tag..."
-$DOCKER pull "$image_name:$tag"
 
 $DOCKER rm --force resin_supervisor || true
 


### PR DESCRIPTION
This patch improves `update-resin-supervisor` script to allow offline updating
of supervisor using new option `-f <path/to/docker/image/file>`.
The docker image file can be generated with `docker save` command.

This is similar to the `hostapp-update -f` command.

Change-type: patch
Changelog-entry: Add support for offline update of supervisor
Signed-off-by: Bruno Binet <bruno.binet@gmail.com>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
