### PR TITLE
update-resin-supervisor: Revert local resin-supervisor image updates

### DIFF
--- a/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/update-resin-supervisor
+++ b/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/update-resin-supervisor
@@ -131,24 +131,25 @@ else
     tag=$UPDATER_SUPERVISOR_TAG
 fi
 
-# Try to stop old supervisor to prevent it deleting the intermediate images while downloading the new one
-echo "Stop supervisor..."
-systemctl stop resin-supervisor
-
 # Get image id of tag. This will be non-empty only in case it's already downloaded.
 echo "Getting image id..."
 imageid=$($DOCKER inspect -f '{{.Id}}' "$image_name:$tag") || imageid=""
 
 if [ -n "$imageid" ]; then
     echo "Supervisor $image_name:$tag already downloaded."
+    exit 0
+fi
+
+# Try to stop old supervisor to prevent it deleting the intermediate images while downloading the new one
+echo "Stop supervisor..."
+systemctl stop resin-supervisor
+
+# Pull target version.
+echo "Pulling supervisor $image_name:$tag..."
+if $DOCKER pull "$image_name:$tag"; then
+    $DOCKER rm --force resin_supervisor || true
 else
-    # Pull target version.
-    echo "Pulling supervisor $image_name:$tag..."
-    if $DOCKER pull "$image_name:$tag"; then
-        $DOCKER rm --force resin_supervisor || true
-    else
-        error_handler "supervisor pull failed"
-    fi
+    error_handler "supervisor pull failed"
 fi
 
 # Store the tagged image string so resin-supervisor.service can pick it up


### PR DESCRIPTION
The change this commit reverts allowed to update with a locally
available image - but it also has the side effect of restarting the
supervisor even if no update is required and that has unintentional
consequences as https://github.com/balena-io/balena-supervisor/issues/1358

This commit reverts 646e4ae809375f4abf35c55cd580e2c62a8812e2

Changelog-entry: Revert allowing local resin-supervisor image updates
Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
