### PR TITLE
chrony: use a non-privileged UDP source port

### DIFF
--- a/meta-balena-common/recipes-core/chrony/files/chrony.conf
+++ b/meta-balena-common/recipes-core/chrony/files/chrony.conf
@@ -9,4 +9,4 @@ logchange 1
 maxdistance 16
 hwtimestamp *
 rtcsync
-acquisitionport 123
+acquisitionport 1234


### PR DESCRIPTION
Change the chrony UDP source port from 123 (privileged) to 1234 (non-privileged).

Previous issues with Phicomm routers had required the use of a fixed UDP source port, so port 123 was chosen as this is used by both ntpd and ntpdate. However recent testing has shown that using a privileged port such as 123 can cause issues on other networks. By changing the port to be non-privileged (i.e. 1234) we can satisfy both network requirements.

Change-type: patch
Connects-to: #2000
Changelog-entry: chrony: use a non-privileged UDP source port
Signed-off-by: Mark Corbin <mark@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
