### PR TITLE
timesync: specify that default NTP options are pools

### DIFF
--- a/meta-balena-common/recipes-core/chrony/files/chrony.conf
+++ b/meta-balena-common/recipes-core/chrony/files/chrony.conf
@@ -1,7 +1,7 @@
-server 0.resinio.pool.ntp.org iburst minpoll 14 maxpoll 14
-server 1.resinio.pool.ntp.org iburst minpoll 14 maxpoll 14
-server 2.resinio.pool.ntp.org iburst minpoll 14 maxpoll 14
-server 3.resinio.pool.ntp.org iburst minpoll 14 maxpoll 14
+pool 0.resinio.pool.ntp.org iburst minpoll 14 maxpoll 14 maxsources 1
+pool 1.resinio.pool.ntp.org iburst minpoll 14 maxpoll 14 maxsources 1
+pool 2.resinio.pool.ntp.org iburst minpoll 14 maxpoll 14 maxsources 1
+pool 3.resinio.pool.ntp.org iburst minpoll 14 maxpoll 14 maxsources 1
 driftfile /var/lib/chrony/drift
 maxupdateskew 100
 makestep 1 -1


### PR DESCRIPTION
the `maxsources` directive is simply to maintain the current behavior of
resolving four servers for synchronization. as noted in chrony's docs:

> When a pool source is unreachable, marked as a falseticker, or has a distance larger than the limit set by the maxdistance directive, chronyd will try to replace the source with a newly resolved address from the pool.

Connects-to: #1852
Change-type: patch
Changelog-entry: Set chrony default servers as pools
Signed-off-by: Matthew McGinn <matthew@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
