### PR TITLE
systemd/timeinit: improve RTC handling at boot

### DIFF
--- a/meta-balena-common/recipes-core/systemd/timeinit.bb
+++ b/meta-balena-common/recipes-core/systemd/timeinit.bb
@@ -16,6 +16,8 @@ DESCRIPTION = "Initialize system clock at boot"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
+RDEPENDS_${PN} += "os-helpers-time"
+
 SRC_URI = " \
     file://timeinit-buildtime.service \
     file://timeinit-buildtime.sh \
@@ -24,6 +26,7 @@ SRC_URI = " \
     file://fake-hwclock-update.service \
     file://fake-hwclock-update.timer \
     file://timeinit-rtc.service \
+    file://timeinit-rtc.sh \
     file://time-set.target \
     file://time-sync.conf \
     "
@@ -47,6 +50,7 @@ do_install() {
     install -d ${D}/etc/fake-hwclock
     install -d ${D}${sysconfdir}/systemd/system/time-sync.target.d/
     install -m 0775 ${WORKDIR}/timeinit-buildtime.sh ${D}${bindir}
+    install -m 0775 ${WORKDIR}/timeinit-rtc.sh ${D}${bindir}
     install -m 0775 ${WORKDIR}/fake-hwclock ${D}${base_sbindir}
     install -m 0644 ${WORKDIR}/timeinit-buildtime.service ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/fake-hwclock.service ${D}${systemd_unitdir}/system

--- a/meta-balena-common/recipes-core/systemd/timeinit/fake-hwclock.service
+++ b/meta-balena-common/recipes-core/systemd/timeinit/fake-hwclock.service
@@ -18,7 +18,7 @@ Documentation=man:fake-hwclock(8)
 DefaultDependencies=no
 Requires=bind-etc-fake-hwclock.service
 After=bind-etc-fake-hwclock.service
-Before=sysinit.target systemd-journald.service systemd-fsck-root.service time-set.target
+Before=sysinit.target systemd-journald.service systemd-fsck-root.service time-set.target timeinit-rtc.service
 Conflicts=shutdown.target
 
 [Service]

--- a/meta-balena-common/recipes-core/systemd/timeinit/timeinit-buildtime.service
+++ b/meta-balena-common/recipes-core/systemd/timeinit/timeinit-buildtime.service
@@ -21,7 +21,7 @@ Before=time-set.target fake-hwclock.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/bin/sh /usr/bin/timeinit-buildtime.sh
+ExecStart=/usr/bin/timeinit-buildtime.sh
 
 [Install]
 WantedBy=time-set.target

--- a/meta-balena-common/recipes-core/systemd/timeinit/timeinit-buildtime.sh
+++ b/meta-balena-common/recipes-core/systemd/timeinit/timeinit-buildtime.sh
@@ -17,6 +17,7 @@
 set -e
 
 . /usr/libexec/os-helpers-logging
+. /usr/libexec/os-helpers-time
 
 TIMESTAMP=/etc/timestamp
 
@@ -26,19 +27,13 @@ fi
 
 info "Setting system time from build time."
 
-SYS_TIME=$(date -u "+%4Y%2m%2d%2H%2M%2S")
+SYS_TIME=$(get_system_time_as_timestamp)
 BUILD_TIME=$(cat $TIMESTAMP)
 
-OLD_SYS_TIME=$(date -d "${SYS_TIME:0:8} ${SYS_TIME:8:2}:${SYS_TIME:10:2}:${SYS_TIME:12:2}")
-NEW_SYS_TIME=$(date -d "${BUILD_TIME:0:8} ${BUILD_TIME:8:2}:${BUILD_TIME:10:2}:${BUILD_TIME:12:2}")
-
 if [ "$SYS_TIME" -lt "$BUILD_TIME" ]; then
-	BUILD_DATETIME="$(echo "$BUILD_TIME" | awk '{string=substr($0, 5, 8); print string;}')"
-	BUILD_YEAR="$(echo "$BUILD_TIME" | awk '{string=substr($0, 1, 4); print string;}')"
-	BUILD_SEC="$(echo "$BUILD_TIME" | awk '{string=substr($0, 13, 2); print string;}')"
-	date -u "${BUILD_DATETIME}${BUILD_YEAR}.${BUILD_SEC}" > /dev/null
-	info "Old time: $OLD_SYS_TIME"
-	info "New time: $NEW_SYS_TIME"
+	$(set_system_time_from_timestamp "$BUILD_TIME")
+	info "Old time: $(get_display_time_from_timestamp "$SYS_TIME")"
+	info "New time: $(get_display_time_from_timestamp "$BUILD_TIME")"
 else
 	info "System time already set."
 fi

--- a/meta-balena-common/recipes-core/systemd/timeinit/timeinit-rtc.service
+++ b/meta-balena-common/recipes-core/systemd/timeinit/timeinit-rtc.service
@@ -1,4 +1,4 @@
-# Copyright 2018 Resinio Ltd.
+# Copyright 2018-2020 Balena Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,17 +13,17 @@
 # limitations under the License.
 
 [Unit]
-Description=Initialize system clock from RTC
+Description=Set the system clock from RTC
 ConditionVirtualization=!docker
 ConditionPathExists=/dev/rtc
 DefaultDependencies=no
 After=systemd-udev-settle.service
-Before=chronyd.service
+Before=time-set.target
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/sbin/hwclock --hctosys
+ExecStart=/usr/bin/timeinit-rtc.sh
 
 [Install]
-WantedBy=time-sync.target
+WantedBy=time-set.target

--- a/meta-balena-common/recipes-core/systemd/timeinit/timeinit-rtc.sh
+++ b/meta-balena-common/recipes-core/systemd/timeinit/timeinit-rtc.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+#
+# Copyright 2020 Balena Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+. /usr/libexec/os-helpers-logging
+. /usr/libexec/os-helpers-time
+
+RTC_DEVICE=/dev/rtc
+
+# Don't bother updating or reporting errors for small differences.
+TIME_DIFF_THRESHOLD=2
+
+info "Setting system time from RTC."
+
+if [ ! -e "$RTC_DEVICE" ]; then
+	fail "RTC device ${RTC_DEVICE} not found."
+fi
+
+SYS_TIME=$(get_system_time_as_timestamp)
+RTC_TIME=$(get_hwclock_time_as_timestamp)
+
+TIME_DIFF=$(get_abs_time_diff_from_timestamps "$SYS_TIME" "$RTC_TIME")
+
+if [ "$SYS_TIME" -lt "$RTC_TIME" ]; then
+	if [ "$TIME_DIFF" -gt "$TIME_DIFF_THRESHOLD" ]; then
+		$(set_system_time_from_timestamp "$RTC_TIME")
+		info "Old time: $(get_display_time_from_timestamp "$SYS_TIME")"
+		info "New time: $(get_display_time_from_timestamp "$RTC_TIME")"
+	else
+		info "System time is already set."
+	fi
+else
+	info "System time is already set."
+	if [ "$TIME_DIFF" -gt "$TIME_DIFF_THRESHOLD" ]; then
+		warn "RTC time is in the past."
+		warn "Check RTC battery if this issue persists."
+		warn "RTC time:    $(get_display_time_from_timestamp "$RTC_TIME")"
+		warn "System time: $(get_display_time_from_timestamp "$SYS_TIME")"
+	fi
+fi

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers.bb
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers.bb
@@ -9,20 +9,23 @@ RDEPENDS_${PN}-fs = "e2fsprogs-tune2fs mtools"
 SRC_URI = " \
     file://os-helpers-fs \
     file://os-helpers-logging \
+    file://os-helpers-time \
 "
 S = "${WORKDIR}"
 
 inherit allarch
 
-PACKAGES = "${PN}-fs ${PN}-logging"
+PACKAGES = "${PN}-fs ${PN}-logging ${PN}-time"
 
 do_install() {
     install -d ${D}${libexecdir}
     install -m 0775 \
         ${WORKDIR}/os-helpers-fs \
         ${WORKDIR}/os-helpers-logging \
+        ${WORKDIR}/os-helpers-time \
         ${D}${libexecdir}
 }
 
 FILES_${PN}-fs = "${libexecdir}/os-helpers-fs"
 FILES_${PN}-logging = "${libexecdir}/os-helpers-logging"
+FILES_${PN}-time = "${libexecdir}/os-helpers-time"

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-time
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-time
@@ -1,0 +1,107 @@
+#!/bin/sh
+
+# Copyright 2020 Balena Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# The timestamp format used by balenaOS is YYYYMMDDhhmmss.
+
+
+# Get the system time as a timestamp.
+get_system_time_as_timestamp() {
+	local timestamp=$(date -u "+%4Y%2m%2d%2H%2M%2S")
+	echo "${timestamp}"
+}
+
+# Get the hwclock time as a timestamp.
+get_hwclock_time_as_timestamp() {
+	local rtc_time_str=$(hwclock --show --utc)
+	local timestamp=$(date -u "+%4Y%2m%2d%2H%2M%2S" -d "${rtc_time_str}")
+	echo "${timestamp}"
+}
+
+# Get a 'date' compatible string from a timestamp for display.
+# YYYYMMDDhhmmss -> YYYYMMDD hh:mm:ss
+# Arguments:
+#   1 - timestamp
+get_date_display_string_from_timestamp() {
+	local timestamp=$1
+	local date="$(echo "${timestamp}" | awk '{string=substr($0, 1, 8); print string;}')"
+	local hour="$(echo "${timestamp}" | awk '{string=substr($0, 9, 2); print string;}')"
+	local minute="$(echo "${timestamp}" | awk '{string=substr($0, 11, 2); print string;}')"
+	local sec="$(echo "${timestamp}" | awk '{string=substr($0, 13, 2); print string;}')"
+	echo "${date} ${hour}:${minute}:${sec}"
+}
+
+# Get a 'date' compatible string from a timestamp for setting the time.
+# YYYYMMDDhhmmss -> MMDDhhmmYYYY.ss
+# Arguments:
+#   1 - timestamp
+get_date_set_string_from_timestamp() {
+	local timestamp=$1
+	local datetime="$(echo "${timestamp}" | awk '{string=substr($0, 5, 8); print string;}')"
+	local year="$(echo "${timestamp}" | awk '{string=substr($0, 1, 4); print string;}')"
+	local sec="$(echo "${timestamp}" | awk '{string=substr($0, 13, 2); print string;}')"
+	echo "${datetime}${year}.${sec}"
+}
+
+# Get a human readable string from a timestamp.
+# YYYYMMDDhhmmss -> Day DD Mon HH:MM:SS TZ YYYY
+# Arguments:
+#   1 - timestamp
+get_display_time_from_timestamp() {
+	local timestamp=$1
+	local datestr="$(get_date_display_string_from_timestamp "$timestamp")"
+	echo "$(date -u -d "${datestr}")"
+}
+
+# Get epoch time from a timestamp.
+# Arguments:
+#   1 - timestamp
+get_epoch_time_from_timestamp() {
+	local timestamp=$1
+	local datestr="$(get_date_display_string_from_timestamp "${timestamp}")"
+	echo "$(date -u "+%s" -d "${datestr}")"
+}
+
+# Get the absolute difference between two timestamps.
+# Arguments:
+#   1 - timestamp1
+#   2 - timestamp2
+get_abs_time_diff_from_timestamps() {
+	local time1="$(get_epoch_time_from_timestamp "$1")"
+	local time2="$(get_epoch_time_from_timestamp "$2")"
+	local diff
+	if [ "$time1" -gt "$time2" ]; then
+		diff="$(expr $time1 - $time2)"
+		echo "${diff}"
+		return 0
+	elif [ "$time2" -gt "$time1" ]; then
+		diff="$(expr $time2 - $time1)"
+		echo "${diff}"
+		return 0
+	else
+		diff="0"
+		echo "${diff}"
+		return 0
+	fi
+}
+
+# Set the system time from a timestamp.
+# Arguments:
+#   1 - timestamp
+set_system_time_from_timestamp() {
+	local datestr="$(get_date_set_string_from_timestamp "$1")"
+        date -u "${datestr}" > /dev/null
+}


### PR DESCRIPTION
The handling of the RTC at boot time has been improved as follows:

1) A 'timeinit-rtc.sh' script has been added to improve logging of system time updates from the RTC and to prevent system time being set when RTC time is behind system time. If RTC time is found to be behind system time a warning is issued regarding potential RTC battery failure.

2) The 'timeinit-rtc.service' has been added to the new systemd 'time-set.target'. This allows for better control and co-ordination between the various time source services.

3) Systemd dependencies have been updated to ensure that the RTC is the final time service before the 'time-set.target' is reached.

Some support functions for system date/time handling have been added via the 'os-helpers-time' script. The 'timeinit-buildtime.sh' script has been updated to use these new functions.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
