### PR TITLE
packagegroup-resin-connectivity: Add wireless-regdb-static to rootfs

### DIFF
--- a/meta-balena-common/recipes-core/packagegroups/packagegroup-resin-connectivity.bb
+++ b/meta-balena-common/recipes-core/packagegroups/packagegroup-resin-connectivity.bb
@@ -20,7 +20,6 @@ CONNECTIVITY_FIRMWARES ?= " \
 CONNECTIVITY_PACKAGES = " \
     ${NETWORK_MANAGER_PACKAGES} \
     avahi-daemon \
-    crda \
     dnsmasq \
     openvpn \
     resin-proxy-config \

--- a/meta-balena-thud/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/meta-balena-thud/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -19,4 +19,5 @@ CONNECTIVITY_FIRMWARES_append = " \
     linux-firmware-rtl8188eu \
     linux-firmware-wl12xx \
     linux-firmware-wl18xx \
+    wireless-regdb-static \
     "

--- a/meta-balena-warrior/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/meta-balena-warrior/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -19,4 +19,5 @@ CONNECTIVITY_FIRMWARES_append = " \
     linux-firmware-rtl8188eu \
     linux-firmware-wl12xx \
     linux-firmware-wl18xx \
+    wireless-regdb-static \
     "

--- a/meta-resin-pyro/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/meta-resin-pyro/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -1,3 +1,5 @@
+CONNECTIVITY_PACKAGES_append = " crda"
+
 CONNECTIVITY_FIRMWARES_append = " \
     linux-firmware-bcm43143 \
     linux-firmware-iwlwifi-135-6 \

--- a/meta-resin-rocko/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/meta-resin-rocko/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -1,3 +1,5 @@
+CONNECTIVITY_PACKAGES_append = " crda"
+
 CONNECTIVITY_FIRMWARES_append = " \
     linux-firmware-bcm43143 \
     linux-firmware-iwlwifi-135-6 \

--- a/meta-resin-sumo/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/meta-resin-sumo/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -1,3 +1,5 @@
+CONNECTIVITY_PACKAGES_append = " crda"
+
 CONNECTIVITY_FIRMWARES_append = " \
     linux-firmware-bcm43143 \
     linux-firmware-iwlwifi-135-6 \


### PR DESCRIPTION
This package adds to rootfs the regulatory database into /lib/firmware/regulatory.db which can be loaded by kernel versions >= v4.15

Changelog-entry: Add regulatory.db (Wireless Central Regulatory Domain Database) to rootfs so kernel versions >= v4.15 can load it
Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
