### PR TITLE
os-helpers-fs: Extend matching root device fallback

### DIFF
--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
@@ -48,11 +48,12 @@ get_dev_label() {
 	lsblk -nlo label "${1}"
 }
 
-# Output the device name for the specified file system label.
+# Output the device path for the specified root filesystem id.
 # Arguments:
-#   1 - Filesystem label
-get_dev_path_from_label() {
-	dev=$(lsblk -nlo name,label | grep "$1" | cut -d ' ' -f1)
+#   1 - Filesystem id (label, partlabel, uuid, partuuid)
+#   2 - Filesystem id value
+get_dev_path() {
+	dev=$(lsblk -nlo name,"$1" | grep "$2" | cut -d ' ' -f1)
 	echo "/dev/$dev"
 }
 
@@ -70,9 +71,11 @@ get_cmdline_root_uuid() {
 			if [ "$opt" = "UUID" ]; then
 				echo "$p" | cut -d'=' -f3
 				return 0
-			elif [ "$opt" = "LABEL" ]; then
-				label=$(echo "$p" | cut -d'=' -f3)
-				get_dev_uuid "$(get_dev_path_from_label "${label}")"
+			elif [ "$opt" = "LABEL" ] ||
+			     [ "$opt" = "PARTUUID" ] ||
+			      [ "$opt" = "PARTLABEL" ] ; then
+				id=$(echo "$p" | cut -d'=' -f3)
+				get_dev_uuid "$(get_dev_path "${opt}" "${id}")"
 				return 0
 			fi
 		fi


### PR DESCRIPTION
Not all devices can fallback to specifying a booting root partition by
label, for example the beeaglebone green, so extend it to partuuid and
partlabel.

Change-type: patch
Changelog-entry: Fallback to partuuid/partlabel root device matching to support devices with closed source bootloaders
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
