### PR TITLE
balena-supervisor: Update to v11.9.6

### DIFF
--- a/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor.inc
+++ b/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor.inc
@@ -17,4 +17,4 @@ SUPERVISOR_REPOSITORY_x86-64 ?= "balena/amd64-supervisor"
 SUPERVISOR_REPOSITORY_intel-quark ?= "balena/i386-nlp-supervisor"
 
 # Balena supervisor default tag
-SUPERVISOR_TAG ?= "v11.9.4"
+SUPERVISOR_TAG ?= "v11.9.6"


### PR DESCRIPTION
Update balena-supervisor from 11.9.4 to 11.9.6

Change-type: patch
Backport-to: next
Signed-off-by: Rich Bayliss <rich@balena.io>
Signed-off-by: Cameron Diver <cameron@balena.io>
