### PR TITLE
busybox: Disable syslogd / klogd

### DIFF
--- a/meta-balena-common/recipes-core/busybox/busybox/balenaos.cfg
+++ b/meta-balena-common/recipes-core/busybox/busybox/balenaos.cfg
@@ -9,3 +9,7 @@ CONFIG_BC=y
 # Enable HTTPS for wget
 CONFIG_FEATURE_WGET_HTTPS=y
 CONFIG_FEATURE_WGET_OPENSSL=y
+# systemd-journald runs the syslog daemon. With busybox's syslogd, some
+# log messages will go to /var/log/messages and not to the journal.
+CONFIG_SYSLOGD=n
+CONFIG_KLOGD=n

--- a/meta-balena-common/recipes-core/busybox/busybox_%.bbappend
+++ b/meta-balena-common/recipes-core/busybox/busybox_%.bbappend
@@ -3,5 +3,8 @@ SRC_URI_append = " \
     file://defconfig \
     file://balenaos.cfg \
     "
+SRC_URI_remove = " \
+    file://syslog.cfg \
+    "
 
 RDEPENDS_${PN}_append = " openssl"


### PR DESCRIPTION
These features are covered by systemd-journald. With syslogd running,
some log messages end up in /var/log/messages and not in the journal. We
want all log messages to end up in the same place; the journal.

Changelog-entry: Disable syslogd and klogd in busybox
Signed-off-by: Sven Schwermer <sven.schwermer@disruptive-technologies.com>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
