### PR TITLE
procps: use procps recipe from upstream poky master

### DIFF
--- a/meta-balena-common/recipes-containers/balena/balena_git.bb
+++ b/meta-balena-common/recipes-containers/balena/balena_git.bb
@@ -42,7 +42,7 @@ USERADD_PACKAGES = "${PN}"
 GROUPADD_PARAM_${PN} = "-r balena-engine"
 
 DEPENDS_append_class-target = " systemd"
-RDEPENDS_${PN}_class-target = "curl util-linux iptables tini systemd healthdog bash"
+RDEPENDS_${PN}_class-target = "curl util-linux iptables tini systemd healthdog bash procps-ps"
 RRECOMMENDS_${PN} += "kernel-module-nf-nat"
 
 # oe-meta-go recipes try to build go-cross-native

--- a/meta-balena-dunfell/recipes-extended/procps/procps/sysctl.conf
+++ b/meta-balena-dunfell/recipes-extended/procps/procps/sysctl.conf
@@ -1,0 +1,67 @@
+# This configuration taken from procps v3.3.15
+# Commented out kernel/pid_max=10000 line
+#
+# /etc/sysctl.conf - Configuration file for setting system variables
+# See sysctl.conf (5) for information.
+
+# you can have the CD-ROM close when you use it, and open
+# when you are done.
+#dev.cdrom.autoeject = 1
+#dev.cdrom.autoclose = 1
+
+# protection from the SYN flood attack
+net/ipv4/tcp_syncookies=1
+
+# see the evil packets in your log files
+net/ipv4/conf/all/log_martians=1
+
+# makes you vulnerable or not :-)
+net/ipv4/conf/all/accept_redirects=0
+net/ipv4/conf/all/accept_source_route=0
+net/ipv4/icmp_echo_ignore_broadcasts =1
+
+# needed for routing, including masquerading or NAT
+#net/ipv4/ip_forward=1
+
+# sets the port range used for outgoing connections
+#net.ipv4.ip_local_port_range = 32768    61000
+
+# Broken routers and obsolete firewalls will corrupt the window scaling
+# and ECN. Set these values to 0 to disable window scaling and ECN.
+# This may, rarely, cause some performance loss when running high-speed
+# TCP/IP over huge distances or running TCP/IP over connections with high
+# packet loss and modern routers. This sure beats dropped connections.
+#net.ipv4.tcp_ecn = 0
+
+# Swapping too much or not enough? Disks spinning up when you'd
+# rather they didn't? Tweak these.
+#vm.vfs_cache_pressure = 100
+#vm.laptop_mode = 0
+#vm.swappiness = 60
+
+#kernel.printk_ratelimit_burst = 10
+#kernel.printk_ratelimit = 5
+#kernel.panic_on_oops = 0
+
+# Reboot 600 seconds after a panic
+#kernel.panic = 600
+
+# enable SysRq key (note: console security issues)
+#kernel.sysrq = 1
+
+# Change name of core file to start with the command name
+# so you get things like: emacs.core mozilla-bin.core X.core
+#kernel.core_pattern = %e.core
+
+# NIS/YP domain (not always equal to DNS domain)
+#kernel.domainname = example.com
+#kernel.hostname = darkstar
+
+# This limits PID values to 4 digits, which allows tools like ps
+# to save screen space.
+#kernel/pid_max=10000
+
+# Protects against creating or following links under certain conditions
+# See https://www.kernel.org/doc/Documentation/sysctl/fs.txt
+#fs.protected_hardlinks = 1
+#fs.protected_symlinks = 1

--- a/meta-balena-dunfell/recipes-extended/procps/procps_3.3.16.bb
+++ b/meta-balena-dunfell/recipes-extended/procps/procps_3.3.16.bb
@@ -1,0 +1,101 @@
+SUMMARY = "System and process monitoring utilities"
+DESCRIPTION = "Procps contains a set of system utilities that provide system information about processes using \
+the /proc filesystem. The package includes the programs ps, top, vmstat, w, kill, and skill."
+HOMEPAGE = "https://gitlab.com/procps-ng/procps"
+SECTION = "base"
+LICENSE = "GPLv2+ & LGPLv2+"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+                    file://COPYING.LIB;md5=4cf66a4984120007c9881cc871cf49db \
+                    "
+
+DEPENDS = "ncurses"
+
+inherit autotools gettext pkgconfig update-alternatives
+
+SRC_URI = "git://gitlab.com/procps-ng/procps.git;protocol=https \
+           file://sysctl.conf \
+           "
+SRCREV = "59c88e18f29000ceaf7e5f98181b07be443cf12f"
+
+S = "${WORKDIR}/git"
+
+# Upstream has a custom autogen.sh which invokes po/update-potfiles as they
+# don't ship a po/POTFILES.in (which is silly).  Without that file gettext
+# doesn't believe po/ is a gettext directory and won't generate po/Makefile.
+do_configure_prepend() {
+    ( cd ${S} && po/update-potfiles )
+}
+
+EXTRA_OECONF = "--enable-skill --disable-modern-top"
+
+PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)}"
+PACKAGECONFIG[systemd] = "--with-systemd,--without-systemd,systemd"
+
+do_install_append () {
+	install -d ${D}${base_bindir}
+	[ "${bindir}" != "${base_bindir}" ] && for i in ${base_bindir_progs}; do mv ${D}${bindir}/$i ${D}${base_bindir}/$i; done
+	install -d ${D}${base_sbindir}
+	[ "${sbindir}" != "${base_sbindir}" ] && for i in ${base_sbindir_progs}; do mv ${D}${sbindir}/$i ${D}${base_sbindir}/$i; done
+        if [ "${base_sbindir}" != "${sbindir}" ]; then
+                rmdir ${D}${sbindir}
+        fi
+
+        install -d ${D}${sysconfdir}
+        install -m 0644 ${WORKDIR}/sysctl.conf ${D}${sysconfdir}/sysctl.conf
+        if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+                install -d ${D}${sysconfdir}/sysctl.d
+                ln -sf ../sysctl.conf ${D}${sysconfdir}/sysctl.d/99-sysctl.conf
+        fi
+}
+
+CONFFILES_${PN} = "${sysconfdir}/sysctl.conf"
+
+bindir_progs = "free pkill pmap pgrep pwdx skill snice top uptime w"
+base_bindir_progs += "kill pidof ps watch"
+base_sbindir_progs += "sysctl"
+
+ALTERNATIVE_PRIORITY = "200"
+ALTERNATIVE_PRIORITY[pidof] = "150"
+
+ALTERNATIVE_${PN} = "${bindir_progs} ${base_bindir_progs} ${base_sbindir_progs}"
+
+ALTERNATIVE_${PN}-doc = "kill.1 uptime.1"
+ALTERNATIVE_LINK_NAME[kill.1] = "${mandir}/man1/kill.1"
+ALTERNATIVE_LINK_NAME[uptime.1] = "${mandir}/man1/uptime.1"
+
+python __anonymous() {
+    for prog in d.getVar('base_bindir_progs').split():
+        d.setVarFlag('ALTERNATIVE_LINK_NAME', prog, '%s/%s' % (d.getVar('base_bindir'), prog))
+
+    for prog in d.getVar('base_sbindir_progs').split():
+        d.setVarFlag('ALTERNATIVE_LINK_NAME', prog, '%s/%s' % (d.getVar('base_sbindir'), prog))
+}
+
+# 'ps' isn't suitable for use as a security tool so whitelist this CVE.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1575473#c3
+CVE_CHECK_WHITELIST += "CVE-2018-1121"
+
+PROCPS_PACKAGES = "${PN}-lib \
+                   ${PN}-ps \
+                   ${PN}-sysctl"
+
+PACKAGE_BEFORE_PN = "${PROCPS_PACKAGES}"
+RDEPENDS_${PN} += "${PROCPS_PACKAGES}"
+
+RDEPENDS_${PN}-ps += "${PN}-lib"
+RDEPENDS_${PN}-sysctl += "${PN}-lib"
+
+FILES_${PN}-lib = "${libdir}"
+FILES_${PN}-ps = "${base_bindir}/ps.${BPN}"
+FILES_${PN}-sysctl = "${base_sbindir}/sysctl.${BPN} ${sysconfdir}/sysctl.conf ${sysconfdir}/sysctl.d"
+
+ALTERNATIVE_${PN}_remove = "ps"
+ALTERNATIVE_${PN}_remove = "sysctl"
+
+ALTERNATIVE_${PN}-ps = "ps"
+ALTERNATIVE_TARGET[ps] = "${base_bindir}/ps"
+ALTERNATIVE_LINK_NAME[ps] = "${base_bindir}/ps"
+
+ALTERNATIVE_${PN}-sysctl = "sysctl"
+ALTERNATIVE_TARGET[sysctl] = "${base_sbindir}/sysctl"
+ALTERNATIVE_LINK_NAME[sysctl] = "${base_sbindir}/sysctl"

--- a/meta-balena-thud/recipes-extended/procps/procps/sysctl.conf
+++ b/meta-balena-thud/recipes-extended/procps/procps/sysctl.conf
@@ -1,0 +1,67 @@
+# This configuration taken from procps v3.3.15
+# Commented out kernel/pid_max=10000 line
+#
+# /etc/sysctl.conf - Configuration file for setting system variables
+# See sysctl.conf (5) for information.
+
+# you can have the CD-ROM close when you use it, and open
+# when you are done.
+#dev.cdrom.autoeject = 1
+#dev.cdrom.autoclose = 1
+
+# protection from the SYN flood attack
+net/ipv4/tcp_syncookies=1
+
+# see the evil packets in your log files
+net/ipv4/conf/all/log_martians=1
+
+# makes you vulnerable or not :-)
+net/ipv4/conf/all/accept_redirects=0
+net/ipv4/conf/all/accept_source_route=0
+net/ipv4/icmp_echo_ignore_broadcasts =1
+
+# needed for routing, including masquerading or NAT
+#net/ipv4/ip_forward=1
+
+# sets the port range used for outgoing connections
+#net.ipv4.ip_local_port_range = 32768    61000
+
+# Broken routers and obsolete firewalls will corrupt the window scaling
+# and ECN. Set these values to 0 to disable window scaling and ECN.
+# This may, rarely, cause some performance loss when running high-speed
+# TCP/IP over huge distances or running TCP/IP over connections with high
+# packet loss and modern routers. This sure beats dropped connections.
+#net.ipv4.tcp_ecn = 0
+
+# Swapping too much or not enough? Disks spinning up when you'd
+# rather they didn't? Tweak these.
+#vm.vfs_cache_pressure = 100
+#vm.laptop_mode = 0
+#vm.swappiness = 60
+
+#kernel.printk_ratelimit_burst = 10
+#kernel.printk_ratelimit = 5
+#kernel.panic_on_oops = 0
+
+# Reboot 600 seconds after a panic
+#kernel.panic = 600
+
+# enable SysRq key (note: console security issues)
+#kernel.sysrq = 1
+
+# Change name of core file to start with the command name
+# so you get things like: emacs.core mozilla-bin.core X.core
+#kernel.core_pattern = %e.core
+
+# NIS/YP domain (not always equal to DNS domain)
+#kernel.domainname = example.com
+#kernel.hostname = darkstar
+
+# This limits PID values to 4 digits, which allows tools like ps
+# to save screen space.
+#kernel/pid_max=10000
+
+# Protects against creating or following links under certain conditions
+# See https://www.kernel.org/doc/Documentation/sysctl/fs.txt
+#fs.protected_hardlinks = 1
+#fs.protected_symlinks = 1

--- a/meta-balena-thud/recipes-extended/procps/procps_3.3.16.bb
+++ b/meta-balena-thud/recipes-extended/procps/procps_3.3.16.bb
@@ -1,0 +1,101 @@
+SUMMARY = "System and process monitoring utilities"
+DESCRIPTION = "Procps contains a set of system utilities that provide system information about processes using \
+the /proc filesystem. The package includes the programs ps, top, vmstat, w, kill, and skill."
+HOMEPAGE = "https://gitlab.com/procps-ng/procps"
+SECTION = "base"
+LICENSE = "GPLv2+ & LGPLv2+"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+                    file://COPYING.LIB;md5=4cf66a4984120007c9881cc871cf49db \
+                    "
+
+DEPENDS = "ncurses"
+
+inherit autotools gettext pkgconfig update-alternatives
+
+SRC_URI = "git://gitlab.com/procps-ng/procps.git;protocol=https \
+           file://sysctl.conf \
+           "
+SRCREV = "59c88e18f29000ceaf7e5f98181b07be443cf12f"
+
+S = "${WORKDIR}/git"
+
+# Upstream has a custom autogen.sh which invokes po/update-potfiles as they
+# don't ship a po/POTFILES.in (which is silly).  Without that file gettext
+# doesn't believe po/ is a gettext directory and won't generate po/Makefile.
+do_configure_prepend() {
+    ( cd ${S} && po/update-potfiles )
+}
+
+EXTRA_OECONF = "--enable-skill --disable-modern-top"
+
+PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)}"
+PACKAGECONFIG[systemd] = "--with-systemd,--without-systemd,systemd"
+
+do_install_append () {
+	install -d ${D}${base_bindir}
+	[ "${bindir}" != "${base_bindir}" ] && for i in ${base_bindir_progs}; do mv ${D}${bindir}/$i ${D}${base_bindir}/$i; done
+	install -d ${D}${base_sbindir}
+	[ "${sbindir}" != "${base_sbindir}" ] && for i in ${base_sbindir_progs}; do mv ${D}${sbindir}/$i ${D}${base_sbindir}/$i; done
+        if [ "${base_sbindir}" != "${sbindir}" ]; then
+                rmdir ${D}${sbindir}
+        fi
+
+        install -d ${D}${sysconfdir}
+        install -m 0644 ${WORKDIR}/sysctl.conf ${D}${sysconfdir}/sysctl.conf
+        if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+                install -d ${D}${sysconfdir}/sysctl.d
+                ln -sf ../sysctl.conf ${D}${sysconfdir}/sysctl.d/99-sysctl.conf
+        fi
+}
+
+CONFFILES_${PN} = "${sysconfdir}/sysctl.conf"
+
+bindir_progs = "free pkill pmap pgrep pwdx skill snice top uptime w"
+base_bindir_progs += "kill pidof ps watch"
+base_sbindir_progs += "sysctl"
+
+ALTERNATIVE_PRIORITY = "200"
+ALTERNATIVE_PRIORITY[pidof] = "150"
+
+ALTERNATIVE_${PN} = "${bindir_progs} ${base_bindir_progs} ${base_sbindir_progs}"
+
+ALTERNATIVE_${PN}-doc = "kill.1 uptime.1"
+ALTERNATIVE_LINK_NAME[kill.1] = "${mandir}/man1/kill.1"
+ALTERNATIVE_LINK_NAME[uptime.1] = "${mandir}/man1/uptime.1"
+
+python __anonymous() {
+    for prog in d.getVar('base_bindir_progs').split():
+        d.setVarFlag('ALTERNATIVE_LINK_NAME', prog, '%s/%s' % (d.getVar('base_bindir'), prog))
+
+    for prog in d.getVar('base_sbindir_progs').split():
+        d.setVarFlag('ALTERNATIVE_LINK_NAME', prog, '%s/%s' % (d.getVar('base_sbindir'), prog))
+}
+
+# 'ps' isn't suitable for use as a security tool so whitelist this CVE.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1575473#c3
+CVE_CHECK_WHITELIST += "CVE-2018-1121"
+
+PROCPS_PACKAGES = "${PN}-lib \
+                   ${PN}-ps \
+                   ${PN}-sysctl"
+
+PACKAGE_BEFORE_PN = "${PROCPS_PACKAGES}"
+RDEPENDS_${PN} += "${PROCPS_PACKAGES}"
+
+RDEPENDS_${PN}-ps += "${PN}-lib"
+RDEPENDS_${PN}-sysctl += "${PN}-lib"
+
+FILES_${PN}-lib = "${libdir}"
+FILES_${PN}-ps = "${base_bindir}/ps.${BPN}"
+FILES_${PN}-sysctl = "${base_sbindir}/sysctl.${BPN} ${sysconfdir}/sysctl.conf ${sysconfdir}/sysctl.d"
+
+ALTERNATIVE_${PN}_remove = "ps"
+ALTERNATIVE_${PN}_remove = "sysctl"
+
+ALTERNATIVE_${PN}-ps = "ps"
+ALTERNATIVE_TARGET[ps] = "${base_bindir}/ps"
+ALTERNATIVE_LINK_NAME[ps] = "${base_bindir}/ps"
+
+ALTERNATIVE_${PN}-sysctl = "sysctl"
+ALTERNATIVE_TARGET[sysctl] = "${base_sbindir}/sysctl"
+ALTERNATIVE_LINK_NAME[sysctl] = "${base_sbindir}/sysctl"

--- a/meta-balena-warrior/recipes-extended/procps/procps/sysctl.conf
+++ b/meta-balena-warrior/recipes-extended/procps/procps/sysctl.conf
@@ -1,0 +1,67 @@
+# This configuration taken from procps v3.3.15
+# Commented out kernel/pid_max=10000 line
+#
+# /etc/sysctl.conf - Configuration file for setting system variables
+# See sysctl.conf (5) for information.
+
+# you can have the CD-ROM close when you use it, and open
+# when you are done.
+#dev.cdrom.autoeject = 1
+#dev.cdrom.autoclose = 1
+
+# protection from the SYN flood attack
+net/ipv4/tcp_syncookies=1
+
+# see the evil packets in your log files
+net/ipv4/conf/all/log_martians=1
+
+# makes you vulnerable or not :-)
+net/ipv4/conf/all/accept_redirects=0
+net/ipv4/conf/all/accept_source_route=0
+net/ipv4/icmp_echo_ignore_broadcasts =1
+
+# needed for routing, including masquerading or NAT
+#net/ipv4/ip_forward=1
+
+# sets the port range used for outgoing connections
+#net.ipv4.ip_local_port_range = 32768    61000
+
+# Broken routers and obsolete firewalls will corrupt the window scaling
+# and ECN. Set these values to 0 to disable window scaling and ECN.
+# This may, rarely, cause some performance loss when running high-speed
+# TCP/IP over huge distances or running TCP/IP over connections with high
+# packet loss and modern routers. This sure beats dropped connections.
+#net.ipv4.tcp_ecn = 0
+
+# Swapping too much or not enough? Disks spinning up when you'd
+# rather they didn't? Tweak these.
+#vm.vfs_cache_pressure = 100
+#vm.laptop_mode = 0
+#vm.swappiness = 60
+
+#kernel.printk_ratelimit_burst = 10
+#kernel.printk_ratelimit = 5
+#kernel.panic_on_oops = 0
+
+# Reboot 600 seconds after a panic
+#kernel.panic = 600
+
+# enable SysRq key (note: console security issues)
+#kernel.sysrq = 1
+
+# Change name of core file to start with the command name
+# so you get things like: emacs.core mozilla-bin.core X.core
+#kernel.core_pattern = %e.core
+
+# NIS/YP domain (not always equal to DNS domain)
+#kernel.domainname = example.com
+#kernel.hostname = darkstar
+
+# This limits PID values to 4 digits, which allows tools like ps
+# to save screen space.
+#kernel/pid_max=10000
+
+# Protects against creating or following links under certain conditions
+# See https://www.kernel.org/doc/Documentation/sysctl/fs.txt
+#fs.protected_hardlinks = 1
+#fs.protected_symlinks = 1

--- a/meta-balena-warrior/recipes-extended/procps/procps_3.3.16.bb
+++ b/meta-balena-warrior/recipes-extended/procps/procps_3.3.16.bb
@@ -1,0 +1,101 @@
+SUMMARY = "System and process monitoring utilities"
+DESCRIPTION = "Procps contains a set of system utilities that provide system information about processes using \
+the /proc filesystem. The package includes the programs ps, top, vmstat, w, kill, and skill."
+HOMEPAGE = "https://gitlab.com/procps-ng/procps"
+SECTION = "base"
+LICENSE = "GPLv2+ & LGPLv2+"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+                    file://COPYING.LIB;md5=4cf66a4984120007c9881cc871cf49db \
+                    "
+
+DEPENDS = "ncurses"
+
+inherit autotools gettext pkgconfig update-alternatives
+
+SRC_URI = "git://gitlab.com/procps-ng/procps.git;protocol=https \
+           file://sysctl.conf \
+           "
+SRCREV = "59c88e18f29000ceaf7e5f98181b07be443cf12f"
+
+S = "${WORKDIR}/git"
+
+# Upstream has a custom autogen.sh which invokes po/update-potfiles as they
+# don't ship a po/POTFILES.in (which is silly).  Without that file gettext
+# doesn't believe po/ is a gettext directory and won't generate po/Makefile.
+do_configure_prepend() {
+    ( cd ${S} && po/update-potfiles )
+}
+
+EXTRA_OECONF = "--enable-skill --disable-modern-top"
+
+PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)}"
+PACKAGECONFIG[systemd] = "--with-systemd,--without-systemd,systemd"
+
+do_install_append () {
+	install -d ${D}${base_bindir}
+	[ "${bindir}" != "${base_bindir}" ] && for i in ${base_bindir_progs}; do mv ${D}${bindir}/$i ${D}${base_bindir}/$i; done
+	install -d ${D}${base_sbindir}
+	[ "${sbindir}" != "${base_sbindir}" ] && for i in ${base_sbindir_progs}; do mv ${D}${sbindir}/$i ${D}${base_sbindir}/$i; done
+        if [ "${base_sbindir}" != "${sbindir}" ]; then
+                rmdir ${D}${sbindir}
+        fi
+
+        install -d ${D}${sysconfdir}
+        install -m 0644 ${WORKDIR}/sysctl.conf ${D}${sysconfdir}/sysctl.conf
+        if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+                install -d ${D}${sysconfdir}/sysctl.d
+                ln -sf ../sysctl.conf ${D}${sysconfdir}/sysctl.d/99-sysctl.conf
+        fi
+}
+
+CONFFILES_${PN} = "${sysconfdir}/sysctl.conf"
+
+bindir_progs = "free pkill pmap pgrep pwdx skill snice top uptime w"
+base_bindir_progs += "kill pidof ps watch"
+base_sbindir_progs += "sysctl"
+
+ALTERNATIVE_PRIORITY = "200"
+ALTERNATIVE_PRIORITY[pidof] = "150"
+
+ALTERNATIVE_${PN} = "${bindir_progs} ${base_bindir_progs} ${base_sbindir_progs}"
+
+ALTERNATIVE_${PN}-doc = "kill.1 uptime.1"
+ALTERNATIVE_LINK_NAME[kill.1] = "${mandir}/man1/kill.1"
+ALTERNATIVE_LINK_NAME[uptime.1] = "${mandir}/man1/uptime.1"
+
+python __anonymous() {
+    for prog in d.getVar('base_bindir_progs').split():
+        d.setVarFlag('ALTERNATIVE_LINK_NAME', prog, '%s/%s' % (d.getVar('base_bindir'), prog))
+
+    for prog in d.getVar('base_sbindir_progs').split():
+        d.setVarFlag('ALTERNATIVE_LINK_NAME', prog, '%s/%s' % (d.getVar('base_sbindir'), prog))
+}
+
+# 'ps' isn't suitable for use as a security tool so whitelist this CVE.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1575473#c3
+CVE_CHECK_WHITELIST += "CVE-2018-1121"
+
+PROCPS_PACKAGES = "${PN}-lib \
+                   ${PN}-ps \
+                   ${PN}-sysctl"
+
+PACKAGE_BEFORE_PN = "${PROCPS_PACKAGES}"
+RDEPENDS_${PN} += "${PROCPS_PACKAGES}"
+
+RDEPENDS_${PN}-ps += "${PN}-lib"
+RDEPENDS_${PN}-sysctl += "${PN}-lib"
+
+FILES_${PN}-lib = "${libdir}"
+FILES_${PN}-ps = "${base_bindir}/ps.${BPN}"
+FILES_${PN}-sysctl = "${base_sbindir}/sysctl.${BPN} ${sysconfdir}/sysctl.conf ${sysconfdir}/sysctl.d"
+
+ALTERNATIVE_${PN}_remove = "ps"
+ALTERNATIVE_${PN}_remove = "sysctl"
+
+ALTERNATIVE_${PN}-ps = "ps"
+ALTERNATIVE_TARGET[ps] = "${base_bindir}/ps"
+ALTERNATIVE_LINK_NAME[ps] = "${base_bindir}/ps"
+
+ALTERNATIVE_${PN}-sysctl = "sysctl"
+ALTERNATIVE_TARGET[sysctl] = "${base_sbindir}/sysctl"
+ALTERNATIVE_LINK_NAME[sysctl] = "${base_sbindir}/sysctl"

--- a/meta-resin-pyro/recipes-extended/procps/procps/sysctl.conf
+++ b/meta-resin-pyro/recipes-extended/procps/procps/sysctl.conf
@@ -1,0 +1,67 @@
+# This configuration taken from procps v3.3.15
+# Commented out kernel/pid_max=10000 line
+#
+# /etc/sysctl.conf - Configuration file for setting system variables
+# See sysctl.conf (5) for information.
+
+# you can have the CD-ROM close when you use it, and open
+# when you are done.
+#dev.cdrom.autoeject = 1
+#dev.cdrom.autoclose = 1
+
+# protection from the SYN flood attack
+net/ipv4/tcp_syncookies=1
+
+# see the evil packets in your log files
+net/ipv4/conf/all/log_martians=1
+
+# makes you vulnerable or not :-)
+net/ipv4/conf/all/accept_redirects=0
+net/ipv4/conf/all/accept_source_route=0
+net/ipv4/icmp_echo_ignore_broadcasts =1
+
+# needed for routing, including masquerading or NAT
+#net/ipv4/ip_forward=1
+
+# sets the port range used for outgoing connections
+#net.ipv4.ip_local_port_range = 32768    61000
+
+# Broken routers and obsolete firewalls will corrupt the window scaling
+# and ECN. Set these values to 0 to disable window scaling and ECN.
+# This may, rarely, cause some performance loss when running high-speed
+# TCP/IP over huge distances or running TCP/IP over connections with high
+# packet loss and modern routers. This sure beats dropped connections.
+#net.ipv4.tcp_ecn = 0
+
+# Swapping too much or not enough? Disks spinning up when you'd
+# rather they didn't? Tweak these.
+#vm.vfs_cache_pressure = 100
+#vm.laptop_mode = 0
+#vm.swappiness = 60
+
+#kernel.printk_ratelimit_burst = 10
+#kernel.printk_ratelimit = 5
+#kernel.panic_on_oops = 0
+
+# Reboot 600 seconds after a panic
+#kernel.panic = 600
+
+# enable SysRq key (note: console security issues)
+#kernel.sysrq = 1
+
+# Change name of core file to start with the command name
+# so you get things like: emacs.core mozilla-bin.core X.core
+#kernel.core_pattern = %e.core
+
+# NIS/YP domain (not always equal to DNS domain)
+#kernel.domainname = example.com
+#kernel.hostname = darkstar
+
+# This limits PID values to 4 digits, which allows tools like ps
+# to save screen space.
+#kernel/pid_max=10000
+
+# Protects against creating or following links under certain conditions
+# See https://www.kernel.org/doc/Documentation/sysctl/fs.txt
+#fs.protected_hardlinks = 1
+#fs.protected_symlinks = 1

--- a/meta-resin-pyro/recipes-extended/procps/procps_3.3.16.bb
+++ b/meta-resin-pyro/recipes-extended/procps/procps_3.3.16.bb
@@ -1,0 +1,101 @@
+SUMMARY = "System and process monitoring utilities"
+DESCRIPTION = "Procps contains a set of system utilities that provide system information about processes using \
+the /proc filesystem. The package includes the programs ps, top, vmstat, w, kill, and skill."
+HOMEPAGE = "https://gitlab.com/procps-ng/procps"
+SECTION = "base"
+LICENSE = "GPLv2+ & LGPLv2+"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+                    file://COPYING.LIB;md5=4cf66a4984120007c9881cc871cf49db \
+                    "
+
+DEPENDS = "ncurses"
+
+inherit autotools gettext pkgconfig update-alternatives
+
+SRC_URI = "git://gitlab.com/procps-ng/procps.git;protocol=https \
+           file://sysctl.conf \
+           "
+SRCREV = "59c88e18f29000ceaf7e5f98181b07be443cf12f"
+
+S = "${WORKDIR}/git"
+
+# Upstream has a custom autogen.sh which invokes po/update-potfiles as they
+# don't ship a po/POTFILES.in (which is silly).  Without that file gettext
+# doesn't believe po/ is a gettext directory and won't generate po/Makefile.
+do_configure_prepend() {
+    ( cd ${S} && po/update-potfiles )
+}
+
+EXTRA_OECONF = "--enable-skill --disable-modern-top"
+
+PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)}"
+PACKAGECONFIG[systemd] = "--with-systemd,--without-systemd,systemd"
+
+do_install_append () {
+	install -d ${D}${base_bindir}
+	[ "${bindir}" != "${base_bindir}" ] && for i in ${base_bindir_progs}; do mv ${D}${bindir}/$i ${D}${base_bindir}/$i; done
+	install -d ${D}${base_sbindir}
+	[ "${sbindir}" != "${base_sbindir}" ] && for i in ${base_sbindir_progs}; do mv ${D}${sbindir}/$i ${D}${base_sbindir}/$i; done
+        if [ "${base_sbindir}" != "${sbindir}" ]; then
+                rmdir ${D}${sbindir}
+        fi
+
+        install -d ${D}${sysconfdir}
+        install -m 0644 ${WORKDIR}/sysctl.conf ${D}${sysconfdir}/sysctl.conf
+        if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+                install -d ${D}${sysconfdir}/sysctl.d
+                ln -sf ../sysctl.conf ${D}${sysconfdir}/sysctl.d/99-sysctl.conf
+        fi
+}
+
+CONFFILES_${PN} = "${sysconfdir}/sysctl.conf"
+
+bindir_progs = "free pkill pmap pgrep pwdx skill snice top uptime w"
+base_bindir_progs += "kill pidof ps watch"
+base_sbindir_progs += "sysctl"
+
+ALTERNATIVE_PRIORITY = "200"
+ALTERNATIVE_PRIORITY[pidof] = "150"
+
+ALTERNATIVE_${PN} = "${bindir_progs} ${base_bindir_progs} ${base_sbindir_progs}"
+
+ALTERNATIVE_${PN}-doc = "kill.1 uptime.1"
+ALTERNATIVE_LINK_NAME[kill.1] = "${mandir}/man1/kill.1"
+ALTERNATIVE_LINK_NAME[uptime.1] = "${mandir}/man1/uptime.1"
+
+python __anonymous() {
+    for prog in d.getVar('base_bindir_progs').split():
+        d.setVarFlag('ALTERNATIVE_LINK_NAME', prog, '%s/%s' % (d.getVar('base_bindir'), prog))
+
+    for prog in d.getVar('base_sbindir_progs').split():
+        d.setVarFlag('ALTERNATIVE_LINK_NAME', prog, '%s/%s' % (d.getVar('base_sbindir'), prog))
+}
+
+# 'ps' isn't suitable for use as a security tool so whitelist this CVE.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1575473#c3
+CVE_CHECK_WHITELIST += "CVE-2018-1121"
+
+PROCPS_PACKAGES = "${PN}-lib \
+                   ${PN}-ps \
+                   ${PN}-sysctl"
+
+PACKAGE_BEFORE_PN = "${PROCPS_PACKAGES}"
+RDEPENDS_${PN} += "${PROCPS_PACKAGES}"
+
+RDEPENDS_${PN}-ps += "${PN}-lib"
+RDEPENDS_${PN}-sysctl += "${PN}-lib"
+
+FILES_${PN}-lib = "${libdir}"
+FILES_${PN}-ps = "${base_bindir}/ps.${BPN}"
+FILES_${PN}-sysctl = "${base_sbindir}/sysctl.${BPN} ${sysconfdir}/sysctl.conf ${sysconfdir}/sysctl.d"
+
+ALTERNATIVE_${PN}_remove = "ps"
+ALTERNATIVE_${PN}_remove = "sysctl"
+
+ALTERNATIVE_${PN}-ps = "ps"
+ALTERNATIVE_TARGET[ps] = "${base_bindir}/ps"
+ALTERNATIVE_LINK_NAME[ps] = "${base_bindir}/ps"
+
+ALTERNATIVE_${PN}-sysctl = "sysctl"
+ALTERNATIVE_TARGET[sysctl] = "${base_sbindir}/sysctl"
+ALTERNATIVE_LINK_NAME[sysctl] = "${base_sbindir}/sysctl"

--- a/meta-resin-rocko/recipes-extended/procps/procps/sysctl.conf
+++ b/meta-resin-rocko/recipes-extended/procps/procps/sysctl.conf
@@ -1,0 +1,67 @@
+# This configuration taken from procps v3.3.15
+# Commented out kernel/pid_max=10000 line
+#
+# /etc/sysctl.conf - Configuration file for setting system variables
+# See sysctl.conf (5) for information.
+
+# you can have the CD-ROM close when you use it, and open
+# when you are done.
+#dev.cdrom.autoeject = 1
+#dev.cdrom.autoclose = 1
+
+# protection from the SYN flood attack
+net/ipv4/tcp_syncookies=1
+
+# see the evil packets in your log files
+net/ipv4/conf/all/log_martians=1
+
+# makes you vulnerable or not :-)
+net/ipv4/conf/all/accept_redirects=0
+net/ipv4/conf/all/accept_source_route=0
+net/ipv4/icmp_echo_ignore_broadcasts =1
+
+# needed for routing, including masquerading or NAT
+#net/ipv4/ip_forward=1
+
+# sets the port range used for outgoing connections
+#net.ipv4.ip_local_port_range = 32768    61000
+
+# Broken routers and obsolete firewalls will corrupt the window scaling
+# and ECN. Set these values to 0 to disable window scaling and ECN.
+# This may, rarely, cause some performance loss when running high-speed
+# TCP/IP over huge distances or running TCP/IP over connections with high
+# packet loss and modern routers. This sure beats dropped connections.
+#net.ipv4.tcp_ecn = 0
+
+# Swapping too much or not enough? Disks spinning up when you'd
+# rather they didn't? Tweak these.
+#vm.vfs_cache_pressure = 100
+#vm.laptop_mode = 0
+#vm.swappiness = 60
+
+#kernel.printk_ratelimit_burst = 10
+#kernel.printk_ratelimit = 5
+#kernel.panic_on_oops = 0
+
+# Reboot 600 seconds after a panic
+#kernel.panic = 600
+
+# enable SysRq key (note: console security issues)
+#kernel.sysrq = 1
+
+# Change name of core file to start with the command name
+# so you get things like: emacs.core mozilla-bin.core X.core
+#kernel.core_pattern = %e.core
+
+# NIS/YP domain (not always equal to DNS domain)
+#kernel.domainname = example.com
+#kernel.hostname = darkstar
+
+# This limits PID values to 4 digits, which allows tools like ps
+# to save screen space.
+#kernel/pid_max=10000
+
+# Protects against creating or following links under certain conditions
+# See https://www.kernel.org/doc/Documentation/sysctl/fs.txt
+#fs.protected_hardlinks = 1
+#fs.protected_symlinks = 1

--- a/meta-resin-rocko/recipes-extended/procps/procps_3.3.16.bb
+++ b/meta-resin-rocko/recipes-extended/procps/procps_3.3.16.bb
@@ -1,0 +1,101 @@
+SUMMARY = "System and process monitoring utilities"
+DESCRIPTION = "Procps contains a set of system utilities that provide system information about processes using \
+the /proc filesystem. The package includes the programs ps, top, vmstat, w, kill, and skill."
+HOMEPAGE = "https://gitlab.com/procps-ng/procps"
+SECTION = "base"
+LICENSE = "GPLv2+ & LGPLv2+"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+                    file://COPYING.LIB;md5=4cf66a4984120007c9881cc871cf49db \
+                    "
+
+DEPENDS = "ncurses"
+
+inherit autotools gettext pkgconfig update-alternatives
+
+SRC_URI = "git://gitlab.com/procps-ng/procps.git;protocol=https \
+           file://sysctl.conf \
+           "
+SRCREV = "59c88e18f29000ceaf7e5f98181b07be443cf12f"
+
+S = "${WORKDIR}/git"
+
+# Upstream has a custom autogen.sh which invokes po/update-potfiles as they
+# don't ship a po/POTFILES.in (which is silly).  Without that file gettext
+# doesn't believe po/ is a gettext directory and won't generate po/Makefile.
+do_configure_prepend() {
+    ( cd ${S} && po/update-potfiles )
+}
+
+EXTRA_OECONF = "--enable-skill --disable-modern-top"
+
+PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)}"
+PACKAGECONFIG[systemd] = "--with-systemd,--without-systemd,systemd"
+
+do_install_append () {
+	install -d ${D}${base_bindir}
+	[ "${bindir}" != "${base_bindir}" ] && for i in ${base_bindir_progs}; do mv ${D}${bindir}/$i ${D}${base_bindir}/$i; done
+	install -d ${D}${base_sbindir}
+	[ "${sbindir}" != "${base_sbindir}" ] && for i in ${base_sbindir_progs}; do mv ${D}${sbindir}/$i ${D}${base_sbindir}/$i; done
+        if [ "${base_sbindir}" != "${sbindir}" ]; then
+                rmdir ${D}${sbindir}
+        fi
+
+        install -d ${D}${sysconfdir}
+        install -m 0644 ${WORKDIR}/sysctl.conf ${D}${sysconfdir}/sysctl.conf
+        if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+                install -d ${D}${sysconfdir}/sysctl.d
+                ln -sf ../sysctl.conf ${D}${sysconfdir}/sysctl.d/99-sysctl.conf
+        fi
+}
+
+CONFFILES_${PN} = "${sysconfdir}/sysctl.conf"
+
+bindir_progs = "free pkill pmap pgrep pwdx skill snice top uptime w"
+base_bindir_progs += "kill pidof ps watch"
+base_sbindir_progs += "sysctl"
+
+ALTERNATIVE_PRIORITY = "200"
+ALTERNATIVE_PRIORITY[pidof] = "150"
+
+ALTERNATIVE_${PN} = "${bindir_progs} ${base_bindir_progs} ${base_sbindir_progs}"
+
+ALTERNATIVE_${PN}-doc = "kill.1 uptime.1"
+ALTERNATIVE_LINK_NAME[kill.1] = "${mandir}/man1/kill.1"
+ALTERNATIVE_LINK_NAME[uptime.1] = "${mandir}/man1/uptime.1"
+
+python __anonymous() {
+    for prog in d.getVar('base_bindir_progs').split():
+        d.setVarFlag('ALTERNATIVE_LINK_NAME', prog, '%s/%s' % (d.getVar('base_bindir'), prog))
+
+    for prog in d.getVar('base_sbindir_progs').split():
+        d.setVarFlag('ALTERNATIVE_LINK_NAME', prog, '%s/%s' % (d.getVar('base_sbindir'), prog))
+}
+
+# 'ps' isn't suitable for use as a security tool so whitelist this CVE.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1575473#c3
+CVE_CHECK_WHITELIST += "CVE-2018-1121"
+
+PROCPS_PACKAGES = "${PN}-lib \
+                   ${PN}-ps \
+                   ${PN}-sysctl"
+
+PACKAGE_BEFORE_PN = "${PROCPS_PACKAGES}"
+RDEPENDS_${PN} += "${PROCPS_PACKAGES}"
+
+RDEPENDS_${PN}-ps += "${PN}-lib"
+RDEPENDS_${PN}-sysctl += "${PN}-lib"
+
+FILES_${PN}-lib = "${libdir}"
+FILES_${PN}-ps = "${base_bindir}/ps.${BPN}"
+FILES_${PN}-sysctl = "${base_sbindir}/sysctl.${BPN} ${sysconfdir}/sysctl.conf ${sysconfdir}/sysctl.d"
+
+ALTERNATIVE_${PN}_remove = "ps"
+ALTERNATIVE_${PN}_remove = "sysctl"
+
+ALTERNATIVE_${PN}-ps = "ps"
+ALTERNATIVE_TARGET[ps] = "${base_bindir}/ps"
+ALTERNATIVE_LINK_NAME[ps] = "${base_bindir}/ps"
+
+ALTERNATIVE_${PN}-sysctl = "sysctl"
+ALTERNATIVE_TARGET[sysctl] = "${base_sbindir}/sysctl"
+ALTERNATIVE_LINK_NAME[sysctl] = "${base_sbindir}/sysctl"

--- a/meta-resin-sumo/recipes-extended/procps/procps/sysctl.conf
+++ b/meta-resin-sumo/recipes-extended/procps/procps/sysctl.conf
@@ -1,0 +1,67 @@
+# This configuration taken from procps v3.3.15
+# Commented out kernel/pid_max=10000 line
+#
+# /etc/sysctl.conf - Configuration file for setting system variables
+# See sysctl.conf (5) for information.
+
+# you can have the CD-ROM close when you use it, and open
+# when you are done.
+#dev.cdrom.autoeject = 1
+#dev.cdrom.autoclose = 1
+
+# protection from the SYN flood attack
+net/ipv4/tcp_syncookies=1
+
+# see the evil packets in your log files
+net/ipv4/conf/all/log_martians=1
+
+# makes you vulnerable or not :-)
+net/ipv4/conf/all/accept_redirects=0
+net/ipv4/conf/all/accept_source_route=0
+net/ipv4/icmp_echo_ignore_broadcasts =1
+
+# needed for routing, including masquerading or NAT
+#net/ipv4/ip_forward=1
+
+# sets the port range used for outgoing connections
+#net.ipv4.ip_local_port_range = 32768    61000
+
+# Broken routers and obsolete firewalls will corrupt the window scaling
+# and ECN. Set these values to 0 to disable window scaling and ECN.
+# This may, rarely, cause some performance loss when running high-speed
+# TCP/IP over huge distances or running TCP/IP over connections with high
+# packet loss and modern routers. This sure beats dropped connections.
+#net.ipv4.tcp_ecn = 0
+
+# Swapping too much or not enough? Disks spinning up when you'd
+# rather they didn't? Tweak these.
+#vm.vfs_cache_pressure = 100
+#vm.laptop_mode = 0
+#vm.swappiness = 60
+
+#kernel.printk_ratelimit_burst = 10
+#kernel.printk_ratelimit = 5
+#kernel.panic_on_oops = 0
+
+# Reboot 600 seconds after a panic
+#kernel.panic = 600
+
+# enable SysRq key (note: console security issues)
+#kernel.sysrq = 1
+
+# Change name of core file to start with the command name
+# so you get things like: emacs.core mozilla-bin.core X.core
+#kernel.core_pattern = %e.core
+
+# NIS/YP domain (not always equal to DNS domain)
+#kernel.domainname = example.com
+#kernel.hostname = darkstar
+
+# This limits PID values to 4 digits, which allows tools like ps
+# to save screen space.
+#kernel/pid_max=10000
+
+# Protects against creating or following links under certain conditions
+# See https://www.kernel.org/doc/Documentation/sysctl/fs.txt
+#fs.protected_hardlinks = 1
+#fs.protected_symlinks = 1

--- a/meta-resin-sumo/recipes-extended/procps/procps_3.3.16.bb
+++ b/meta-resin-sumo/recipes-extended/procps/procps_3.3.16.bb
@@ -1,0 +1,101 @@
+SUMMARY = "System and process monitoring utilities"
+DESCRIPTION = "Procps contains a set of system utilities that provide system information about processes using \
+the /proc filesystem. The package includes the programs ps, top, vmstat, w, kill, and skill."
+HOMEPAGE = "https://gitlab.com/procps-ng/procps"
+SECTION = "base"
+LICENSE = "GPLv2+ & LGPLv2+"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+                    file://COPYING.LIB;md5=4cf66a4984120007c9881cc871cf49db \
+                    "
+
+DEPENDS = "ncurses"
+
+inherit autotools gettext pkgconfig update-alternatives
+
+SRC_URI = "git://gitlab.com/procps-ng/procps.git;protocol=https \
+           file://sysctl.conf \
+           "
+SRCREV = "59c88e18f29000ceaf7e5f98181b07be443cf12f"
+
+S = "${WORKDIR}/git"
+
+# Upstream has a custom autogen.sh which invokes po/update-potfiles as they
+# don't ship a po/POTFILES.in (which is silly).  Without that file gettext
+# doesn't believe po/ is a gettext directory and won't generate po/Makefile.
+do_configure_prepend() {
+    ( cd ${S} && po/update-potfiles )
+}
+
+EXTRA_OECONF = "--enable-skill --disable-modern-top"
+
+PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)}"
+PACKAGECONFIG[systemd] = "--with-systemd,--without-systemd,systemd"
+
+do_install_append () {
+	install -d ${D}${base_bindir}
+	[ "${bindir}" != "${base_bindir}" ] && for i in ${base_bindir_progs}; do mv ${D}${bindir}/$i ${D}${base_bindir}/$i; done
+	install -d ${D}${base_sbindir}
+	[ "${sbindir}" != "${base_sbindir}" ] && for i in ${base_sbindir_progs}; do mv ${D}${sbindir}/$i ${D}${base_sbindir}/$i; done
+        if [ "${base_sbindir}" != "${sbindir}" ]; then
+                rmdir ${D}${sbindir}
+        fi
+
+        install -d ${D}${sysconfdir}
+        install -m 0644 ${WORKDIR}/sysctl.conf ${D}${sysconfdir}/sysctl.conf
+        if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+                install -d ${D}${sysconfdir}/sysctl.d
+                ln -sf ../sysctl.conf ${D}${sysconfdir}/sysctl.d/99-sysctl.conf
+        fi
+}
+
+CONFFILES_${PN} = "${sysconfdir}/sysctl.conf"
+
+bindir_progs = "free pkill pmap pgrep pwdx skill snice top uptime w"
+base_bindir_progs += "kill pidof ps watch"
+base_sbindir_progs += "sysctl"
+
+ALTERNATIVE_PRIORITY = "200"
+ALTERNATIVE_PRIORITY[pidof] = "150"
+
+ALTERNATIVE_${PN} = "${bindir_progs} ${base_bindir_progs} ${base_sbindir_progs}"
+
+ALTERNATIVE_${PN}-doc = "kill.1 uptime.1"
+ALTERNATIVE_LINK_NAME[kill.1] = "${mandir}/man1/kill.1"
+ALTERNATIVE_LINK_NAME[uptime.1] = "${mandir}/man1/uptime.1"
+
+python __anonymous() {
+    for prog in d.getVar('base_bindir_progs').split():
+        d.setVarFlag('ALTERNATIVE_LINK_NAME', prog, '%s/%s' % (d.getVar('base_bindir'), prog))
+
+    for prog in d.getVar('base_sbindir_progs').split():
+        d.setVarFlag('ALTERNATIVE_LINK_NAME', prog, '%s/%s' % (d.getVar('base_sbindir'), prog))
+}
+
+# 'ps' isn't suitable for use as a security tool so whitelist this CVE.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1575473#c3
+CVE_CHECK_WHITELIST += "CVE-2018-1121"
+
+PROCPS_PACKAGES = "${PN}-lib \
+                   ${PN}-ps \
+                   ${PN}-sysctl"
+
+PACKAGE_BEFORE_PN = "${PROCPS_PACKAGES}"
+RDEPENDS_${PN} += "${PROCPS_PACKAGES}"
+
+RDEPENDS_${PN}-ps += "${PN}-lib"
+RDEPENDS_${PN}-sysctl += "${PN}-lib"
+
+FILES_${PN}-lib = "${libdir}"
+FILES_${PN}-ps = "${base_bindir}/ps.${BPN}"
+FILES_${PN}-sysctl = "${base_sbindir}/sysctl.${BPN} ${sysconfdir}/sysctl.conf ${sysconfdir}/sysctl.d"
+
+ALTERNATIVE_${PN}_remove = "ps"
+ALTERNATIVE_${PN}_remove = "sysctl"
+
+ALTERNATIVE_${PN}-ps = "ps"
+ALTERNATIVE_TARGET[ps] = "${base_bindir}/ps"
+ALTERNATIVE_LINK_NAME[ps] = "${base_bindir}/ps"
+
+ALTERNATIVE_${PN}-sysctl = "sysctl"
+ALTERNATIVE_TARGET[sysctl] = "${base_sbindir}/sysctl"
+ALTERNATIVE_LINK_NAME[sysctl] = "${base_sbindir}/sysctl"


### PR DESCRIPTION
Replace busybox ps link with ps.procps without installing
any other procps packages. This will avoid regression and bloat
from swapping existing busybox links with procps variants.

By using procps as docker expects we can properly handle ps args
such as -e and -o to format output. Busybox is only capable of this
when compiled in "desktop" mode.

This upstream commit to poky has already split the ps binary into
a separate procps package:

https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/?id=507a47a4e5077d5f8f76d9629be6b871dfd8eb90

So for now we can copy this recipe at the commit above into compat branches
and use that version until we pick up a branch newer than gatesgarth.

Change-type: patch
Connects-to: https://github.com/balena-os/balena-engine/issues/236
Changelog-entry: replace busybox ps with procps [klutchell]
Signed-off-by: Kyle Harding <kyle@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
