### PR TITLE
update-resin-supervisor: short circuit if remote image cannot be fetched

### DIFF
--- a/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor.bb
+++ b/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor.bb
@@ -34,6 +34,7 @@ FILES_${PN} += " \
 
 RDEPENDS_${PN} = " \
 	balena \
+	bash \
 	coreutils \
 	curl \
 	healthdog \

--- a/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/update-resin-supervisor
+++ b/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/update-resin-supervisor
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o pipefail
 
@@ -131,23 +131,25 @@ else
     tag=$UPDATER_SUPERVISOR_TAG
 fi
 
+# Try to stop old supervisor to prevent it deleting the intermediate images while downloading the new one
+echo "Stop supervisor..."
+systemctl stop resin-supervisor
+
 # Get image id of tag. This will be non-empty only in case it's already downloaded.
 echo "Getting image id..."
 imageid=$($DOCKER inspect -f '{{.Id}}' "$image_name:$tag") || imageid=""
 
 if [ -n "$imageid" ]; then
     echo "Supervisor $image_name:$tag already downloaded."
+else
+    # Pull target version.
+    echo "Pulling supervisor $image_name:$tag..."
+    if $DOCKER pull "$image_name:$tag"; then
+        $DOCKER rm --force resin_supervisor || true
+    else
+        error_handler "supervisor pull failed"
+    fi
 fi
-
-# Try to stop old supervisor to prevent it deleting the intermediate images while downloading the new one
-echo "Stop supervisor..."
-systemctl stop resin-supervisor
-
-# Pull target version.
-echo "Pulling supervisor $image_name:$tag..."
-$DOCKER pull "$image_name:$tag"
-
-$DOCKER rm --force resin_supervisor || true
 
 # Store the tagged image string so resin-supervisor.service can pick it up
 sed -e "s|SUPERVISOR_IMAGE=.*|SUPERVISOR_IMAGE=$image_name|" -e "s|SUPERVISOR_TAG=.*|SUPERVISOR_TAG=$tag|" /etc/resin-supervisor/supervisor.conf > $UPDATECONF


### PR DESCRIPTION
Changelog-entry: update-resin-supervisor: short circuit if remote image cannot be fetched
HQ: https://github.com/balena-io/balena/issues/2108
Connects-to: #1869
Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
