### PR TITLE
systemd/timeinit: add fake.hwclock to maintain system time over reboots

### DIFF
--- a/meta-balena-common/recipes-core/chrony/files/chronyd.conf.systemd
+++ b/meta-balena-common/recipes-core/chrony/files/chronyd.conf.systemd
@@ -8,4 +8,4 @@ Type=simple
 Restart=always
 RestartSec=10s
 ExecStart=
-ExecStart=/usr/sbin/chronyd -s -d
+ExecStart=/usr/sbin/chronyd -d

--- a/meta-balena-common/recipes-core/systemd/timeinit.bb
+++ b/meta-balena-common/recipes-core/systemd/timeinit.bb
@@ -1,4 +1,4 @@
-# Copyright 2018 Resinio Ltd.
+# Copyright 2018-2020 Balena Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,23 +17,42 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 SRC_URI = " \
+    file://timeinit-buildtime.service \
+    file://timeinit-buildtime.sh \
+    file://fake-hwclock \
+    file://fake-hwclock.service \
+    file://fake-hwclock-update.service \
+    file://fake-hwclock-update.timer \
     file://timeinit-rtc.service \
-    file://timeinit-timestamp.service \
-    file://timeinit-timestamp.sh \
+    file://time-set.target \
+    file://time-sync.conf \
     "
 S = "${WORKDIR}"
 
 inherit allarch systemd
 
 SYSTEMD_SERVICE_${PN} = " \
+	timeinit-buildtime.service \
+	fake-hwclock.service \
+	fake-hwclock-update.service \
+	fake-hwclock-update.timer \
 	timeinit-rtc.service \
-	timeinit-timestamp.service \
+	time-set.target \
 	"
 
 do_install() {
+    install -d ${D}${base_sbindir}
     install -d ${D}${bindir}
     install -d ${D}${systemd_unitdir}/system
-    install -m 0775 ${WORKDIR}/timeinit-timestamp.sh ${D}${bindir}
-    install -c -m 0644 ${WORKDIR}/timeinit-timestamp.service ${D}${systemd_unitdir}/system
-    install -c -m 0644 ${WORKDIR}/timeinit-rtc.service ${D}${systemd_unitdir}/system
+    install -d ${D}/etc/fake-hwclock
+    install -d ${D}${sysconfdir}/systemd/system/time-sync.target.d/
+    install -m 0775 ${WORKDIR}/timeinit-buildtime.sh ${D}${bindir}
+    install -m 0775 ${WORKDIR}/fake-hwclock ${D}${base_sbindir}
+    install -m 0644 ${WORKDIR}/timeinit-buildtime.service ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/fake-hwclock.service ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/fake-hwclock-update.service ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/fake-hwclock-update.timer ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/timeinit-rtc.service ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/time-set.target ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/time-sync.conf ${D}${sysconfdir}/systemd/system/time-sync.target.d/
 }

--- a/meta-balena-common/recipes-core/systemd/timeinit/fake-hwclock
+++ b/meta-balena-common/recipes-core/systemd/timeinit/fake-hwclock
@@ -1,0 +1,75 @@
+#!/bin/sh
+#
+# Trivial script to load/save current contents of the kernel clock
+# from/to a file. Helpful as a *bootstrap* clock on machines where
+# there isn't a useful RTC driver (e.g. on development boards). Using
+# NTP is still recommended on these machines to get to real time sync
+# once more of the system is up and running.
+#
+# Copyright 2012-2016 Steve McIntyre <93sam@debian.org>
+# Copyright 2020 Balena Ltd.
+#
+# License: GPLv2, see COPYING
+
+. /usr/libexec/os-helpers-logging
+
+FILE=/etc/fake-hwclock/fake-hwclock.data
+TIMESTAMP=/etc/timestamp
+
+# Build time is used as a sanity check when saving
+if [ ! -f $TIMESTAMP ]; then
+	fail "$TIMESTAMP not found."
+fi
+
+BUILD_TIME=$(cat $TIMESTAMP)
+BUILD_EPOCH_SEC=$(date -d "${BUILD_TIME:0:8} ${BUILD_TIME:8:2}:${BUILD_TIME:10:2}:${BUILD_TIME:12:2}" '+%s')
+
+COMMAND=$1
+if [ "$COMMAND"x = ""x ] ; then
+	COMMAND="save"
+fi
+
+FORCE=false
+if [ "$2"x = "force"x ] ; then
+	FORCE=true
+fi
+
+case $COMMAND in
+	save)
+		if [ -e $FILE ] ; then
+			NOW_SEC=$(date -u '+%s')
+			if $FORCE || [ $NOW_SEC -ge $BUILD_EPOCH_SEC ] ; then
+				info "Saving system time to $FILE."
+				date -u '+%Y-%m-%d %H:%M:%S' > $FILE
+			else
+				info "Time travel detected!"
+				info "fake-hwclock release date is in the future: $(date -u -d@$BUILD_EPOCH_SEC)"
+				info "Current system time: $(date -u '+%Y-%m-%d %H:%M:%S')"
+				info "To force the saved system clock backwards in time anyway, use \"force\""
+			fi
+		else
+			info "Saving system time to $FILE."
+			date -u '+%Y-%m-%d %H:%M:%S' > $FILE
+		fi
+		;;
+	load)
+		if [ -e $FILE ] ; then
+			SAVED="$(cat $FILE)"
+			SAVED_SEC=$(date -u -d "$SAVED" '+%s')
+			NOW_SEC=$(date -u '+%s')
+			if $FORCE || [ $NOW_SEC -le $SAVED_SEC ] ; then
+				info "Setting system time from $FILE."
+				date -u -s "$SAVED"
+			else
+				info "Current system time: $(date -u '+%Y-%m-%d %H:%M:%S')"
+				info "fake-hwclock saved clock information is in the past: $SAVED"
+				info "To set system time to this saved clock anyway, use \"force\""
+			fi
+		else
+			info "Unable to read saved clock information: $FILE does not exist"
+		fi
+		;;
+	*)
+		fail "Unknown command $COMMAND"
+		;;
+esac

--- a/meta-balena-common/recipes-core/systemd/timeinit/fake-hwclock-update.service
+++ b/meta-balena-common/recipes-core/systemd/timeinit/fake-hwclock-update.service
@@ -1,4 +1,4 @@
-# Copyright 2018 Resinio Ltd.
+# Copyright 2020 Balena Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,17 +13,9 @@
 # limitations under the License.
 
 [Unit]
-Description=Initialize system clock from RTC
-ConditionVirtualization=!docker
-ConditionPathExists=/dev/rtc
+Description=Update the saved fake-hwclock file.
 DefaultDependencies=no
-After=systemd-udev-settle.service
-Before=chronyd.service
 
 [Service]
-Type=oneshot
-RemainAfterExit=yes
-ExecStart=/sbin/hwclock --hctosys
-
-[Install]
-WantedBy=time-sync.target
+Type=simple
+ExecStart=/sbin/fake-hwclock save

--- a/meta-balena-common/recipes-core/systemd/timeinit/fake-hwclock-update.timer
+++ b/meta-balena-common/recipes-core/systemd/timeinit/fake-hwclock-update.timer
@@ -1,4 +1,4 @@
-# Copyright 2018 Resinio Ltd.
+# Copyright 2020 Balena Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +13,11 @@
 # limitations under the License.
 
 [Unit]
-Description=Initialize system clock from build timestamp
-DefaultDependencies=no
-Before=chronyd.service
+Description=Periodically update the saved fake-hwclock.
+After=time-sync.target
 
-[Service]
-Type=oneshot
-RemainAfterExit=yes
-ExecStart=/bin/sh /usr/bin/timeinit-timestamp.sh
+[Timer]
+OnCalendar=hourly
 
 [Install]
-WantedBy=time-sync.target
+WantedBy=timers.target

--- a/meta-balena-common/recipes-core/systemd/timeinit/fake-hwclock.service
+++ b/meta-balena-common/recipes-core/systemd/timeinit/fake-hwclock.service
@@ -1,4 +1,4 @@
-# Copyright 2018 Resinio Ltd.
+# Copyright 2020 Balena Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,17 +13,19 @@
 # limitations under the License.
 
 [Unit]
-Description=Initialize system clock from RTC
-ConditionVirtualization=!docker
-ConditionPathExists=/dev/rtc
+Description=Restore/save the current clock
+Documentation=man:fake-hwclock(8)
 DefaultDependencies=no
-After=systemd-udev-settle.service
-Before=chronyd.service
+Requires=bind-etc-fake-hwclock.service
+After=bind-etc-fake-hwclock.service
+Before=sysinit.target systemd-journald.service systemd-fsck-root.service time-set.target
+Conflicts=shutdown.target
 
 [Service]
+ExecStart=/sbin/fake-hwclock load
+ExecStop=/sbin/fake-hwclock save
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/sbin/hwclock --hctosys
 
 [Install]
-WantedBy=time-sync.target
+WantedBy=time-set.target

--- a/meta-balena-common/recipes-core/systemd/timeinit/time-set.target
+++ b/meta-balena-common/recipes-core/systemd/timeinit/time-set.target
@@ -1,0 +1,13 @@
+#  SPDX-License-Identifier: LGPL-2.1+
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=System Time Set
+Documentation=man:systemd.special(7)
+RefuseManualStart=yes

--- a/meta-balena-common/recipes-core/systemd/timeinit/time-sync.conf
+++ b/meta-balena-common/recipes-core/systemd/timeinit/time-sync.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=time-set.target
+Wants=time-set.target

--- a/meta-balena-common/recipes-core/systemd/timeinit/timeinit-buildtime.service
+++ b/meta-balena-common/recipes-core/systemd/timeinit/timeinit-buildtime.service
@@ -1,4 +1,4 @@
-# Copyright 2018 Resinio Ltd.
+# Copyright 2020 Balena Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,17 +13,15 @@
 # limitations under the License.
 
 [Unit]
-Description=Initialize system clock from RTC
-ConditionVirtualization=!docker
-ConditionPathExists=/dev/rtc
+Description=Set the system clock from the build timestamp
 DefaultDependencies=no
-After=systemd-udev-settle.service
-Before=chronyd.service
+ConditionPathExists=/etc/timestamp
+Before=time-set.target fake-hwclock.service
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/sbin/hwclock --hctosys
+ExecStart=/bin/sh /usr/bin/timeinit-buildtime.sh
 
 [Install]
-WantedBy=time-sync.target
+WantedBy=time-set.target

--- a/meta-balena-common/recipes-core/systemd/timeinit/timeinit-buildtime.sh
+++ b/meta-balena-common/recipes-core/systemd/timeinit/timeinit-buildtime.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2018 Resinio Ltd.
+# Copyright 2020 Balena Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,22 +16,29 @@
 
 set -e
 
+. /usr/libexec/os-helpers-logging
+
 TIMESTAMP=/etc/timestamp
 
 if [ ! -f $TIMESTAMP ]; then
-	echo "[ERROR] $TIMESTAMP not found."
-	exit 1
+	fail "$TIMESTAMP not found."
 fi
+
+info "Setting system time from build time."
 
 SYS_TIME=$(date -u "+%4Y%2m%2d%2H%2M%2S")
 BUILD_TIME=$(cat $TIMESTAMP)
 
+OLD_SYS_TIME=$(date -d "${SYS_TIME:0:8} ${SYS_TIME:8:2}:${SYS_TIME:10:2}:${SYS_TIME:12:2}")
+NEW_SYS_TIME=$(date -d "${BUILD_TIME:0:8} ${BUILD_TIME:8:2}:${BUILD_TIME:10:2}:${BUILD_TIME:12:2}")
+
 if [ "$SYS_TIME" -lt "$BUILD_TIME" ]; then
-	echo "[INFO] Updating systemd time from build time."
 	BUILD_DATETIME="$(echo "$BUILD_TIME" | awk '{string=substr($0, 5, 8); print string;}')"
 	BUILD_YEAR="$(echo "$BUILD_TIME" | awk '{string=substr($0, 1, 4); print string;}')"
 	BUILD_SEC="$(echo "$BUILD_TIME" | awk '{string=substr($0, 13, 2); print string;}')"
-	date -u "${BUILD_DATETIME}${BUILD_YEAR}.${BUILD_SEC}"
+	date -u "${BUILD_DATETIME}${BUILD_YEAR}.${BUILD_SEC}" > /dev/null
+	info "Old time: $OLD_SYS_TIME"
+	info "New time: $NEW_SYS_TIME"
 else
-	echo "[INFO] Systemd date already updated."
+	info "System time already set."
 fi

--- a/meta-balena-common/recipes-support/resin-mounts/resin-mounts.inc
+++ b/meta-balena-common/recipes-support/resin-mounts/resin-mounts.inc
@@ -17,6 +17,7 @@ FILES_${PN} += " \
 
 BINDMOUNTS += " \
 	${sysconfdir}/ssh/hostkeys \
+	/etc/fake-hwclock \
 	/etc/hostname \
 	/etc/openvpn \
 	/etc/NetworkManager/conf.d \
@@ -72,6 +73,11 @@ do_compile () {
 			# sure that is mounted as well
 			sed -i -e "/^Requires=/s/\$/ bind-usr-share-ca-certificates-balena.service/" "$servicefile"
 			sed -i -e "/^After=/s/\$/ bind-usr-share-ca-certificates-balena.service/" "$servicefile"
+		elif [ "$bindmount" = "/etc/fake-hwclock" ]; then
+			# This bind mount needs to be running before the fake-hwclock service starts
+			sed -i -e "s/^\(Requires=\).*/\1resin-state.service resin-state-reset.service/" "$servicefile"
+			sed -i -e "s/^\(After=\).*/\1resin-state.service resin-state-reset.service/" "$servicefile"
+			sed -i -e "/^Before=/s/\$/ fake-hwclock.service/" "$servicefile"
 		fi
 	done
 }


### PR DESCRIPTION
In order to produce sensible timestamps for journald log messages:
a) the system time needs to be maintained correctly over a reboot, and
b) the system time needs to be set before journald is started.

Currently the system time is maintained over reboots on systems without an RTC using the last modified time of the chrony drift file. However there are a couple of issues with this approach:

a) /var/lib/chrony/ is not mounted early enough in the boot process to be available for setting the time before journald is started.
b) there is an issue with the current systemd dependencies that result in the last modified time of the drift file not being updated when the system is shutdown or rebooted (see #1995).

The Debian fake-hwclock service (as used by Raspberry Pi OS) has been added to overcome these issues.

The fake-hwclock service will save and restore the system time from the fake-hwclock.data file. A persistent r/w location (root-overlay/etc/fake-hwclock/) has been added to the resin-state partition for storage of this file. The system time is loaded from this file at boot and saved to it on shutdown. An additional timer service has been added to update the file on an hourly basis to cater for unexpected shutdown scenarios, e.g. power failure.

The timeinit-timestamp service has improved logging and has been renamed to timeinit-buildtime for clarity.

A new time-set.target has been added as per upstream systemd and the fake-hwclock and timeinit-buildtime services have been added to it.

The '-s' command line parameter has been dropped from chronyd as restoring time from the drift file is no longer necessary (and the restore from RTC functionality is already covered by the timeinit-rtc service).

Change-type: minor
Connects-to: #1367 #1919
Signed-off-by: Mark Corbin <mark@balena.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
