### PR TITLE
Add support for rootfs on MD RAID1

### DIFF
--- a/meta-balena-common/classes/kernel-resin.bbclass
+++ b/meta-balena-common/classes/kernel-resin.bbclass
@@ -102,6 +102,7 @@ BALENA_CONFIGS ?= " \
     task-accounting \
     ipv6_mroute \
     disable_hung_panic \
+    mdraid \
     "
 
 #
@@ -567,6 +568,14 @@ BALENA_CONFIGS[uprobes] = " \
 BALENA_CONFIGS[disable_hung_panic] = " \
     CONFIG_BOOTPARAM_HUNG_TASK_PANIC=n \
     "
+
+# enable rootfs on RAID1
+BALENA_CONFIGS[mdraid] = " \
+    CONFIG_MD=y \
+    CONFIG_BLK_DEV_MD=y \
+    CONFIG_MD_RAID1=y \
+    CONFIG_MD_AUTODETECT=y \
+"
 
 ###########
 # HELPERS #

--- a/meta-balena-common/recipes-core/images/balena-image-initramfs.bb
+++ b/meta-balena-common/recipes-core/images/balena-image-initramfs.bb
@@ -19,6 +19,7 @@ PACKAGE_INSTALL = " \
     initramfs-module-udev \
     initramfs-framework-base \
     udev \
+    mdadm \
     ${ROOTFS_BOOTSTRAP_INSTALL} \
     "
 

--- a/meta-balena-common/recipes-core/packagegroups/packagegroup-resin.inc
+++ b/meta-balena-common/recipes-core/packagegroups/packagegroup-resin.inc
@@ -20,4 +20,5 @@ RDEPENDS_${PN} = " \
     os-config \
     os-release \
     less \
+    mdadm \
     "


### PR DESCRIPTION
Tested and working with
- VM + two SATA drives
- NUC + one NVME & one SATA drive (intentionally)
- RPi4 + two USB drives

RPi4 + USB drive & SD card is somewhat unstable (freezes at a random point), at this point not clear why.

No flashing procedure so far, one needs to manually create an MD RAID1 device (metadata 0.90 - the partitions must be visible to GRUB/u-boot) and flash the image to it.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
