### PR TITLE
ppp: Fix timeout when launched by NetworkManager

### DIFF
--- a/meta-balena-common/recipes-connectivity/ppp/ppp_%.bbappend
+++ b/meta-balena-common/recipes-connectivity/ppp/ppp_%.bbappend
@@ -1,0 +1,3 @@
+do_install_append() {
+    echo 'connect ""' >> ${D}${sysconfdir}/ppp/options
+}


### PR DESCRIPTION
Fixes #1846

UART modems (RaspberryPi HATs) are not working currently under
balenaOS as NetworkManager times out while attempting to establish
ppp connection. This is not a balenaOS specific issue.

This commits adds a `connect ""` declaration to `/etc/ppp/options`
to workaround this as the NULL default value causes the timeout.

The connect option specifies an external script to establish the
physical link. When using NetworkManager/ModemManager it is
ModemManager that establishes the physical link before passing it
to NetworkManager. Thus `connect` should be empty.

Change-type: patch
Changelog-entry: Fix pppd timeout when launched by NetworkManager
Signed-off-by: Zahari Petkov <zahari@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
