### PR TITLE
networkmanager: Set modem MTU correctly

### DIFF
--- a/meta-balena-common/recipes-connectivity/networkmanager/networkmanager/0001-wwan-Set-MTU-based-on-what-ModemManager-exposes.patch
+++ b/meta-balena-common/recipes-connectivity/networkmanager/networkmanager/0001-wwan-Set-MTU-based-on-what-ModemManager-exposes.patch
@@ -1,0 +1,38 @@
+From 03d8a98f7054bff544f1270f89d4a0ee97e1a591 Mon Sep 17 00:00:00 2001
+From: Sven Schwermer <sven.schwermer@disruptive-technologies.com>
+Date: Fri, 8 May 2020 08:49:49 +0200
+Subject: [PATCH] wwan: Set MTU based on what ModemManager exposes
+
+Signed-off-by: Sven Schwermer <sven.schwermer@disruptive-technologies.com>
+Upstream-Status: Accepted [99efe69f685534c7f9d22245d145543b7e970ca3]
+---
+ src/devices/wwan/nm-modem-broadband.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/devices/wwan/nm-modem-broadband.c b/src/devices/wwan/nm-modem-broadband.c
+index 216fedf..3a65a70 100644
+--- a/src/devices/wwan/nm-modem-broadband.c
++++ b/src/devices/wwan/nm-modem-broadband.c
+@@ -875,6 +875,7 @@ static_stage3_ip4_done (NMModemBroadband *self)
+ 	guint i;
+ 	guint32 ip4_route_table, ip4_route_metric;
+ 	NMPlatformIP4Route *r;
++	guint32 mtu_n;
+ 
+ 	g_assert (self->_priv.ipv4_config);
+ 	g_assert (self->_priv.bearer);
+@@ -946,6 +947,14 @@ static_stage3_ip4_done (NMModemBroadband *self)
+ 		}
+ 	}
+ 
++#if MM_CHECK_VERSION(1, 4, 0)
++	mtu_n = mm_bearer_ip_config_get_mtu (self->_priv.ipv4_config);
++	if (mtu_n) {
++		nm_ip4_config_set_mtu (config, mtu_n, NM_IP_CONFIG_SOURCE_WWAN);
++		_LOGI ("  MTU %u", mtu_n);
++	}
++#endif
++
+ out:
+ 	g_signal_emit_by_name (self, NM_MODEM_IP4_CONFIG_RESULT, config, error);
+ 	g_clear_error (&error);

--- a/meta-balena-common/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/meta-balena-common/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -11,6 +11,7 @@ SRC_URI_append = " \
     file://nm-tmpfiles.conf \
     file://balena-client-id.patch \
     file://remove-https-warning.patch \
+    file://0001-wwan-Set-MTU-based-on-what-ModemManager-exposes.patch \
     "
 
 RDEPENDS_${PN}_append = " \


### PR DESCRIPTION
Change-type: patch
Changelog-entry: Backport NM patch for setting modem MTU correctly
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
