### PR TITLE
Use separate service for loading healthcheck image

### DIFF
--- a/meta-balena-common/recipes-containers/balena/balena/balena-healthcheck-image-load.service
+++ b/meta-balena-common/recipes-containers/balena/balena/balena-healthcheck-image-load.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Load balena healthcheck image
+After=balena.service
+Requires=balena.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c '/usr/lib/balena/balena-healthcheck-image-load'
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-balena-common/recipes-containers/balena/balena/balena.service
+++ b/meta-balena-common/recipes-containers/balena/balena/balena.service
@@ -10,7 +10,6 @@ Type=notify
 Restart=always
 SyslogIdentifier=balenad
 ExecStart=/usr/bin/healthdog --healthcheck=/usr/lib/balena/balena-healthcheck /usr/bin/balenad --experimental --log-driver=journald -s @BALENA_STORAGE@ -H fd:// -H unix:///var/run/balena.sock -H unix:///var/run/balena-engine.sock --dns 10.114.102.1 --bip 10.114.101.1/24 --fixed-cidr=10.114.101.0/25 --max-download-attempts=10 --exec-opt native.cgroupdriver=systemd
-ExecStartPost=/bin/bash -c '/usr/lib/balena/balena-healthcheck-image-load &'
 #Adjust OOMscore to -900 to make killing unlikely
 OOMScoreAdjust=-900
 MountFlags=slave

--- a/meta-balena-common/recipes-containers/balena/balena_git.bb
+++ b/meta-balena-common/recipes-containers/balena/balena_git.bb
@@ -22,6 +22,7 @@ SRC_URI = "\
 	file://balena-host.socket \
 	file://balena-healthcheck \
 	file://balena-healthcheck-image-load \
+	file://balena-healthcheck-image-load.service \
 	file://var-lib-docker.mount \
 	file://balena.conf.systemd \
 	file://balena-tmpfiles.conf \
@@ -35,7 +36,7 @@ SECURITY_CFLAGS = "${SECURITY_NOPIE_CFLAGS}"
 SECURITY_LDFLAGS = ""
 
 SYSTEMD_PACKAGES = "${PN}"
-SYSTEMD_SERVICE_${PN} = "balena.service balena-host.socket var-lib-docker.mount"
+SYSTEMD_SERVICE_${PN} = "balena.service balena-host.socket var-lib-docker.mount balena-healthcheck-image-load.service"
 GO_IMPORT = "import"
 USERADD_PACKAGES = "${PN}"
 GROUPADD_PARAM_${PN} = "-r balena-engine"
@@ -150,6 +151,7 @@ do_install() {
 	install -m 0644 ${S}/src/import/contrib/init/systemd/balena-engine.socket ${D}/${systemd_unitdir}/system
 
 	install -m 0644 ${WORKDIR}/balena.service ${D}/${systemd_unitdir}/system
+	install -m 0644 ${WORKDIR}/balena-healthcheck-image-load.service ${D}/${systemd_unitdir}/system
 	sed -i "s/@BALENA_STORAGE@/${BALENA_STORAGE}/g" ${D}${systemd_unitdir}/system/balena.service
 
 	install -m 0644 ${WORKDIR}/balena-host.service ${D}/${systemd_unitdir}/system


### PR DESCRIPTION
In rocko, systemd kills any script started in background,
same thing happening to children that get re-parented.

One solution is to use a separate service file for
starting the healtcheck image load script, after balena.service
was started.

This PR replaces https://github.com/balena-os/meta-balena/pull/1858 , which was older and open against the development branch.

Change that added the necessity of this PR is https://github.com/balena-os/meta-balena/commit/4ec47419b97cf5ca6fe15436a32348e1dc7b5d9d

As a difference from the old PR, added "Requires=balena.service".

The original healthcheck script already waits for the balena service to become active: https://github.com/balena-os/meta-balena/blob/master/meta-balena-common/recipes-containers/balena/balena/balena-healthcheck-image-load#L5

Tested on rocko based setup of TX2 carrier board, hup from 2.45.1 to 2.53.4 + this PR.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
