### PR TITLE
resin-supervisor: Create required directories before launch

### DIFF
--- a/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/start-resin-supervisor
+++ b/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/start-resin-supervisor
@@ -72,6 +72,9 @@ runSupervisor() {
     if [ ! -d "/resin-data/resin-supervisor" ]; then
 	    mkdir -p "/resin-data/resin-supervisor"
     fi
+    if [ ! -d "/var/log/supervisor-log" ]; then
+	    mkdir -p "/var/log/supervisor-log"
+    fi
     balena rm --force resin_supervisor || true
     balena run --privileged --name resin_supervisor \
         --restart=always \


### PR DESCRIPTION
On commit a4ce26caadabcb1e87d944d78218cc32c579914e the supervisor moved
from using --volume to using --mount to avoid the implicit creation of
directories instead of files.

However, in the case where the mount referred to a directory, these have
to exist in the rootfs beforehand as --mount will not create them.

This commit checks for the existence of the /var/log/supervisor-log
directory and creates it if required.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
