### PR TITLE
procps: split recipe and install ps.procps

### DIFF
--- a/meta-balena-common/recipes-containers/balena/balena_git.bb
+++ b/meta-balena-common/recipes-containers/balena/balena_git.bb
@@ -42,7 +42,7 @@ USERADD_PACKAGES = "${PN}"
 GROUPADD_PARAM_${PN} = "-r balena-engine"
 
 DEPENDS_append_class-target = " systemd"
-RDEPENDS_${PN}_class-target = "curl util-linux iptables tini systemd healthdog bash"
+RDEPENDS_${PN}_class-target = "curl util-linux iptables tini systemd healthdog bash procps-ps"
 RRECOMMENDS_${PN} += "kernel-module-nf-nat"
 
 # oe-meta-go recipes try to build go-cross-native

--- a/meta-balena-common/recipes-extended/procps/procps_%.bbappend
+++ b/meta-balena-common/recipes-extended/procps/procps_%.bbappend
@@ -1,0 +1,59 @@
+
+ALLOW_EMPTY_${PN} = "1"
+FILES_${PN} = ""
+ALTERNATIVE_${PN} = ""
+
+python procps_binpackages () {
+    def pkg_hook(f, pkg, file_regex, output_pattern, modulename):
+        pn = d.getVar('PN')
+        d.appendVar('RRECOMMENDS_%s' % pn, ' %s' % pkg)
+
+        if d.getVar('ALTERNATIVE_' + pkg):
+            return
+        if d.getVarFlag('ALTERNATIVE_LINK_NAME', modulename):
+            d.setVar('ALTERNATIVE_' + pkg, modulename)
+
+    bindirs = sorted(list(set(d.expand("${base_sbindir} ${base_bindir} ${bindir}").split())))
+    for dir in bindirs:
+        do_split_packages(d, root=dir,
+                          file_regex=r'(.*)', output_pattern='${PN}-%s',
+                          description='${PN} %s',
+                          hook=pkg_hook, extra_depends='${PN}-libprocps', allow_links=False, prepend=False)
+
+    # There are some symlinks for some binaries which we have ignored
+    # above. Add them to the package owning the binary they are
+    # pointing to
+    extras = {}
+    dvar = d.getVar('PKGD')
+    for root in bindirs:
+        for walkroot, dirs, files in os.walk(dvar + root):
+            for f in files:
+                file = os.path.join(walkroot, f)
+                if not os.path.islink(file):
+                    continue
+
+                pkg = os.path.basename(os.readlink(file))
+                extras[pkg] = extras.get(pkg, '') + ' ' + file.replace(dvar, '', 1)
+
+    pn = d.getVar('PN')
+    for pkg, links in extras.items():
+        of = d.getVar('FILES_' + pn + '-' + pkg)
+        links = of + links
+        d.setVar('FILES_' + pn + '-' + pkg, links)
+}
+
+# we must execute before update-alternatives PACKAGE_PREPROCESS_FUNCS
+PACKAGE_PREPROCESS_FUNCS =+ "procps_binpackages "
+
+PACKAGES_DYNAMIC = "^${PN}-.*"
+
+python procps_libpackages() {
+    do_split_packages(d, root=d.getVar('libdir'), file_regex=r'^lib(.*)\.so\..*$',
+                      output_pattern='${PN}-lib%s',
+                      description='${PN} lib%s',
+                      extra_depends='', prepend=True, allow_links=True)
+}
+
+PACKAGESPLITFUNCS =+ "procps_libpackages"
+
+FILES_${PN}-sysctl += " ${sysconfdir}/sysctl* "


### PR DESCRIPTION
https://github.com/balena-os/balena-engine/issues/236

Replace busybox ps link with ps.procps without installing
any other procps packages. This will avoid regression and bloat
from swapping existing busybox links with procps variants.

By using procps as docker expects we can properly handle ps args
such as -e and -o to format output. Busybox is only capable of this
when compiled in "desktop" mode.

Change-type: patch
Changelog-entry: replace busybox ps with procps [klutchell]
Signed-off-by: Kyle Harding <kyle@balena.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
