### PR TITLE
zram-swap-init: adjust default to lesser of 50%/4GB

### DIFF
--- a/meta-balena-common/recipes-core/systemd/systemd/zram-swap-init
+++ b/meta-balena-common/recipes-core/systemd/systemd/zram-swap-init
@@ -7,11 +7,11 @@ if [ "$device" = "" ]; then
     exit 1
 fi
 
-# Allocate zram to be 25% of all system memory or 1GB whichever smallest
+# Allocate zram to be 50% of all system memory or 4GB whichever smallest
 # Note: zram is only allocated when used. When swapped pages compress with a
 # a 2:1 ratio zram will require 50% of system memory (while allowing to use
 # 150% memory).
-ZRAM_SIZE_PERCENT=25
+ZRAM_SIZE_PERCENT=50
 ZRAM_ALGORITHM=lz4
 
 # shellcheck disable=SC2015
@@ -19,8 +19,8 @@ ZRAM_ALGORITHM=lz4
 
 memtotal=$(grep MemTotal /proc/meminfo | awk ' { print $2 } ')
 memzram=$((memtotal*ZRAM_SIZE_PERCENT/100))
-if [ "${memzram}" -gt "1024000" ]; then
-	memzram=1024000
+if [ "${memzram}" -gt "4096000" ]; then
+	memzram=4096000
 fi
 
 echo ${ZRAM_ALGORITHM} > /sys/block/"${device##/dev/}"/comp_algorithm


### PR DESCRIPTION
Adjust zram to lesser of 50% or 4GB, inline with defaults used by Fedora.

Related issue: https://github.com/balena-os/meta-balena/issues/2056

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
