### PR TITLE
supervisor: allow supervisor updates without controlling the supervis…

### DIFF
--- a/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/update-resin-supervisor
+++ b/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/update-resin-supervisor
@@ -17,9 +17,13 @@ Options:
 
   -t <SUPERVISOR TAG>, --supervisor-tag <SUPERVISOR TAG>
         Set supervisor tag to update to.
+
+  -n, --no-start-stop-supervisor
+        Do not start/stop the supervisor.
 EOF
 }
 
+START_STOP_SUPERVISOR=1
 # Parse arguments
 while [ $# -gt 0 ]; do
     arg="$1"
@@ -45,9 +49,12 @@ while [ $# -gt 0 ]; do
             UPDATER_SUPERVISOR_TAG=$2
             shift
             ;;
+        -n|--no-start-stop-supervisor)
+            START_STOP_SUPERVISOR=0
+            shift
+            ;;
         *)
             echo "ERROR: Unrecognized option $1."
-            exit 1
             ;;
     esac
     shift
@@ -69,7 +76,9 @@ error_handler() {
 
     # If docker pull fails, start the old supervisor again and exit
     rm -rf $UPDATECONF
-    systemctl start resin-supervisor
+    if [ "${START_STOP_SUPERVISOR}" -eq 1 ]; then
+        systemctl start resin-supervisor
+    fi
     exit 1
 }
 
@@ -140,9 +149,11 @@ if [ -n "$imageid" ]; then
     exit 0
 fi
 
-# Try to stop old supervisor to prevent it deleting the intermediate images while downloading the new one
-echo "Stop supervisor..."
-systemctl stop resin-supervisor
+if [ "${START_STOP_SUPERVISOR}" -eq 1 ]; then
+    # Try to stop old supervisor to prevent it deleting the intermediate images while downloading the new one
+    echo "Stop supervisor..."
+    systemctl stop resin-supervisor
+fi
 
 # Pull target version.
 echo "Pulling supervisor $image_name:$tag..."
@@ -157,7 +168,9 @@ sed -e "s|SUPERVISOR_IMAGE=.*|SUPERVISOR_IMAGE=$image_name|" -e "s|SUPERVISOR_TA
 
 # Run supervisor with the device-type-specific options.
 # We give a specific name to the container to guarantee only one running.
-echo "Start supervisor..."
-systemctl start resin-supervisor
+if [ "${START_STOP_SUPERVISOR}" -eq 1 ]; then
+    echo "Start supervisor..."
+    systemctl start resin-supervisor
+fi
 
 sed -i -e "s|SUPERVISOR_IMAGE=.*|SUPERVISOR_IMAGE=$image_name|" -e "s|SUPERVISOR_TAG=.*|SUPERVISOR_TAG=$tag|" /etc/resin-supervisor/supervisor.conf


### PR DESCRIPTION
…or state

Recently the supervisor added a codepath that assumes no files underneath it will change during runtime.
OS update hooks can trigger a condition whereby the supervisor reboots the device during a HUP,
which in turn bricks the device.

Additionally, since unknown args cause this update to fail-closed,
remove that barrier to future-proof more flag expansion.

Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
