### PR TITLE
initrdscripts: Use /tmp as bootparam_root storage

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/rootfs
+++ b/meta-balena-common/recipes-core/initrdscripts/files/rootfs
@@ -76,5 +76,7 @@ rootfs_run() {
     done
 
     # Move the /run mountpoint to the rootfs mountpoint
-    mount -n -o move /run "${ROOTFS_DIR}/run"
+    # For backwards compatibility we need to use /tmp instead of /run which is
+    # not available in older releases
+    mount -n -o move /run "${ROOTFS_DIR}/tmp"
 }

--- a/meta-balena-common/recipes-core/systemd/systemd/resin_update_state_probe
+++ b/meta-balena-common/recipes-core/systemd/systemd/resin_update_state_probe
@@ -29,7 +29,7 @@ parent=$3
 
 # If the UUIDs have been regenerated in this boot, the root UUID is stored
 # on a temporary file, otherwise fetch from the kernel command line
-new_root="/run/initramfs/bootparam_root"
+new_root="/tmp/initramfs/bootparam_root"
 if [ -f "${new_root}" ]; then
 	ruuid=$(cat "${new_root}" | cut -c6-)
 else


### PR DESCRIPTION
From v2.49, the hostapp-update utility creates the /run directory in the
root filesystem, however when huping from previous versions /run is not there.

This commit switches to use /tmp to store the new UUID for the root partition on
first boot after generating new UUIDs.

Changelog-entry: Use /tmp as bootparam_root storage
Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
