### PR TITLE
busybox: Force to use the busybox version of hwclock

### DIFF
--- a/meta-balena-common/recipes-core/busybox/busybox_%.bbappend
+++ b/meta-balena-common/recipes-core/busybox/busybox_%.bbappend
@@ -5,3 +5,5 @@ SRC_URI_append = " \
     "
 
 RDEPENDS_${PN}_append = " openssl"
+
+ALTERNATIVE_PRIORITY[hwclock] = "100"


### PR DESCRIPTION
Otherwise, as util-linux has a higher default alternative priority, the
version in util-linux is chosen. It would seem they are exchangeable, but
the busybox version reportedly works even if the RTC interrupt line is not
connected.

Fixes #1936

Change-type: patch
Changelog-entry: Force choosing busybox-hwclock over util-linux-hwclock
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
