### PR TITLE
balena.service: Set systemd KillMode to process

### DIFF
--- a/meta-balena-common/recipes-containers/balena/balena/balena.service
+++ b/meta-balena-common/recipes-containers/balena/balena/balena.service
@@ -19,6 +19,7 @@ LimitNPROC=1048576
 LimitCORE=infinity
 WatchdogSec=360
 Restart=always
+KillMode=process
 
 [Install]
 Alias=balena-engine.service


### PR DESCRIPTION
We need to allow user containers to do some clean-up if they wish to on
reboot / shutdown through systemctl so let's add KillMode set to process
so that systemd won't directly kill the user containers first.

For reference see also upstream moby:
https://github.com/moby/moby/pull/23636/commits/
db435f526ac5703276ad1add28188c0c8c6e4c2a

Changelog-entry: Do not send SIGKILL directly to user containers (set KillMode=process in balena.service)
Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
