### PR TITLE
networkmanager: Fix a typo in a plugin path

### DIFF
--- a/meta-balena-common/recipes-connectivity/networkmanager/networkmanager_1.20.2.bb
+++ b/meta-balena-common/recipes-connectivity/networkmanager/networkmanager_1.20.2.bb
@@ -81,7 +81,7 @@ PACKAGECONFIG[bluez5] = "--enable-bluez5-dun,--disable-bluez5-dun,bluez5"
 # consolekit is not picked by shlibs, so add it to RDEPENDS too
 PACKAGECONFIG[consolekit] = "--with-session-tracking=consolekit,,consolekit,consolekit"
 PACKAGECONFIG[modemmanager] = "--with-modem-manager-1=yes,--with-modem-manager-1=no,modemmanager"
-PACKAGECONFIG[ppp] = "--enable-ppp,--disable-ppp,ppp,ppp"
+PACKAGECONFIG[ppp] = "--enable-ppp --with-pppd-plugin-dir=${libdir}/pppd/2.4.7,--disable-ppp,ppp,ppp"
 # Use full featured dhcp client instead of internal one
 PACKAGECONFIG[dhclient] = "--with-dhclient=${base_sbindir}/dhclient,,,dhcp-client"
 PACKAGECONFIG[dnsmasq] = "--with-dnsmasq=${bindir}/dnsmasq"


### PR DESCRIPTION
ppp version is 2.4.7. Without defining the right path, the path defaults
to v2.4.5 in NM configure scripts.

Lets pass it here to keep it correct.

Should not have any actual affect. NM plugin was built with reference
to the 2.4.7 headers. Just the directoy path would say 2.4.5 misleading
some debug effort

Sanity test on pi3

```
root@balena:~# find /usr/ | grep pppd
/usr/sbin/pppd
/usr/lib/pppd
/usr/lib/pppd/2.4.7
/usr/lib/pppd/2.4.7/nm-pppd-plugin.so
root@balena:~# 
```

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
