### PR TITLE
kernel-modules-headers: Pack /lib/vdso/Makefile

### DIFF
--- a/meta-balena-common/recipes-devtools/kernel-modules-headers/files/gen_mod_headers
+++ b/meta-balena-common/recipes-devtools/kernel-modules-headers/files/gen_mod_headers
@@ -197,13 +197,16 @@ if [ "$karch" = "arm64" ] && [ -f "$karch_dir/include/asm/opcodes.h" ]; then
 	copy_mkdir "$target_dir" "./arch/arm/include/asm/opcodes.h"
 fi
 
-# copy module.lds and vdso.lds if they exist
+# copy module.lds, vdso.lds and Makefile if they exist
 if [ "$karch" = "arm64" ]; then
 	if [ -f "arch/arm64/kernel/module.lds" ]; then
 		copy_mkdir "$target_dir" "./arch/arm64/kernel/module.lds"
 	fi
 	if [ -f "arch/arm64/kernel/vdso/vdso.lds" ]; then
 		copy_mkdir "$target_dir" "./arch/arm64/kernel/vdso/vdso.lds"
+	fi
+	if [ -f "lib/vdso/Makefile" ]; then
+		copy_mkdir "$target_dir" "./lib/vdso/Makefile"
 	fi
 fi
 


### PR DESCRIPTION
For the updated 5.4 kernel or RPI4 , kernel-headers-test fails with
arch/arm64/kernel/vdso/Makefile lib/vdso/Makefile No such file or directory
make[1] *** No rule to make target 'lib/vdso/Makefile'.  Stop.
make *** [vdso_prepare] Error 2

when doing modules_pepare in the docker build

This patch adds /lib/vdso/Makefile to kernel-modules-headers
compressed archive

Change-type: patch
Changelog-entry: Pack /lib/vdso/Makefile in kernel-modules-headers
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
