### PR TITLE
openvpn: add bash to RDEPENDS

### DIFF
--- a/meta-balena-common/recipes-connectivity/openvpn/openvpn_%.bbappend
+++ b/meta-balena-common/recipes-connectivity/openvpn/openvpn_%.bbappend
@@ -13,6 +13,7 @@ USERADD_PACKAGES = "${PN}"
 USERADD_PARAM_${PN} += "--system -d / -M --shell /bin/nologin openvpn"
 
 RDEPENDS_${PN} += "resin-vars"
+RDEPENDS_${PN} += "bash"
 
 SYSTEMD_SERVICE_${PN} = "openvpn.service prepare-openvpn.service"
 SYSTEMD_AUTO_ENABLE = "enable"


### PR DESCRIPTION
OpenVPN fails with:
    ERROR: openvpn-2.4.7-r0 do_package_qa: QA Issue:
    /etc/openvpn-misc/upscript.sh contained in package openvpn requires
    /bin/bash, but no providers found in RDEPENDS_openvpn? [file-rdeps]

Add bash to RDEPENDS to fix qa error.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph.kogut@gmail.com>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
