### PR TITLE
hostapp-update-hooks: Blacklist supervisor configuration backends

### DIFF
--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-bootfiles
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-bootfiles
@@ -14,6 +14,10 @@ bootfiles_blacklist="\
 	/config.json \
 	/config.txt \
 	/splash/balena-logo.png \
+	/extlinux.conf \
+	/extra_uEnv.txt \
+	/extra_grubEnv.txt \
+	/configfs.json \
 	"
 boot_mountpoint="/mnt/boot"
 DURING_UPDATE=${DURING_UPDATE:-0}


### PR DESCRIPTION
The hostapp update process should not overwrite the supervisor configuration
backend files to avoid the supervisor being forced to set the target state
after HUP and reboot the device during the rollback period.

This only applies to the host configuration files which are the only ones
that force a reboot.

Connects-to: https://github.com/balena-io/balena-supervisor/issues/1464
Change-type: patch
Changelog-entry: Blacklist supervisor configuration backend files during HUP
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
