### PR TITLE
systemd: Simplify zram swap unit dependencies to avoid ordering cycle

### DIFF
--- a/meta-balena-common/recipes-core/systemd/systemd/dev-zram0.swap
+++ b/meta-balena-common/recipes-core/systemd/systemd/dev-zram0.swap
@@ -1,6 +1,7 @@
 [Unit]
 Description=Enable compressed swap in memory using zram
-After=systemd-udev-trigger.service systemd-udevd.service systemd-udev-settle.service
+After=systemd-udev-settle.service
+DefaultDependencies=no
 
 [Swap]
 What=/dev/zram0


### PR DESCRIPTION
The default dependency:

Before=swap.target

Causes randomly appearing ordering cycles that leave the system in not
functioning states.

Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
