### PR TITLE
classes:balena-linux-firmware: Fix fw cleanup task ordering

### DIFF
--- a/meta-balena-common/classes/balena-linux-firmware.bbclass
+++ b/meta-balena-common/classes/balena-linux-firmware.bbclass
@@ -57,3 +57,4 @@ python __anonymous() {
 }
 do_iwlwifi_firmware_clean[vardeps] += "IWLWIFI_FW_MIN_API_VARDEPS"
 addtask iwlwifi_firmware_clean after do_install before do_package
+addtask iwlwifi_firmware_clean after do_install before do_populate_sysroot


### PR DESCRIPTION
We need to make sure the firmware cleanup function runs before
do_populate_sysroot otherwise do_populate_sysroot will race with it and
will fail complaining about the missing firmware that
iwlwifi_firmware_clean had just deleted at the same time.

Change-type: patch
Changelog-entry: Fix task ordering for the iwlwifi_firmware_clean task
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
