### PR TITLE
chrony: bump to version 4.0

### DIFF
--- a/meta-balena-common/recipes-core/chrony/chrony_4.0.bb
+++ b/meta-balena-common/recipes-core/chrony/chrony_4.0.bb
@@ -1,0 +1,138 @@
+SUMMARY = "Versatile implementation of the Network Time Protocol"
+DESCRIPTION = "Chrony can synchronize the system clock with NTP \
+servers, reference clocks (e.g. GPS receiver), and manual input using \
+wristwatch and keyboard. It can also operate as an NTPv4 (RFC 5905) \
+server and peer to provide a time service to other computers in the \
+network. \
+\
+It is designed to perform well in a wide range of conditions, \
+including intermittent network connections, heavily congested \
+networks, changing temperatures (ordinary computer clocks are \
+sensitive to temperature), and systems that do not run continuously, or \
+run on a virtual machine. \
+\
+Typical accuracy between two machines on a LAN is in tens, or a few \
+hundreds, of microseconds; over the Internet, accuracy is typically \
+within a few milliseconds. With a good hardware reference clock \
+sub-microsecond accuracy is possible. \
+\
+Two programs are included in chrony: chronyd is a daemon that can be \
+started at boot time and chronyc is a command-line interface program \
+which can be used to monitor chronyd's performance and to change \
+various operating parameters whilst it is running. \
+\
+This recipe produces two binary packages: 'chrony' which contains chronyd, \
+the configuration file and the init script, and 'chronyc' which contains \
+the client program only."
+
+HOMEPAGE = "https://chrony.tuxfamily.org/"
+SECTION = "net"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
+
+SRC_URI = "https://download.tuxfamily.org/chrony/chrony-${PV}.tar.gz \
+    file://chrony.conf \
+    file://chronyd \
+    file://arm_eabi.patch \
+"
+
+SRC_URI_append_libc-musl = " \
+    file://0001-Fix-compilation-with-musl.patch \
+"
+SRC_URI[sha256sum] = "be27ea14c55e7a4434b2fa51d53018c7051c42fa6a3198c9aa6a1658bae0c625"
+
+DEPENDS = "pps-tools"
+
+# Note: Despite being built via './configure; make; make install',
+#       chrony does not use GNU Autotools.
+inherit update-rc.d systemd
+
+# Configuration options:
+# - For command line editing support in chronyc, you may specify either
+#   'editline' or 'readline' but not both.  editline is smaller, but
+#   many systems already have readline for other purposes so you might want
+#   to choose that instead.  However, beware license incompatibility
+#   since chrony is GPLv2 and readline versions after 6.0 are GPLv3+.
+#   You can of course choose neither, but if you're that tight on space
+#   consider dropping chronyc entirely (you can use it remotely with
+#   appropriate chrony.conf options).
+# - Security-related:
+#   - 'sechash' is omitted by default because it pulls in nss which is huge.
+#   - 'privdrop' allows chronyd to run as non-root; would need changes to
+#     chrony.conf and init script.
+#   - 'scfilter' enables support for system call filtering, but requires the
+#     kernel to have CONFIG_SECCOMP enabled.
+PACKAGECONFIG ??= "editline \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'ipv6', d)} \
+"
+PACKAGECONFIG[readline] = "--without-editline,--without-readline,readline"
+PACKAGECONFIG[editline] = ",--without-editline,libedit"
+PACKAGECONFIG[sechash] = "--without-tomcrypt,--disable-sechash,nss"
+PACKAGECONFIG[privdrop] = ",--disable-privdrop,libcap"
+PACKAGECONFIG[scfilter] = "--enable-scfilter,--without-seccomp,libseccomp"
+PACKAGECONFIG[ipv6] = ",--disable-ipv6,"
+PACKAGECONFIG[nss] = "--with-nss,--without-nss,nss"
+PACKAGECONFIG[libcap] = "--with-libcap,--without-libcap,libcap"
+
+# --disable-static isn't supported by chrony's configure script.
+DISABLE_STATIC = ""
+
+do_configure() {
+    ./configure --sysconfdir=${sysconfdir} --bindir=${bindir} --sbindir=${sbindir} \
+                --localstatedir=${localstatedir} --datarootdir=${datadir} \
+                --with-ntp-era=$(shell date -d '1970-01-01 00:00:00+00:00' +'%s') \
+                --with-pidfile=/run/chrony/chronyd.pid \
+                --chronyrundir=/run/chrony \
+                --host-system=Linux \
+                ${PACKAGECONFIG_CONFARGS}
+}
+
+do_install() {
+    # Binaries
+    install -d ${D}${bindir}
+    install -m 0755 ${S}/chronyc ${D}${bindir}
+    install -d ${D}${sbindir}
+    install -m 0755 ${S}/chronyd ${D}${sbindir}
+
+    # Config file
+    install -d ${D}${sysconfdir}
+    install -m 644 ${WORKDIR}/chrony.conf ${D}${sysconfdir}
+
+    # System V init script
+    install -d ${D}${sysconfdir}/init.d
+    install -m 755 ${WORKDIR}/chronyd ${D}${sysconfdir}/init.d
+
+    # systemd unit configuration file
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${S}/examples/chronyd.service ${D}${systemd_unitdir}/system/
+
+    # Variable data (for drift and/or rtc file)
+    install -d ${D}${localstatedir}/lib/chrony
+
+    # Fix hard-coded paths in config files and init scripts
+    sed -i -e 's!/var/!${localstatedir}/!g' -e 's!/etc/!${sysconfdir}/!g' \
+           -e 's!/usr/sbin/!${sbindir}/!g' -e 's!/usr/bin/!${bindir}/!g' \
+           ${D}${sysconfdir}/chrony.conf \
+           ${D}${sysconfdir}/init.d/chronyd \
+           ${D}${systemd_unitdir}/system/chronyd.service
+    sed -i 's!^PATH=.*!PATH=${base_sbindir}:${base_bindir}:${sbindir}:${bindir}!' ${D}${sysconfdir}/init.d/chronyd
+    sed -i 's!^EnvironmentFile=.*!EnvironmentFile=-${sysconfdir}/default/chronyd!' ${D}${systemd_unitdir}/system/chronyd.service
+}
+
+FILES_${PN} = "${sbindir}/chronyd ${sysconfdir} ${localstatedir}/lib/chrony ${localstatedir}"
+CONFFILES_${PN} = "${sysconfdir}/chrony.conf"
+INITSCRIPT_NAME = "chronyd"
+INITSCRIPT_PARAMS = "defaults"
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE_${PN} = "chronyd.service"
+
+# It's probably a bad idea to run chrony and another time daemon on
+# the same system.  systemd includes the SNTP client 'timesyncd', which
+# will be disabled by chronyd.service, however it will remain on the rootfs
+# wasting 150 kB unless you put 'PACKAGECONFIG_remove_pn-systemd = "timesyncd"'
+# in a conf file or bbappend somewhere.
+RCONFLICTS_${PN} = "ntp ntimed"
+
+# Separate the client program into its own package
+PACKAGES =+ "chronyc"
+FILES_chronyc = "${bindir}/chronyc"

--- a/meta-balena-common/recipes-core/chrony/files/0001-Fix-compilation-with-musl.patch
+++ b/meta-balena-common/recipes-core/chrony/files/0001-Fix-compilation-with-musl.patch
@@ -1,0 +1,29 @@
+From 11ec10cdb5ab4b94c5999e018a9c854419997761 Mon Sep 17 00:00:00 2001
+From: Oleksandr Kravchuk <open.source@oleksandr-kravchuk.com>
+Date: Wed, 10 Apr 2019 03:18:17 +0200
+Subject: [PATCH] Fix compilation with musl
+
+Fixes:
+../hash_intmd5.c:58: undefined reference to `MIN'
+
+Signed-off-by: Oleksandr Kravchuk <open.source@oleksandr-kravchuk.com>
+---
+ hash_intmd5.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/hash_intmd5.c b/hash_intmd5.c
+index 49da1cf..47efe4c 100644
+--- a/hash_intmd5.c
++++ b/hash_intmd5.c
+@@ -33,6 +33,8 @@
+ 
+ #include "md5.c"
+ 
++#include <sys/param.h>
++
+ static MD5_CTX ctx;
+ 
+ int
+-- 
+2.17.1
+

--- a/meta-balena-common/recipes-core/chrony/files/arm_eabi.patch
+++ b/meta-balena-common/recipes-core/chrony/files/arm_eabi.patch
@@ -1,0 +1,86 @@
+From f35e07aceb4a16121d83b47ee77990018bec98ea Mon Sep 17 00:00:00 2001
+From: Joe Slater <jslater@windriver.com>
+Date: Thu, 9 Mar 2017 10:58:06 -0800
+Subject: [PATCH] chrony: fix build failure for arma9
+
+    Eliminate references to syscalls not available
+    for ARM_EABI.  Also add a dependency on libseccomp
+    which is needed for scfilter to work.
+
+    Set PACKAGECONFIG to not enable scfilter, since
+    kernel CONFIG_SECCOMP is unlikely to be set.  This
+    aligns the usage of libseccomp with that of other packages.
+
+    Upstream-Status: Pending
+
+    Signed-off-by: Joe Slater <jslater@windriver.com>
+
+    Refresh patch for new upstream version.
+
+    Signed-off-by: Robert Joslyn <robert.joslyn@redrectangle.org>
+
+    Refreshed for 4.0
+
+    Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ sys_linux.c | 20 ++++++++++++++------
+ 1 file changed, 14 insertions(+), 6 deletions(-)
+
+--- a/sys_linux.c
++++ b/sys_linux.c
+@@ -499,14 +499,12 @@ SYS_Linux_EnableSystemCallFilter(int lev
+ #endif
+     SCMP_SYS(gettimeofday),
+     SCMP_SYS(settimeofday),
+-    SCMP_SYS(time),
+
+     /* Process */
+     SCMP_SYS(clone),
+     SCMP_SYS(exit),
+     SCMP_SYS(exit_group),
+     SCMP_SYS(getpid),
+-    SCMP_SYS(getrlimit),
+     SCMP_SYS(getuid),
+     SCMP_SYS(rt_sigaction),
+     SCMP_SYS(rt_sigreturn),
+@@ -519,7 +517,6 @@ SYS_Linux_EnableSystemCallFilter(int lev
+     /* Memory */
+     SCMP_SYS(brk),
+     SCMP_SYS(madvise),
+-    SCMP_SYS(mmap),
+     SCMP_SYS(mmap2),
+     SCMP_SYS(mprotect),
+     SCMP_SYS(mremap),
+@@ -573,8 +570,6 @@ SYS_Linux_EnableSystemCallFilter(int lev
+     SCMP_SYS(sendmsg),
+     SCMP_SYS(sendto),
+     SCMP_SYS(shutdown),
+-    /* TODO: check socketcall arguments */
+-    SCMP_SYS(socketcall),
+
+     /* General I/O */
+     SCMP_SYS(_newselect),
+@@ -597,7 +592,6 @@ SYS_Linux_EnableSystemCallFilter(int lev
+ #ifdef __NR_futex_time64
+     SCMP_SYS(futex_time64),
+ #endif
+-    SCMP_SYS(select),
+     SCMP_SYS(set_robust_list),
+     SCMP_SYS(write),
+
+@@ -605,6 +599,15 @@ SYS_Linux_EnableSystemCallFilter(int lev
+     SCMP_SYS(getrandom),
+     SCMP_SYS(sysinfo),
+     SCMP_SYS(uname),
++    /* not always available */
++#if ! defined(__ARM_EABI__)
++    SCMP_SYS(time),
++    SCMP_SYS(getrlimit),
++    SCMP_SYS(select),
++    SCMP_SYS(mmap),
++    /* TODO: check socketcall arguments */
++    SCMP_SYS(socketcall),
++#endif
+   };
+
+   const int socket_domains[] = {

--- a/meta-balena-common/recipes-core/chrony/files/chronyd
+++ b/meta-balena-common/recipes-core/chrony/files/chronyd
@@ -1,0 +1,58 @@
+#! /bin/sh
+
+# System V init script for chrony
+# Adapted from the script already in meta-networking for ntpd
+
+### BEGIN INIT INFO
+# Provides:        chrony
+# Required-Start:  $network $remote_fs $syslog
+# Required-Stop:   $network $remote_fs $syslog
+# Default-Start:   2 3 4 5
+# Default-Stop:
+# Short-Description: Start chrony time daemon
+### END INIT INFO
+
+PATH=/sbin:/bin:/usr/bin:/usr/sbin
+
+DAEMON=/usr/sbin/chronyd
+PIDFILE=/run/chrony/chronyd.pid
+
+test -x $DAEMON -a -r /etc/chrony.conf || exit 0
+
+# Source function library.
+. /etc/init.d/functions
+
+# Functions to do individual actions
+startdaemon(){
+	echo -n "Starting chronyd: "
+	start-stop-daemon --start --quiet --oknodo --pidfile $PIDFILE --startas $DAEMON -- "$@"
+	echo "done"
+}
+stopdaemon(){
+	echo -n "Stopping chronyd: "
+	start-stop-daemon --stop --quiet --oknodo -p $PIDFILE
+	echo "done"
+}
+
+case "$1" in
+  start)
+	startdaemon
+	;;
+  stop)
+  	stopdaemon
+	;;
+  force-reload | restart | reload)
+  	stopdaemon
+	startdaemon
+	;;
+  status)
+	status /usr/sbin/chronyd;
+	exit $?
+	;;
+  *)
+	echo "Usage: chronyd { start | stop | status | restart | reload }" >&2
+	exit 1
+	;;
+esac
+
+exit 0


### PR DESCRIPTION
Update chrony from version 3.4 to version 4.0.

The new version has enhancements and new features that will help to improve time synchronisation, including:

- the ability to add server pools via scripts using chronyc.
- support for dynamic NTP source files that can be reloaded as necessary (useful for DHCP and config.json sources).
- source name options for improved handling of pool addresses.
- repeat 'iburst' when a source is changed from offline to online state.

Tested on a Raspberry Pi 4.

Change-type: minor
Changelog-entry: chrony: bump to version 4.0
Signed-off-by: Mark Corbin <mark@balena.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
