### PR TITLE
kernel-resin: Force not to include debugging information in kernel an…

### DIFF
--- a/meta-balena-common/classes/kernel-resin.bbclass
+++ b/meta-balena-common/classes/kernel-resin.bbclass
@@ -96,6 +96,7 @@ RESIN_CONFIGS ?= " \
     nf_tables \
     dummy \
     uinput \
+    no-debug-info \
     "
 
 #
@@ -287,6 +288,12 @@ RESIN_CONFIGS[no-logo] ?= " \
 RESIN_CONFIGS[compress-kmodules] ?= " \
     CONFIG_MODULE_COMPRESS=y \
     CONFIG_MODULE_COMPRESS_GZIP=y \
+    "
+
+#
+# Do not include debugging info in kernel and modules
+#
+RESIN_CONFIGS[no-debug-info] ?= " \
     CONFIG_DEBUG_INFO=n \
     "
 


### PR DESCRIPTION
…d modules

The DEBUG_INFO configuration option is currently bundled with
compressing the modules. This commit separated them in two different
items, and also disabled DEBUG_INFO by default instead of depending on
whatever specific device type configuration files speicify.

DEBUG_INFO increases the size of artifacts significantly and is only useful
for low level debugging in which case developers will know to enable it.

Changelog-entry: Force removal of kernel debug information
Changelog-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
