### PR TITLE
resin-device-register: Fix post provisioning state not reported

### DIFF
--- a/meta-balena-common/recipes-support/resin-device-register/resin-device-register/resin-device-register
+++ b/meta-balena-common/recipes-support/resin-device-register/resin-device-register/resin-device-register
@@ -61,7 +61,7 @@ while true; do
                         --data-urlencode "device_type=$DEVICE_TYPE" \
                         --data-urlencode "uuid=$UUID" \
                         --data-urlencode "api_key=$DEVICE_API_KEY" \
-                        --data-urlencode "supervisor_version=${SUPERVISOR_TAG:-null}" \
+                        ${SUPERVISOR_TAG:+ --data-urlencode "supervisor_version=${SUPERVISOR_TAG}"} \
                         "$API_ENDPOINT/device/register")
 
             if [ "$status_code" -eq 201 ]; then


### PR DESCRIPTION
Starting with dee971c0dbeb6e8363f3e321af582e99627626e9, flasher
images, which don't contain a supervisor version, try to register
in the API using the parameter supervisor_version='null'.

However, the API expects this parameter to be unset completely if
there's no version to be reported during registration, otherwise
the call fails and the device doesn't show up in dashboard during
flashing or report the post-provisioning state.

Change-type: Patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Root cause discussed internally in https://www.flowdock.com/app/rulemotion/resin-devices/threads/EcpplGAu7uIsW87UZYSpMU88qR2

Fixes https://github.com/balena-os/meta-balena/issues/2082

Tested on BeagleboneBlack, TX2 and Nano SD-card

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
