### PR TITLE
linux-firmware: Package iwlwifi-cc-a0-48 firmware

### DIFF
--- a/meta-balena-common/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/meta-balena-common/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -59,3 +59,9 @@ PACKAGES =+ "${PN}-iwlwifi-3160"
 FILES_${PN}-iwlwifi-3160 = " \
     ${nonarch_base_libdir}/firmware/iwlwifi-3160-17.ucode \
 "
+
+PACKAGES =+ "${PN}-iwlwifi-cc-a0"
+
+FILES_${PN}-iwlwifi-cc-a0 = " \
+    ${nonarch_base_libdir}/firmware/iwlwifi-cc-a0-48.ucode \
+"


### PR DESCRIPTION
We add this fw on its own package so that boards can add it to
rootfs (for Microsoft Surface Go 2 more specifically)

Changelog-entry: Package iwlwifi-cc-a0-48 firmware separately
Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
