### PR TITLE
chrony: set the source UDP port for NTP requests to 123

### DIFF
--- a/meta-balena-common/recipes-core/chrony/files/chrony.conf
+++ b/meta-balena-common/recipes-core/chrony/files/chrony.conf
@@ -9,3 +9,4 @@ logchange 1
 maxdistance 16
 hwtimestamp *
 rtcsync
+acquisitionport 123


### PR DESCRIPTION
By default chrony uses a random UDP source port for each NTP request. This can cause problems with particular routers/firewalls (issues have been reported for the Phicomm KE 2P).

The chrony `acquisitionport` configuration setting has been added to the chrony.conf file to change the UDP source port for NTP requests to 123 (this is the same as the default source port used by both ntpdate and ntpd).

Tested on a RPi3 using balenaOS 2.58.6+rev4.

Change-type: patch
Connects-to: #2000
Signed-off-by: Mark Corbin <mark@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
