### PR TITLE
Add LZ4 support config for older kernels

### DIFF
--- a/meta-balena-common/classes/kernel-resin.bbclass
+++ b/meta-balena-common/classes/kernel-resin.bbclass
@@ -451,6 +451,12 @@ RESIN_CONFIGS[zram] = " \
     CONFIG_CRYPTO_LZ4=y \
     "
 
+# Kernel versions between 4.0 and 4.9
+# need this for lz4 support
+RESIN_CONFIGS_DEPS[zram] = " \
+    CONFIG_ZRAM_LZ4_COMPRESS=y \
+"
+
 # USB Modem (CDC ACM) support
 RESIN_CONFIGS[cdc-acm] = " \
     CONFIG_USB_ACM=m \


### PR DESCRIPTION
Kernel versions between 4.0 and 4.9 use
CONFIG_ZRAM_LZ4_COMPRESS, whereas newer ones
use CONFIG_CRYPTO_LZ4.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
