### PR TITLE
resin-u-boot: Make sure import command is available

### DIFF
--- a/meta-balena-common/classes/resin-u-boot.bbclass
+++ b/meta-balena-common/classes/resin-u-boot.bbclass
@@ -63,6 +63,7 @@ UBOOT_VARS = "RESIN_UBOOT_DEVICES \
               OS_BOOTCOUNT_LIMIT \
               CONFIG_RESET_TO_RETRY \
               CONFIG_BOOT_RETRY_TIME \
+              CONFIG_CMD_IMPORTENV \
               CONFIG_CMD_FS_UUID "
 
 python do_generate_resin_uboot_configuration () {


### PR DESCRIPTION
BalenaOS requires the `env import` command to be available so make sure
to configure u-boot accordingly.

Change-type: patch
Changelog-entry: Make sure u-boot is able to import an environment file
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
