### PR TITLE
kernel-resin: Add IPV6 multicast routing capabilities

### DIFF
--- a/meta-balena-common/classes/kernel-resin.bbclass
+++ b/meta-balena-common/classes/kernel-resin.bbclass
@@ -100,6 +100,7 @@ RESIN_CONFIGS ?= " \
     no-debug-info \
     uprobes \
     task-accounting \
+    ipv6_mroute \
     "
 
 #
@@ -343,6 +344,11 @@ RESIN_CONFIGS_DEPS[ip6tables_nat] = " \
     "
 RESIN_CONFIGS[ip6tables_nat] = " \
     CONFIG_IP6_NF_NAT=m \
+    "
+
+RESIN_CONFIGS[ipv6_mroute] = " \
+    CONFIG_IPV6_MROUTE=y \
+    CONFIG_IPV6_MROUTE_MULTIPLE_TABLES=y \
     "
 
 RESIN_CONFIGS[seccomp] = " \


### PR DESCRIPTION
Add IPV6 multicast routing capability to the default configuration.

Fixes #2051

Change-type: patch
Changelog-entry: Add IPV6 multicast routing capability
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
