### PR TITLE
docker-disk: Allow expanding data filesystem on 2TB disks

### DIFF
--- a/meta-balena-common/recipes-containers/docker-disk/docker-disk.bb
+++ b/meta-balena-common/recipes-containers/docker-disk/docker-disk.bb
@@ -19,6 +19,7 @@ TARGET_REPOSITORY ?= "${SUPERVISOR_REPOSITORY}"
 TARGET_TAG ?= "${SUPERVISOR_TAG}"
 
 PARTITION_SIZE ?= "192"
+FS_BLOCK_SIZE ?= "4k"
 
 python () {
     import re
@@ -71,6 +72,7 @@ do_compile () {
 		-e PRIVATE_REGISTRY_USER="${PRIVATE_REGISTRY_USER}" \
 		-e PRIVATE_REGISTRY_PASSWORD="${PRIVATE_REGISTRY_PASSWORD}" \
 		-e PARTITION_SIZE="${PARTITION_SIZE}" \
+		-e FS_BLOCK_SIZE="${FS_BLOCK_SIZE}" \
 		-v /sys/fs/cgroup:/sys/fs/cgroup:ro -v ${B}:/build \
 		--name ${_container_name} ${_image_name}
 	$DOCKER rmi ${_image_name}

--- a/meta-balena-common/recipes-containers/docker-disk/files/entry.sh
+++ b/meta-balena-common/recipes-containers/docker-disk/files/entry.sh
@@ -62,4 +62,6 @@ wait "$(cat /var/run/docker.pid)" || true
 
 # Export the final data filesystem
 dd if=/dev/zero of=${BUILD}/resin-data.img bs=1M count=0 seek="${PARTITION_SIZE}"
-mkfs.ext4 -E lazy_itable_init=0,lazy_journal_init=0 -i 8192 -d ${DATA_VOLUME} -F ${BUILD}/resin-data.img
+
+# Usage type default, block size 4k defined in recipe. See https://github.com/tytso/e2fsprogs/issues/50
+mkfs.ext4 -E lazy_itable_init=0,lazy_journal_init=0 -T default -b ${FS_BLOCK_SIZE}  -i 8192 -d ${DATA_VOLUME} -F ${BUILD}/resin-data.img


### PR DESCRIPTION
Switch to 4k block size for the resin-data filesystem
so it can be expanded to sizes greater than 1023GiB.

Usage type set to 'default' to allow for the fs to
be optimized for expanding to sizes greater than 512MB.

See: https://github.com/tytso/e2fsprogs/issues/50

Change-type: patch
Changelog-entry: docker-disk: Allow expanding data filesystem on 2TB disks
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Tested on Pi4

Addresses: https://github.com/balena-os/meta-balena/issues/1977#issuecomment-669119901

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
