### PR TITLE
use device UUID not ID where possible

### DIFF
--- a/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/update-resin-supervisor
+++ b/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/update-resin-supervisor
@@ -91,7 +91,7 @@ fi
 # The script will exit if curl does not get a valid response.
 # Getting data separately before reading it fixes error handling.
 echo "Getting image name and tag..."
-if [ -n "$API_ENDPOINT" ] && [ -n "$DEVICE_ID" ] && [ -n "$_device_api_key" ] && data=$(curl --silent --header "Authorization: Bearer $_device_api_key" --header "User-Agent:" --compressed "$API_ENDPOINT/v4/supervisor_release?\$select=supervisor_version,image_name&\$filter=should_manage__device/any(d:d/id%20eq%20$DEVICE_ID)" | jq -e -r '.d[0].supervisor_version,.d[0].image_name'); then
+if [ -n "$API_ENDPOINT" ] && [ -n "${DEVICE_UUID}" ] && [ -n "$_device_api_key" ] && data=$(curl --silent --header "Authorization: Bearer $_device_api_key" --header "User-Agent:" --compressed "${API_ENDPOINT}/v4/supervisor_release?\$select=supervisor_version,image_name&\$filter=should_manage__device/any(d:d/uuid%20eq%20${DEVICE_UUID})" | jq -e -r '.d[0].supervisor_version,.d[0].image_name'); then
     echo "Supervisor configuration found from API."
 
     if [ -n "$UPDATER_SUPERVISOR_TAG" ] || [ -n "$UPDATER_SUPERVISOR_IMAGE" ]; then

--- a/meta-balena-common/recipes-support/resin-device-progress/resin-device-progress/resin-device-progress
+++ b/meta-balena-common/recipes-support/resin-device-progress/resin-device-progress/resin-device-progress
@@ -62,15 +62,15 @@ if [ -z "$REGISTERED_AT" ]; then
     exit 1
 fi
 
-if [ -z "$DEVICE_ID" ]; then
-    echo "[ERROR] resin-device-progress : Device id (deviceId) missing from config file, provisioning progress cannot be reported."
+if [ -z "${DEVICE_UUID}" ]; then
+    echo "[ERROR] resin-device-progress : Device UUID missing from config file, provisioning progress cannot be reported."
     exit 1
 fi
 
 # If the user api key exists we use it instead of the deviceApiKey as it means we haven't done the key exchange yet
 _device_api_key=${PROVISIONING_API_KEY:-$DEVICE_API_KEY}
 
-curl -s -X PATCH "$API_ENDPOINT/v4/device($DEVICE_ID)" \
+curl -s -X PATCH "${API_ENDPOINT}/v4/device?\$filter=uuid%20eq%20'${DEVICE_UUID}'" \
      --header "Authorization: Bearer $_device_api_key" \
      -o "/var/log/provisioning-progress-curl-$PERCENTAGE.log" \
      --data-urlencode "provisioning_progress=$PERCENTAGE" \

--- a/meta-balena-common/recipes-support/resin-device-register/resin-device-register/resin-device-register
+++ b/meta-balena-common/recipes-support/resin-device-register/resin-device-register/resin-device-register
@@ -76,13 +76,12 @@ while true; do
 
         if [ -f ${PINNING_CONF} ]; then
             source "${PINNING_CONF}"
-            [[ -z $DEVICE_ID ]] && DEVICE_ID=$device_id
 
             status_code=$(curl -s -X PATCH -w "%{http_code}" \
                 --header "Authorization: Bearer $DEVICE_API_KEY" \
                 --output $PIN_LOG_FILE \
                 --data-urlencode "should_be_running__release=$RELEASE_ID" \
-                "$API_ENDPOINT/v4/device($DEVICE_ID)")
+                "$API_ENDPOINT/v4/device?\$filter=uuid%20eq%20'${UUID}'")
 
             if [ "$status_code" -eq 200 ]; then
                 echo "[INFO] resin-device-pinning: Pinned device ${UUID} to release ${RELEASE_ID}"


### PR DESCRIPTION
Changelog-entry: Use UUID rather than ID when communicating with API
HQ: https://github.com/balena-io/balena-io/issues/2227
Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
