### PR TITLE
start-resin-supervisor: fix directory creation for 'balena start'

### DIFF
--- a/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/start-resin-supervisor
+++ b/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor/start-resin-supervisor
@@ -54,9 +54,6 @@ runSupervisor() {
     if [ ! -d "/resin-data/resin-supervisor" ]; then
 	    mkdir -p "/resin-data/resin-supervisor"
     fi
-    if [ ! -d "/var/log/supervisor-log" ]; then
-	    mkdir -p "/var/log/supervisor-log"
-    fi
     balena rm --force resin_supervisor || true
     balena run --privileged --name resin_supervisor \
         --restart=always \
@@ -79,6 +76,10 @@ runSupervisor() {
         -e "SUPERVISOR_IMAGE=${SUPERVISOR_IMAGE}:${SUPERVISOR_TAG}" \
         "${SUPERVISOR_IMAGE}:${SUPERVISOR_TAG}"
 }
+
+if [ ! -d "/var/log/supervisor-log" ]; then
+    mkdir -p "/var/log/supervisor-log"
+fi
 
 if [ -z "$SUPERVISOR_IMAGE_ID" ]; then
     # No supervisor image exists on the device, try to pull it


### PR DESCRIPTION
Ensure that the /var/log/supervisor-log directory exists prior to running 'balena start --attach resin_supervisor' as well as 'runSupervisor'.

Updates to the 'start-resin-supervisor' script in v2.62.1 removed the check for updates to the REGISTRY_ENDPOINT variable. Previously this had been detected as changing every time the script was run due to a comparison between 'null' and ''. This resulted in the 'start-resin-supervisor' script always running through the 'runSupervisor' path. With this variable check removed, and no config updates being detected, the script was trying to run 'balena start --attach resin_supervisor' and failing due to the absence of the /var/log/supervisor-log directory. To fix this problem we unconditionally test for and create this directory (if necessary) so that it is available regardless of the path taken through the script.

Change-type: patch
Connects-to: #2064
Changelog-entry: start-resin-supervisor: fix directory creation for 'balena start'
Signed-off-by: Mark Corbin <mark@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
