### PR TITLE
provisioning: provide base supervisor_version during provision

### DIFF
--- a/meta-balena-common/recipes-support/resin-device-register/resin-device-register/resin-device-register
+++ b/meta-balena-common/recipes-support/resin-device-register/resin-device-register/resin-device-register
@@ -41,6 +41,7 @@ done
 
 # shellcheck disable=SC2086
 source /usr/sbin/resin-vars $RESIN_VARS_ARGS
+source /etc/resin-supervisor/supervisor.conf
 
 if [ -z "$API_ENDPOINT" ] || [ -z "$CONFIG_PATH" ]; then
     echo "[ERROR] resin-device-register : Please set API_ENDPOINT and CONFIG_PATH environment variables."
@@ -60,6 +61,7 @@ while true; do
                         --data-urlencode "device_type=$DEVICE_TYPE" \
                         --data-urlencode "uuid=$UUID" \
                         --data-urlencode "api_key=$DEVICE_API_KEY" \
+                        --data-urlencode "supervisor_version=${SUPERVISOR_TAG}" \
                         "$API_ENDPOINT/device/register")
 
             if [ "$status_code" -eq 201 ]; then


### PR DESCRIPTION
In order to get closer to formally requiring a target supervisor release
in the model, we should expand our provisioning process to provide the
initial supervisor_version metadata. This connects back to tri-app.

Depends-on: https://github.com/balena-io/open-balena-api/pull/394
HQ: https://github.com/balena-io/balena-io/pull/2177
Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
