### PR TITLE
flasher-register: if no supervisor information found, report null

### DIFF
--- a/meta-balena-common/recipes-support/resin-device-register/resin-device-register/resin-device-register
+++ b/meta-balena-common/recipes-support/resin-device-register/resin-device-register/resin-device-register
@@ -61,7 +61,7 @@ while true; do
                         --data-urlencode "device_type=$DEVICE_TYPE" \
                         --data-urlencode "uuid=$UUID" \
                         --data-urlencode "api_key=$DEVICE_API_KEY" \
-                        --data-urlencode "supervisor_version=${SUPERVISOR_TAG}" \
+                        --data-urlencode "supervisor_version=${SUPERVISOR_TAG:-null}" \
                         "$API_ENDPOINT/device/register")
 
             if [ "$status_code" -eq 201 ]; then


### PR DESCRIPTION
In b791055f3f6ffd6cc5796569a7321c5060129eea I attempted to have flasher
images report their preconfigured supervisor version without a good
understanding of how flasher images work. As it turns out no supervisor
information is maintained in the flasher image itself, so until that is
sorted stop reporting a blank string for the supervisor version.

Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
