### PR TITLE
os-config: Add systemd timer to run once a day

### DIFF
--- a/meta-balena-common/recipes-core/os-config/os-config.inc
+++ b/meta-balena-common/recipes-core/os-config/os-config.inc
@@ -5,12 +5,14 @@ DEPENDS += "dbus openssl"
 SRC_URI += " \
 	file://os-config.json \
 	file://os-config.service \
+	file://os-config.timer \
 	file://os-config-devicekey.service \
 	file://0001-Adjust-CONFIG_JSON_FLASHER_PATH-based-on-OS-changes.patch \
 	"
 
 SYSTEMD_SERVICE_${PN} = " \
 	os-config.service \
+	os-config.timer \
 	os-config-devicekey.service \
 	"
 
@@ -20,6 +22,7 @@ do_install_append() {
 
 	install -d ${D}${systemd_unitdir}/system
 	install -c -m 0644 ${WORKDIR}/os-config.service ${D}${systemd_unitdir}/system
+	install -c -m 0644 ${WORKDIR}/os-config.timer ${D}${systemd_unitdir}/system
 	install -c -m 0644 ${WORKDIR}/os-config-devicekey.service ${D}${systemd_unitdir}/system
 
 }

--- a/meta-balena-common/recipes-core/os-config/os-config/os-config.timer
+++ b/meta-balena-common/recipes-core/os-config/os-config/os-config.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Periodic check for configuration changes
+
+[Timer]
+OnCalendar=daily
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
