### PR TITLE
systemd/timeinit: use systemd mount unit for /etc/fake-hwclock

### DIFF
--- a/meta-balena-common/recipes-core/systemd/timeinit/fake-hwclock.service
+++ b/meta-balena-common/recipes-core/systemd/timeinit/fake-hwclock.service
@@ -16,8 +16,8 @@
 Description=Restore/save the current clock
 Documentation=man:fake-hwclock(8)
 DefaultDependencies=no
-Requires=bind-etc-fake-hwclock.service
-After=bind-etc-fake-hwclock.service
+Requires=etc-fake\x2dhwclock.mount
+After=etc-fake\x2dhwclock.mount
 Before=sysinit.target systemd-journald.service systemd-fsck-root.service time-set.target timeinit-rtc.service
 Conflicts=shutdown.target
 

--- a/meta-balena-common/recipes-support/resin-mounts/resin-mounts.bb
+++ b/meta-balena-common/recipes-support/resin-mounts/resin-mounts.bb
@@ -12,6 +12,7 @@ SRC_URI += " \
 	file://mnt-sysroot-inactive.automount \
 	file://mnt-sysroot-inactive.mount \
 	file://resin-partition-mounter \
+	file://etc-fake-hwclock.mount \
 	"
 
 SYSTEMD_SERVICE_${PN} += " \
@@ -58,4 +59,5 @@ do_install_prepend () {
 	for service in ${SYSTEMD_SERVICE_resin-mounts}; do
 		install -m 0644 $service ${D}${systemd_unitdir}/system/
 	done
+	install -m 0644 ${WORKDIR}/etc-fake-hwclock.mount ${D}${systemd_unitdir}/system/etc-fake\\x2dhwclock.mount
 }

--- a/meta-balena-common/recipes-support/resin-mounts/resin-mounts.inc
+++ b/meta-balena-common/recipes-support/resin-mounts/resin-mounts.inc
@@ -17,7 +17,6 @@ FILES_${PN} += " \
 
 BINDMOUNTS += " \
 	${sysconfdir}/ssh/hostkeys \
-	/etc/fake-hwclock \
 	/etc/hostname \
 	/etc/openvpn \
 	/etc/NetworkManager/conf.d \
@@ -73,11 +72,6 @@ do_compile () {
 			# sure that is mounted as well
 			sed -i -e "/^Requires=/s/\$/ bind-usr-share-ca-certificates-balena.service/" "$servicefile"
 			sed -i -e "/^After=/s/\$/ bind-usr-share-ca-certificates-balena.service/" "$servicefile"
-		elif [ "$bindmount" = "/etc/fake-hwclock" ]; then
-			# This bind mount needs to be running before the fake-hwclock service starts
-			sed -i -e "s/^\(Requires=\).*/\1resin-state.service resin-state-reset.service/" "$servicefile"
-			sed -i -e "s/^\(After=\).*/\1resin-state.service resin-state-reset.service/" "$servicefile"
-			sed -i -e "/^Before=/s/\$/ fake-hwclock.service/" "$servicefile"
 		fi
 	done
 }

--- a/meta-balena-common/recipes-support/resin-mounts/resin-mounts/etc-fake-hwclock.mount
+++ b/meta-balena-common/recipes-support/resin-mounts/resin-mounts/etc-fake-hwclock.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description=Bind mount for /etc/fake-hwclock
+
+[Mount]
+What=/mnt/state/root-overlay/etc/fake-hwclock
+Where=/etc/fake-hwclock
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Replace the 'bind-etc-fake-hwclock.service' with a systemd mount unit (etc-fake\x2dhwclock.mount).

Using a systemd service to bind mount the /etc/fake-hwclock directory results in systemd generating an internal mount unit for the same directory. This causes problems at shutdown when both methods try to unmount the directory. This frequently leads to the directory being unmounted before the fake-hwclock service has managed to save the system time. This results in an inaccurate fake-hwclock time at next boot and corruption of the journal log.

Testing on a RPi3 shows that the original problem occurs on average every 2-3 boots. With this fix deployed no errors were observed after an overnight test of 563 consecutive reboots.

Change-type: minor
Connects-to: #1919 #2107
Changelog-entry: systemd/timeinit: use systemd mount unit for /etc/fake-hwclock
Signed-off-by: Mark Corbin <mark@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
