### PR TITLE
balena-unique-key: Ensure config.json is synced after replacing

### DIFF
--- a/meta-balena-common/recipes-support/balena-unique-key/balena-unique-key/balena-unique-key
+++ b/meta-balena-common/recipes-support/balena-unique-key/balena-unique-key/balena-unique-key
@@ -56,7 +56,7 @@ if [ -z "$key" ]; then
     generated_json=$(jq ".$key_name=\"$key\"" "$CONFIG_PATH")
     echo "$generated_json" > "$CONFIG_PATH.tmp"
     sync "$CONFIG_PATH.tmp"
-    mv "$CONFIG_PATH.tmp" "$CONFIG_PATH"
+    mv "$CONFIG_PATH.tmp" "$CONFIG_PATH" && sync
 else
     echo "[INFO] balena-unique-key : Device already has $key_name assigned."
 fi


### PR DESCRIPTION
Ensuring changes are flushed to the filesystem at this point
helps prevent config.json from becoming corrupt if power is cut.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
