### PR TITLE
docker-disk: force Go net module to use pure go resolver

### DIFF
--- a/meta-balena-common/recipes-containers/docker-disk/docker-disk.bb
+++ b/meta-balena-common/recipes-containers/docker-disk/docker-disk.bb
@@ -55,6 +55,10 @@ do_compile () {
 	# mismatches
 	DOCKER=$(PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" which docker)
 
+	# Force Go net module to use pure go resolver
+	# This prevents TLS handshake timeouts when net falls back to the cgo resolver
+	export GODEBUG=netdns=go
+
 	# Generate the data filesystem
 	RANDOM=$$
 	_image_name="docker-disk-$RANDOM"


### PR DESCRIPTION
This prevents TLS handshake timeouts when net falls back to the cgo
resolver

Related issue: https://github.com/balena-os/meta-balena/issues/2111

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
