### PR TITLE
kernel-resin: Configure uprobes support by default

### DIFF
--- a/meta-balena-common/classes/kernel-resin.bbclass
+++ b/meta-balena-common/classes/kernel-resin.bbclass
@@ -98,6 +98,7 @@ RESIN_CONFIGS ?= " \
     dummy \
     uinput \
     no-debug-info \
+    uprobes \
     "
 
 #
@@ -544,6 +545,11 @@ RESIN_CONFIGS[uinput] = " \
 # enable Analog Devices AD5446 and similar single channel DACs driver
 RESIN_CONFIGS[ad5446] = " \
     CONFIG_AD5446=m \
+"
+
+# enable user space probes support
+RESIN_CONFIGS[uprobes] = " \
+    CONFIG_UPROBE_EVENTS=y \
 "
 
 ###########


### PR DESCRIPTION
This is needed to make use of eBPF and all the debugging and extra
features it brings.

Change-type: patch
Changelog-entry: Enable kernel user space probes support
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
