### PR TITLE
Update codeowners and test coverage details

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @alexgg @mtoman @markcorbinuk
+*       @alexgg @mtoman @markcorbinuk @majorz @klutchell @jakogut

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,8 @@
 ### Contributor checklist
 <!-- For completed items, change [ ] to [x].  -->
 - [ ] Changes have been tested
+  - [ ] Covered in automated test suite
+  - [ ] Manual test case recorded
 - [ ] `Change-type` present on at least one commit
 - [ ] `Signed-off-by` is present
 - [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)


### PR DESCRIPTION
Update the codeowners list so that all OS team members are default reviewers. This should speed up the PR approvals.

Also, include test coverage details as part of the PR. For external contributions this can be just  a manual test case described in the comments or PR body.