### PR TITLE
os-helpers-logging: Log to stderr rather than stdout

### DIFF
--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-logging
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-logging
@@ -23,7 +23,7 @@ ME=$(basename "$0")
 log () {
     _level="$1"
     _message="$2"
-    printf "[%s][%s] %s\n" "$ME" "$_level" "$_message"
+    printf "[%s][%s] %s\n" "$ME" "$_level" "$_message" >&2
 }
 
 fail () {


### PR DESCRIPTION
This is where the logs and error messages should go by default
as they are not part of the tool's output.

Change-Type: patch
Signed-off-by: Michal Toman <michalt@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
