### PR TITLE
balena-host: Ignore environment file if it does not exist

### DIFF
--- a/meta-balena-common/recipes-containers/balena/balena/balena-host.service
+++ b/meta-balena-common/recipes-containers/balena/balena/balena-host.service
@@ -9,7 +9,7 @@ ConditionVirtualization=!docker
 [Service]
 Type=notify
 Restart=always
-EnvironmentFile=/etc/docker/balenahost.env
+EnvironmentFile=-/etc/docker/balenahost.env
 ExecStart=/usr/bin/balenad --delta-data-root=/mnt/sysroot/active/balena --delta-storage-driver=@BALENA_STORAGE@ --log-driver=journald -s @BALENA_STORAGE@ --data-root=/mnt/sysroot/inactive/balena -H fd:// --pidfile=/var/run/balena-host.pid --exec-root=/var/run/balena-host --bip 10.114.101.1/24 --fixed-cidr=10.114.101.128/25 --iptables=false --max-download-attempts=10 --exec-opt native.cgroupdriver=systemd
 #Adjust OOMscore to -900 to make killing unlikely
 OOMScoreAdjust=-900


### PR DESCRIPTION
Instruct the service to ignore the environment file if it does not exist.
This avoids the service failing if the file does not exist.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
