### PR TITLE
resin-init: Move wlan power management setup to udev rule

### DIFF
--- a/meta-balena-common/recipes-core/resin-extra-udev-rules/files/79-wlan-power.rules
+++ b/meta-balena-common/recipes-core/resin-extra-udev-rules/files/79-wlan-power.rules
@@ -1,0 +1,1 @@
+ACTION=="add", KERNEL=="wl*", SUBSYSTEM=="net", RUN+="/usr/sbin/iw dev $name set power_save off"

--- a/meta-balena-common/recipes-core/resin-extra-udev-rules/resin-extra-udev-rules.bb
+++ b/meta-balena-common/recipes-core/resin-extra-udev-rules/resin-extra-udev-rules.bb
@@ -6,6 +6,7 @@ inherit allarch
 
 SRC_URI = " \
 	file://49-teensy.rules \
+	file://79-wlan-power.rules \
 	file://99-misc.rules \
 	"
 
@@ -15,4 +16,7 @@ do_install_append() {
 
 	# Install miscellaneous rules file
 	install -D -m 0644 ${WORKDIR}/99-misc.rules ${D}/lib/udev/rules.d/99-misc.rules
+
+	# Install wlan rules file
+	install -D -m 0644 ${WORKDIR}/79-wlan-power.rules ${D}/lib/udev/rules.d/79-wlan-power.rules
 }

--- a/meta-balena-common/recipes-support/resin-init/resin-init/resin-init
+++ b/meta-balena-common/recipes-support/resin-init/resin-init/resin-init
@@ -4,9 +4,4 @@ set -e
 echo "Board specific initialization..."
 /usr/bin/resin-init-board
 
-echo "Disable power management on wlan0..."
-if ! iw dev wlan0 set power_save off; then
-    echo "Failed to disable power save on wlan0."
-fi
-
 exit 0


### PR DESCRIPTION
resin-init has a hardcoded command to disable power management
on wlan0. This commit moves the logic to udev rule as there is
no guarantee wlan0 is the only or default wlan adapter in the system.

There seems to be no better way to identify a wlan device in udev
than KERNEL=="wl*" which should match both net.ifnames=0 (wlanX)
and net.ifnames=1 (wlpX).

Fixes #1422

Change-type: minor
Changelog-entry: Use udev for setting up wlan power management
Signed-off-by: Michal Toman <michalt@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
