### PR TITLE
networkmanager: Use absolute path in drop-in

### DIFF
--- a/meta-balena-common/recipes-connectivity/networkmanager/resin-files/NetworkManager.conf.systemd
+++ b/meta-balena-common/recipes-connectivity/networkmanager/resin-files/NetworkManager.conf.systemd
@@ -3,7 +3,7 @@ Wants=resin-net-config.service bind-var-lib-NetworkManager.service chronyd.servi
 After=resin-net-config.service bind-var-lib-NetworkManager.service chronyd.service
 
 [Service]
-ExecStartPre=systemd-tmpfiles --remove /etc/tmpfiles.d/nm-tmpfiles.conf
+ExecStartPre=/bin/systemd-tmpfiles --remove /etc/tmpfiles.d/nm-tmpfiles.conf
 OOMScoreAdjust=-1000
 Restart=always
 RestartSec=10s


### PR DESCRIPTION
systemd requires executable paths to be absolute. This causes an error
in the system journal.

Change-type: patch
Signed-off-by: Sven Schwermer <sven.schwermer@disruptive-technologies.com>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
