### PR TITLE
resin-ntp-config: merge 'burst' command with 'add server' line

### DIFF
--- a/meta-balena-common/recipes-connectivity/resin-ntp-config/resin-ntp-config/resin-ntp-config
+++ b/meta-balena-common/recipes-connectivity/resin-ntp-config/resin-ntp-config/resin-ntp-config
@@ -16,8 +16,7 @@ fi
 
 if [ ! -z "$NTP_SERVERS" ]; then
 	for ntp in ${NTP_SERVERS}; do
-		/usr/bin/chronyc add server $ntp minpoll 14 maxpoll 14 || true
-		/usr/bin/chronyc burst 4/10 "$ntp" || true
+		/usr/bin/chronyc add server $ntp iburst minpoll 14 maxpoll 14 || true
 	done
 fi
 


### PR DESCRIPTION
When the user supplies an additional NTP server source which is a pool URL the 'burst' command may fail. This occurs when the pool URL resolves to a different IP addresses for the 'add server' and 'burst' commands.

To avoid this issue we can combine the burst functionality into the 'add server' command by using the 'iburst' option. Although this option is not documented by the chronyc man page it has been present since v1.25 released in 2011.

This fix has been tested via the balenaOS (2.51.1+rev1) command line running on a RPi3.

Change-type: patch
Connects-to: #1903
Signed-off-by: Mark Corbin <mark@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
