### PR TITLE
initrdscripts: Wait for root device to come up in fsuuid script

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/fsuuidsinit
+++ b/meta-balena-common/recipes-core/initrdscripts/files/fsuuidsinit
@@ -30,6 +30,16 @@ fsuuidsinit_enabled() {
         return 1
     fi
 
+    # Wait for balena by-state symlinks to come up
+    # We only wait for resin-rootA here as we use it right away
+    # but we in fact assume the other symlinks are created as well
+    # wait4file does $2 loops of 100ms, therefore use 10 * roottimeout
+    timeout=${bootparam_roottimeout:-5}
+    if ! wait4file "/dev/disk/by-state/resin-rootA" "$((timeout * 10))"; then
+        error "Timeout while waiting for resin-root partition to be detected"
+        return 1
+    fi
+
     # Check whether UUIDs have already been regenerated
     uuid_prefix="$(get_dev_uuid "/dev/disk/by-state/resin-rootA" | cut -d "-" -f1)"
     if [ "${uuid_prefix}" = "ba1eadef" ]; then
@@ -44,12 +54,7 @@ fsuuidsinit_run() {
     # Generate new UUIDs only for resin-root filesystems
     # These are passed by the bootloaders, and used to generate the udev
     # by-state symlinks that are then used by everything else.
-    info "Generating new UUIDs for filesystems..."
-    if ! wait4file "/dev/disk/by-state/resin-rootA" "300" ||
-       ! wait4file "/dev/disk/by-state/resin-rootB" "300"; then
-        error "Timeout while waiting for resin-root partitions to be detected"
-        return
-    fi
+
     # Only rename the partitions mounted on the initramfs
     # the rest will be done at runtime mount in parallel with system boot
     # Include both resin-root partitions as the inactive one is access mounted


### PR DESCRIPTION
If the rootfs is on a slow-to-bring-up device (e.g. RPi4 + USB)
the fsuuidsinit_enabled() function may return before the balena symlinks
are created. This gets wrongly interpreted as missing UUIDs leading to
a chain of failures in the subsequent scripts.
This patch moves the symlink waiting loop from fsuuidsinit_run()
to fsuuids_enabled() before the first usage of the symlink.

Changelog-Entry: Wait for the root device to come up when necessary
Change-Type: patch
Signed-off-by: Michal Toman <michalt@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
