### PR TITLE
supervisor: fix supervisor startup when custom certs are involved

### DIFF
--- a/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/start-resin-supervisor
+++ b/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/start-resin-supervisor
@@ -52,7 +52,6 @@ configIsUnchanged() {
     SUPERVISOR_CONTAINER_ENV_JSON="$(balena inspect resin_supervisor | jq '.[0].Config.Env | map(.| { (.[0:index("=")]): .[index("=")+1:] }) | add')"
 
     if hasValueChanged "BOOT_MOUNTPOINT"       "$BOOT_MOUNTPOINT" "$SUPERVISOR_CONTAINER_ENV_JSON" || \
-    hasValueChanged "REGISTRY_ENDPOINT"     "$REGISTRY_ENDPOINT" "$SUPERVISOR_CONTAINER_ENV_JSON" || \
     hasValueChanged "MIXPANEL_TOKEN"        "$MIXPANEL_TOKEN" "$SUPERVISOR_CONTAINER_ENV_JSON" || \
     hasValueChanged "DELTA_ENDPOINT"        "$DELTA_ENDPOINT" "$SUPERVISOR_CONTAINER_ENV_JSON" || \
     hasValueChanged "LED_FILE"              "${LED_FILE}" "$SUPERVISOR_CONTAINER_ENV_JSON" || \

--- a/meta-balena-common/recipes-support/resin-vars/resin-vars/resin-vars
+++ b/meta-balena-common/recipes-support/resin-vars/resin-vars/resin-vars
@@ -52,12 +52,15 @@ RESIN_BOOT_MOUNTPOINT="/mnt/boot"
 
 # If config.json provides redefinitions for our vars let us rewrite their
 # runtime value
+# `REGISTRY_ENDPOINT` only required for custom certs until system-wide custom certs are supported/implemented, see
+# https://github.com/balena-os/meta-balena/issues/1398
 if [ -f $CONFIG_PATH ]; then
     eval "$(jq -r '@sh "
          API_ENDPOINT=\(.apiEndpoint // "")
          LISTEN_PORT=\(.listenPort // "")
          MIXPANEL_TOKEN=\(.mixpanelToken // "")
          DELTA_ENDPOINT=\(.deltaEndpoint // "")
+         REGISTRY_ENDPOINT=\(.registryEndpoint // "")
          CONFIG_HOSTNAME=\(.hostname // "")
          PERSISTENT_LOGGING=\(.persistentLogging // "")
          COUNTRY=\(.country // "")


### PR DESCRIPTION
In this commit
https://github.com/balena-os/meta-balena/commit/b3222e619bbeebc0a2bd9e7419a9d8ae12b34dce
we removed `REGISTRY_ENDPOINT` from our sourced variables. Since this
value is still used to pass custom certs to the supervisor, we need to
keep it around for the time being. It can be removed once again as soon
as https://github.com/balena-os/meta-balena/issues/1398 is addressed.

Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
