### PR TITLE
networkmanager: Remove build warning

### DIFF
--- a/meta-balena-common/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/meta-balena-common/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -1,6 +1,6 @@
 inherit deploy
 
-FILESEXTRAPATHS_append := ":${THISDIR}/resin-files"
+FILESEXTRAPATHS_append := ":${THISDIR}/resin-files:${THISDIR}/${BPN}"
 
 SRC_URI_append = " \
     file://NetworkManager.conf.systemd \


### PR DESCRIPTION
Include BPN in the generic bbappends extra path to avoid the
following warning:

    WARNING: networkmanager_1.16.0.bb: Unable to get checksum for networkmanager SRC_URI entry 0001-wwan-Set-MTU-based-on-what-ModemManager-exposes.patch: file could not be found

Changelog-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
