### PR TITLE
balena: Make the healthcheck loading service part of balena.service

### DIFF
--- a/meta-balena-common/recipes-containers/balena/balena/balena-healthcheck-image-load
+++ b/meta-balena-common/recipes-containers/balena/balena/balena-healthcheck-image-load
@@ -6,6 +6,7 @@ until $(systemctl is-active --quiet balena.service) ; do
         sleep 1
 done
 
+balena image inspect balena-healthcheck-image >&2 2> /dev/null && exit 0
 balena load -i /usr/lib/balena/balena-healthcheck-image.tar
 
 # The healthcheck image was previously called hello-world.

--- a/meta-balena-common/recipes-containers/balena/balena/balena-healthcheck-image-load.service
+++ b/meta-balena-common/recipes-containers/balena/balena/balena-healthcheck-image-load.service
@@ -2,6 +2,7 @@
 Description=Load balena healthcheck image
 After=balena.service
 Requires=balena.service
+PartOf=balena.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This prevents issues with the health check when the image is manually
removed.

Change-type: patch
Connects-to: https://github.com/balena-os/meta-balena/issues/2010
Signed-off-by: Robert Günzler <robertg@balena.io>