### PR TITLE
recipes-bsp: grub: install only release modules

### DIFF
--- a/meta-balena-common/recipes-bsp/grub/grub-efi_%.bbappend
+++ b/meta-balena-common/recipes-bsp/grub/grub-efi_%.bbappend
@@ -1,7 +1,9 @@
 # We don't want grub modules in our sysroot, remove the entire prefix after do_deploy
 # This removes them for x86-64
 do_deploy_append_class-target_x86-64() {
-    cp -r ${D}${libdir}/grub/ ${DEPLOYDIR}/
+    install -d ${DEPLOYDIR}/grub/${GRUB_TARGET}-efi/
+    cp -r ${D}/${libdir}/grub/${GRUB_TARGET}-efi/*.mod \
+        ${DEPLOYDIR}/grub/${GRUB_TARGET}-efi/
     rm -rf ${D}${prefix}
 }
 

--- a/meta-balena-common/recipes-bsp/grub/grub_%.bbappend
+++ b/meta-balena-common/recipes-bsp/grub/grub_%.bbappend
@@ -6,8 +6,9 @@ DEPENDS_append_class-target = " grub-conf"
 # this removes them for aarch64
 FILES_${PN}-common_remove = "${libdir}/${BPN}"
 
-do_deploy_class-target() {
-    cp -r ${D}${libdir}/grub/ ${DEPLOYDIR}/
+do_deploy_class-target_aarch64() {
+    install -d ${DEPLOYDIR}/grub/arm64-efi
+    cp -r ${D}/${libdir}/grub/arm64-efi/*.mod ${DEPLOYDIR}/grub/arm64-efi/
 }
 
 do_deploy() {


### PR DESCRIPTION
GRUB builds modules with both debug and release variants, with *.module
and *.mod extensions respectively.

Install only the release modules in do_deploy() to avoid balooning the
size of the boot partition.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
