### PR TITLE
modemmanager: add u-blox-modeswitch scripts

### DIFF
--- a/meta-balena-common/recipes-connectivity/modemmanager/balena-files/77-mm-u-blox-modeswitch.rules
+++ b/meta-balena-common/recipes-connectivity/modemmanager/balena-files/77-mm-u-blox-modeswitch.rules
@@ -1,0 +1,5 @@
+ACTION!="add|change", GOTO="modeswitch_rules_end"
+
+KERNEL=="ttyACM*", ATTRS{idVendor}=="1546", ATTRS{idProduct}=="1146", TAG+="systemd", ENV{SYSTEMD_WANTS}="u-blox-switch@'%E{DEVNAME}'.service"
+
+LABEL="modeswitch_rules_end"

--- a/meta-balena-common/recipes-connectivity/modemmanager/balena-files/u-blox-switch.sh
+++ b/meta-balena-common/recipes-connectivity/modemmanager/balena-files/u-blox-switch.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+MODEM_TTY_PATH=$1
+
+while true; do
+        echo -e "AT+UUSBCONF=2,\"ECM\"\r\n" > $MODEM_TTY_PATH
+        sleep 2
+        echo -e "AT+CFUN=1,1\r\n" > $MODEM_TTY_PATH
+        sleep 20
+        if lsusb | grep "1546:1143" > /dev/null; then # test if modem is in ECM mode
+                echo "Succesfully switched modem mode"
+                reboot
+        fi
+done

--- a/meta-balena-common/recipes-connectivity/modemmanager/balena-files/u-blox-switch@.service
+++ b/meta-balena-common/recipes-connectivity/modemmanager/balena-files/u-blox-switch@.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Switch u-blox modem from RNDIS to ECM mode
+Before=ModemManager.service NetworkManager.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/u-blox-switch.sh %I

--- a/meta-balena-common/recipes-connectivity/modemmanager/modemmanager_%.bbappend
+++ b/meta-balena-common/recipes-connectivity/modemmanager/modemmanager_%.bbappend
@@ -4,21 +4,31 @@ SYSTEMD_AUTO_ENABLE = "enable"
 SRC_URI_append = " \
     file://77-mm-huawei-configuration.rules \
     file://mm-huawei-configuration-switch.sh \
+    file://77-mm-u-blox-modeswitch.rules \
+    file://u-blox-switch@.service \
+    file://u-blox-switch.sh \
     file://ModemManager.conf.systemd \
 "
 
 PACKAGECONFIG_remove = "polkit"
 
 do_install_append() {
-    install -d ${D}/lib/udev/rules.d/
-    install -m 0644 ${WORKDIR}/77-mm-huawei-configuration.rules ${D}/lib/udev/rules.d/
-    install -m 0755 ${WORKDIR}/mm-huawei-configuration-switch.sh ${D}/lib/udev/
-
-    install -d ${D}${sysconfdir}/systemd/system/ModemManager.service.d
-    install -m 0644 ${WORKDIR}/ModemManager.conf.systemd ${D}${sysconfdir}/systemd/system/ModemManager.service.d/ModemManager.conf
+    install -d ${D}${base_libdir}/udev/rules.d/
+    install -m 0644 ${WORKDIR}/77-mm-huawei-configuration.rules ${D}${base_libdir}/udev/rules.d/
+    install -m 0755 ${WORKDIR}/mm-huawei-configuration-switch.sh ${D}${base_libdir}/udev/
+    install -m 0644 ${WORKDIR}/77-mm-u-blox-modeswitch.rules ${D}${base_libdir}/udev/rules.d
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/u-blox-switch.sh ${D}${bindir}
+    install -d ${D}${systemd_unitdir}/system/ModemManager.service.d
+    install -m 0644 ${WORKDIR}/ModemManager.conf.systemd ${D}${systemd_unitdir}/system/ModemManager.service.d/ModemManager.conf
+    install -m 0644 ${WORKDIR}/u-blox-switch@.service ${D}${systemd_unitdir}/system
 }
 
 FILES_${PN} += " \
-    /lib/udev/rules.d/77-mm-huawei-configuration.rules \
-    /lib/udev/mm-huawei-configuration-switch.sh \
+    ${base_libdir}/udev/rules.d/77-mm-huawei-configuration.rules \
+    ${base_libdir}/udev/mm-huawei-configuration-switch.sh \
+    ${base_libdir}/udev/rules.d/77-mm-u-blox-modeswitch.rules \
+    ${systemd_unitdir}/system/u-blox-switch@.service \
+    ${bindir}/u-blox-switch.sh \
+    ${systemd_unitdir}/system/ModemManager.service.d/ModemManager.conf \
     "


### PR DESCRIPTION
Add the u-blox-modeswitch scripts to modemmanager. The scripts are generic and therefore it makes sense to provide them as part of meta-balena instead of balena-raspberrypi.

Change-type: patch
Connects-to: #1789
Connects-to: #510 (in balena-raspberrypi)
Signed-off-by: Mark Corbin <mark@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
