### PR TITLE
systemd/timeinit: add HTTPS time synchronisation service

### DIFF
--- a/meta-balena-common/recipes-connectivity/balena-connectivity-wait/balena-connectivity-wait.bb
+++ b/meta-balena-common/recipes-connectivity/balena-connectivity-wait/balena-connectivity-wait.bb
@@ -1,0 +1,34 @@
+DESCRIPTION = "balena full network connectivity checker"
+SECTION = "console/utils"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = " \
+    file://balena-connectivity-wait \
+    file://balena-connectivity-wait.service \
+    file://balena-connectivity-wait.target \
+    "
+S = "${WORKDIR}"
+
+inherit allarch systemd
+
+PACKAGES = "${PN}"
+
+SYSTEMD_SERVICE_${PN} = " \
+	balena-connectivity-wait.service \
+	balena-connectivity-wait.target \
+	"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0775 ${WORKDIR}/balena-connectivity-wait ${D}${bindir}/balena-connectivity-wait
+
+    if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        install -d ${D}${systemd_unitdir}/system
+        install -c -m 0644 ${WORKDIR}/balena-connectivity-wait.service ${D}${systemd_unitdir}/system
+        install -c -m 0644 ${WORKDIR}/balena-connectivity-wait.target ${D}${systemd_unitdir}/system
+        sed -i -e 's,@BASE_BINDIR@,${base_bindir},g' \
+        -e 's,@BINDIR@,${bindir},g' \
+            ${D}${systemd_unitdir}/system/balena-connectivity-wait.service
+    fi
+}

--- a/meta-balena-common/recipes-connectivity/balena-connectivity-wait/balena-connectivity-wait/balena-connectivity-wait
+++ b/meta-balena-common/recipes-connectivity/balena-connectivity-wait/balena-connectivity-wait/balena-connectivity-wait
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+# Copyright 2020 Balena Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. /usr/libexec/os-helpers-logging
+
+# Remote server address.
+CONNECTIVITY_URL=https://api.balena-cloud.com/connectivity-check
+# Timeout for curl command in seconds.
+# Note that curl does not apply this timeout to DNS lookups.
+CURL_TIMEOUT=5
+# Delay in seconds between connection attempts.
+CONNECTIVITY_CHECK_DELAY=5
+
+info "Waiting for full network connectivity."
+
+while [ true ]; do
+	HTTP_CODE=$(curl -m$CURL_TIMEOUT -o "/dev/null" -k -I -s -w "%{http_code}" ${CONNECTIVITY_URL})
+	if [ "$HTTP_CODE" -eq "204" ]; then
+		break
+	fi
+	sleep $CONNECTIVITY_CHECK_DELAY
+done
+info "Full network connectivity detected."
+exit 0

--- a/meta-balena-common/recipes-connectivity/balena-connectivity-wait/balena-connectivity-wait/balena-connectivity-wait.service
+++ b/meta-balena-common/recipes-connectivity/balena-connectivity-wait/balena-connectivity-wait/balena-connectivity-wait.service
@@ -1,0 +1,27 @@
+# Copyright 2020 Balena Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=Wait for full network connectivity
+DefaultDependencies=no
+After=network.target
+Before=balena-connectivity-wait.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=@BINDIR@/balena-connectivity-wait
+
+[Install]
+WantedBy=balena-connectivity-wait.target

--- a/meta-balena-common/recipes-connectivity/balena-connectivity-wait/balena-connectivity-wait/balena-connectivity-wait.target
+++ b/meta-balena-common/recipes-connectivity/balena-connectivity-wait/balena-connectivity-wait/balena-connectivity-wait.target
@@ -1,0 +1,18 @@
+# Copyright 2020 Balena Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=Wait for full network connectivity
+RefuseManualStart=yes
+After=network.target

--- a/meta-balena-common/recipes-connectivity/networkmanager/resin-files/NetworkManager.conf.systemd
+++ b/meta-balena-common/recipes-connectivity/networkmanager/resin-files/NetworkManager.conf.systemd
@@ -1,6 +1,6 @@
 [Unit]
-Wants=resin-net-config.service bind-var-lib-NetworkManager.service chronyd.service
-After=resin-net-config.service bind-var-lib-NetworkManager.service chronyd.service
+Wants=resin-net-config.service bind-var-lib-NetworkManager.service
+After=resin-net-config.service bind-var-lib-NetworkManager.service
 
 [Service]
 ExecStartPre=/bin/systemd-tmpfiles --remove /etc/tmpfiles.d/nm-tmpfiles.conf

--- a/meta-balena-common/recipes-core/packagegroups/packagegroup-resin-connectivity.bb
+++ b/meta-balena-common/recipes-core/packagegroups/packagegroup-resin-connectivity.bb
@@ -27,6 +27,7 @@ CONNECTIVITY_PACKAGES = " \
     resin-proxy-config \
     usb-modeswitch \
     iw \
+    balena-connectivity-wait \
     "
 
 RDEPENDS_${PN} = " \

--- a/meta-balena-common/recipes-core/systemd/timeinit.bb
+++ b/meta-balena-common/recipes-core/systemd/timeinit.bb
@@ -27,6 +27,8 @@ SRC_URI = " \
     file://fake-hwclock-update.timer \
     file://timeinit-rtc.service \
     file://timeinit-rtc.sh \
+    file://timesync-https.service \
+    file://timesync-https.sh \
     file://time-set.target \
     file://time-sync.conf \
     "
@@ -40,6 +42,7 @@ SYSTEMD_SERVICE_${PN} = " \
 	fake-hwclock-update.service \
 	fake-hwclock-update.timer \
 	timeinit-rtc.service \
+	timesync-https.service \
 	time-set.target \
 	"
 
@@ -51,12 +54,14 @@ do_install() {
     install -d ${D}${sysconfdir}/systemd/system/time-sync.target.d/
     install -m 0775 ${WORKDIR}/timeinit-buildtime.sh ${D}${bindir}
     install -m 0775 ${WORKDIR}/timeinit-rtc.sh ${D}${bindir}
+    install -m 0775 ${WORKDIR}/timesync-https.sh ${D}${bindir}
     install -m 0775 ${WORKDIR}/fake-hwclock ${D}${base_sbindir}
     install -m 0644 ${WORKDIR}/timeinit-buildtime.service ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/fake-hwclock.service ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/fake-hwclock-update.service ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/fake-hwclock-update.timer ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/timeinit-rtc.service ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/timesync-https.service ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/time-set.target ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/time-sync.conf ${D}${sysconfdir}/systemd/system/time-sync.target.d/
 }

--- a/meta-balena-common/recipes-core/systemd/timeinit/timesync-https.service
+++ b/meta-balena-common/recipes-core/systemd/timeinit/timesync-https.service
@@ -1,0 +1,28 @@
+# Copyright 2020 Balena Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=Set system clock from a secure website
+DefaultDependencies=no
+Wants=balena-connectivity-wait.target
+After=balena-connectivity-wait.target
+Before=time-sync.target chronyd.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/timesync-https.sh
+
+[Install]
+WantedBy=time-sync.target

--- a/meta-balena-common/recipes-core/systemd/timeinit/timesync-https.sh
+++ b/meta-balena-common/recipes-core/systemd/timeinit/timesync-https.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+#
+# Copyright 2020 Balena Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. /usr/libexec/os-helpers-logging
+. /usr/libexec/os-helpers-time
+
+# Delay in seconds between poll attempts.
+HTTPS_POLL_DELAY=1
+# Remote server address.
+HTTPS_SERVER=https://api.balena-cloud.com/connectivity-check
+# Timeout for curl command in seconds.
+# Note that curl does not apply this timeout to DNS lookups.
+CURL_TIMEOUT=5
+# Maximum number of poll attempts (must be at least 1).
+MAX_HTTPS_POLLS=100
+# Don't bother updating or reporting errors for small differences.
+TIME_DIFF_THRESHOLD=2
+
+# Poll HTTPS server for time string.
+info "Starting HTTPS time synchronisation."
+
+HTTPS_POLL_COUNTER=0
+
+# In theory the potential maximum delay is given by:
+#     (((HTTPS_POLL_DELAY + CURL_TIMEOUT) * MAX_HTTPS_POLLS) - HTTPS_POLL_DELAY) seconds.
+# Using the above calculation with the default values gives a delay
+# period of approximately 10 minutes.
+# Note that this period can be extended as curl DNS lookup timeouts do
+# not obey the -m (--max-time) parameter.
+
+while [ true  ]; do
+	SYS_TIME=$(get_system_time_as_timestamp)
+	SERVER_TIME_STRING=$(curl -m$CURL_TIMEOUT -k -I -s "$HTTPS_SERVER" --stderr - | grep -i Date: | sed -e 's/[Dd]ate: //')
+	if [ ! -z "$SERVER_TIME_STRING" ]; then
+		SERVER_TIME=$(get_server_time_as_timestamp "$SERVER_TIME_STRING")
+		TIME_DIFF=$(get_abs_time_diff_from_timestamps "$SYS_TIME" "$SERVER_TIME")
+		if [ "$TIME_DIFF" -gt "$TIME_DIFF_THRESHOLD" ]; then
+			if [ "$SYS_TIME" -lt "$SERVER_TIME" ]; then
+				$(set_system_time_from_timestamp "$SERVER_TIME")
+				info "Time synchronised via HTTPS."
+				info "Old time: $(get_display_time_from_timestamp "$SYS_TIME")"
+				info "New time: $(get_display_time_from_timestamp "$SERVER_TIME")"
+				exit 0
+			else
+				info "System time is already synchronised."
+				warn "HTTPS header time is in the past."
+				warn "Server time: $(get_display_time_from_timestamp "$SERVER_TIME")"
+				warn "System time: $(get_display_time_from_timestamp "$SYS_TIME")"
+				exit 0
+			fi
+		else
+			info "System time is already synchronised."
+			exit 0
+		fi
+	fi
+	HTTPS_POLL_COUNTER=$(expr $HTTPS_POLL_COUNTER + 1)
+	if [ "$HTTPS_POLL_COUNTER" -ge "$MAX_HTTPS_POLLS" ]; then
+		fail "HTTPS time synchronisation failed after $MAX_HTTPS_POLLS attempts."
+	fi
+	sleep $HTTPS_POLL_DELAY
+done

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-time
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-time
@@ -31,6 +31,14 @@ get_hwclock_time_as_timestamp() {
 	echo "${timestamp}"
 }
 
+# Get an HTTP server header time string as a timestamp.
+# Arguments:
+#   1 - server time string (Day, DD Mon YYYY hh:mm:ss TZ)
+get_server_time_as_timestamp() {
+	local server_time_str=$1
+	echo "$(date -u "+%4Y%2m%2d%2H%2M%2S" -d "${server_time_str}")"
+}
+
 # Get a 'date' compatible string from a timestamp for display.
 # YYYYMMDDhhmmss -> YYYYMMDD hh:mm:ss
 # Arguments:


### PR DESCRIPTION
Add a new `timesync-https` systemd service to synchronise the system time at boot using an HTTPS header. The service uses `curl` to request an HTTPS header from https://api.balena-cloud.com/connectivity-check. The date field returned in the header is used to set the system time.

The service will exit when either a valid response has been received or a maximum number of attempts has been reached.

The service provides time synchronisation for devices where NTP is blocked. For devices where NTP is available it should ensure that the system 'time jump' is only a few seconds when NTP synchronisation is eventually achieved.

The `timesync-https` service depends on the `balena-connectivity-wait` service to ensure that it only runs when full network connectivity is available.

The `balena-connectivity-wait` service makes use of the fixed HTTP response code from https://api.balena-cloud.com/connectivity-check. This page will return code 204 (No Content) which is used to determine that we have full connectivity, i.e. internet is reachable and DNS is configured. This service can be used to prevent issues related to router delays and captive portals.

Change-type: minor
Connects-to: #1337 #2044
Signed-off-by: Mark Corbin <mark@balena.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
