### PR TITLE
Respect balenaRootCA system-wide

### DIFF
--- a/meta-balena-common/recipes-support/ca-certificates/ca-certificates/extract-balena-ca
+++ b/meta-balena-common/recipes-support/ca-certificates/ca-certificates/extract-balena-ca
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+CONFIG_JSON="/mnt/boot/config.json"
+JSON_CA_KEY=".balenaRootCA"
+BALENA_CA_FILE="/usr/share/ca-certificates/balena/balenaRootCA.crt"
+CRTDIR_BIND_SERVICE="bind-etc-ssl-certs.service"
+
+. /usr/libexec/os-helpers-logging
+
+RAW_DEST_FILE=$(mktemp)
+if ! jq -e -r "${JSON_CA_KEY}" < "${CONFIG_JSON}" > "${RAW_DEST_FILE}" 2> /dev/null
+then
+  info "The config.json file does not contain custom CA"
+  rm -f "${RAW_DEST_FILE}"
+  exit 0
+fi
+
+info "Found custom CA in config.json"
+
+DEST_FILE=$(mktemp)
+if ! base64 -d "${RAW_DEST_FILE}" > "${DEST_FILE}" 2> /dev/null
+then
+  rm -f "${RAW_DEST_FILE}" "${DEST_FILE}"
+  fail "Unable to base64-decode the custom CA from config.json"
+fi
+
+if diff "${DEST_FILE}" "${BALENA_CA_FILE}" > /dev/null 2>&1
+then
+  info "The custom CA from config.json is already installed"
+  rm -f "${RAW_DEST_FILE}" "${DEST_FILE}"
+  exit 0
+fi
+
+info "Adding the custom CA from config.json"
+
+# Copy new CA to its place
+cp -a "${DEST_FILE}" "${BALENA_CA_FILE}"
+
+# Rebuild the CA bundle - for this we need to make /etc/ssl/certs writable
+if ! systemctl -q is-active "${CRTDIR_BIND_SERVICE}"
+then
+  systemctl start "${CRTDIR_BIND_SERVICE}"
+fi
+
+update-ca-certificates
+
+rm -f "${RAW_DEST_FILE}" "${DEST_FILE}"

--- a/meta-balena-common/recipes-support/ca-certificates/ca-certificates/extract-balena-ca.service
+++ b/meta-balena-common/recipes-support/ca-certificates/ca-certificates/extract-balena-ca.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Extract custom CA from config.json
+After=bind-usr-share-ca-certificates-balena.service
+Requires=bind-usr-share-ca-certificates-balena.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/extract-balena-ca
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-balena-common/recipes-support/ca-certificates/ca-certificates_%.bbappend
+++ b/meta-balena-common/recipes-support/ca-certificates/ca-certificates_%.bbappend
@@ -1,0 +1,32 @@
+FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
+
+inherit systemd
+
+SYSTEMD_SERVICE_${PN} = "extract-balena-ca.service"
+
+RDEPENDS_${PN}_class-target += "os-helpers-logging"
+
+SRC_URI_append = " \
+    file://extract-balena-ca \
+    file://extract-balena-ca.service \
+"
+
+do_install_append_class-target () {
+    # Create a drop-in directory for balena-controlled CAs
+    install -d ${D}/usr/share/ca-certificates/balena/
+
+    # Add a service to regenerate CA chain on update
+    install -d ${D}${bindir}/
+    install -m 0755 ${WORKDIR}/extract-balena-ca ${D}${bindir}/
+
+    install -d ${D}${systemd_unitdir}/system/
+    install -m 0644 ${WORKDIR}/extract-balena-ca.service ${D}${systemd_unitdir}/system/
+
+    # Make update-ca-certificates use our directory instead of the non-existing default
+    sed -i -e "s,^LOCALCERTSDIR=.*$,LOCALCERTSDIR=\$SYSROOT/usr/share/ca-certificates/balena," ${D}/usr/sbin/update-ca-certificates
+}
+
+FILES_${PN} += " \
+    ${bindir}/extract-balena-ca \
+    ${systemd_unitdir}/system/extract-balena-ca.service \
+"

--- a/meta-balena-common/recipes-support/resin-mounts/resin-mounts.inc
+++ b/meta-balena-common/recipes-support/resin-mounts/resin-mounts.inc
@@ -22,6 +22,8 @@ BINDMOUNTS += " \
 	/etc/NetworkManager/conf.d \
 	/etc/NetworkManager/system-connections \
 	/etc/udev/rules.d \
+	/etc/ssl/certs \
+	/usr/share/ca-certificates/balena \
 	/home/root/.rnd \
 	/var/lib/bluetooth \
 	/var/lib/NetworkManager \
@@ -63,6 +65,13 @@ do_compile () {
 		elif [ "$bindmount" = "/etc/udev/rules.d" ]; then
 			# This bind mount needs to be running before the udev service starts for os-udevrules
 			sed -i -e "/^Before=/s/\$/ systemd-udevd.service/" "$servicefile"
+		elif [ "$bindmount" = "/etc/ssl/certs" ]; then
+			# This bind should only be started when a custom CA file exists
+			sed -i -e "/^Conflicts=/s,\$,\nConditionDirectoryNotEmpty=/usr/share/ca-certificates/balena," "$servicefile"
+			# The custom CA file itself is in a bind-mounted directory, make
+			# sure that is mounted as well
+			sed -i -e "/^Requires=/s/\$/ bind-usr-share-ca-certificates-balena.service/" "$servicefile"
+			sed -i -e "/^After=/s/\$/ bind-usr-share-ca-certificates-balena.service/" "$servicefile"
 		fi
 	done
 }


### PR DESCRIPTION
We allow the user to specify a custom CA in the .balenaRootCA key
of config.json but at this moment this is only respected by
the supervisor. This commit adds it to the system-wide CA bundle
so that the CA is respected everywhere.

Fixes #1398

Change-type: minor
Signed-off-by: Michal Toman <michalt@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
