### PR TITLE
update-resin-supervisor: Allow to run any image locally available

### DIFF
--- a/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/update-resin-supervisor
+++ b/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/update-resin-supervisor
@@ -137,7 +137,6 @@ imageid=$($DOCKER inspect -f '{{.Id}}' "$image_name:$tag") || imageid=""
 
 if [ -n "$imageid" ]; then
     echo "Supervisor $image_name:$tag already downloaded."
-    exit 0
 fi
 
 # Try to stop old supervisor to prevent it deleting the intermediate images while downloading the new one


### PR DESCRIPTION
This commit removes the requirement of only running an image that has been
successfully pulled. If the specified image is available locally, let's
use it.

The process to run a local image would be:

* Create a tarball with "balena save"
* Load it locally with "balena load -i <tarball>"
* Tag it with "balena tag <image id> <repo>:<tag>
* Update resin-supervisor with:
```
update-resin-supervisor -i <repo> -i <tag>
```

This provides a way to perform local offline updates as requested in:
https://github.com/balena-os/meta-balena/pull/1827

Changelog-entry: Allow local resin-supervisor image updates
Changelog-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
