### PR TITLE
grub-efi: build required modules into grub image

### DIFF
--- a/meta-balena-common/recipes-bsp/grub/grub-efi_%.bbappend
+++ b/meta-balena-common/recipes-bsp/grub/grub-efi_%.bbappend
@@ -1,11 +1,13 @@
-# We don't want grub modules in our sysroot, remove the entire prefix after do_deploy
-# This removes them for x86-64
-do_deploy_append_class-target_x86-64() {
-    install -d ${DEPLOYDIR}/grub/${GRUB_TARGET}-efi/
-    cp -r ${D}/${libdir}/grub/${GRUB_TARGET}-efi/*.mod \
-        ${DEPLOYDIR}/grub/${GRUB_TARGET}-efi/
+# We don't want grub modules in our sysroot
+do_install_append_class-target() {
     rm -rf ${D}${prefix}
 }
 
-# also remove the entry from FILES
-FILES_${PN}_remove_class-target_x86-64 = "${libdir}/grub/${GRUB_TARGET}-efi"
+# Modules are built into the grub image for speed and simplicity, but DTs still
+# expect the modules directory to exist in ${DEPLOYDIR}, so create it.
+do_deploy_append_class-target() {
+    install -d ${DEPLOYDIR}/grub/${GRUB_TARGET}-efi/
+}
+
+# build in additional required modules
+GRUB_BUILDIN_append = " regexp probe"

--- a/meta-balena-common/recipes-bsp/grub/grub_%.bbappend
+++ b/meta-balena-common/recipes-bsp/grub/grub_%.bbappend
@@ -6,9 +6,10 @@ DEPENDS_append_class-target = " grub-conf"
 # this removes them for aarch64
 FILES_${PN}-common_remove = "${libdir}/${BPN}"
 
+# Modules are built into the grub image for speed and simplicity, but DTs still
+# expect the modules directory to exist in ${DEPLOYDIR}, so create it.
 do_deploy_class-target_aarch64() {
     install -d ${DEPLOYDIR}/grub/arm64-efi
-    cp -r ${D}/${libdir}/grub/arm64-efi/*.mod ${DEPLOYDIR}/grub/arm64-efi/
 }
 
 do_deploy() {


### PR DESCRIPTION
grub-efi requires modules to be installed in the boot partition, and
resin-image installs them from `${DEPLOYDIR}`.

A normal grub installation installs those modules to `${PREFIX}/${libdir}`
to allow grub tooling to install them at runtime, but we're building the
image with GRUB baked in, so we don't need those in the sysroot.

The first iteration of this bbappend attempted to solve these
constraints by copying the modules from `${D}/${libdir}/grub/` to
`${DEPLOYDIR}` in `do_deploy()`, then removing `${D}${prefix}`. This had the
unfortunate side effect of breaking the build in certain cases, such as
clean builds or reexecuting `do_deploy()` without the other steps of the
build.

Instead, remove the unwanted files in `do_install()`, and append the
required modules to GRUB_BUILDIN to create a standalone grub image
without any external modules at all.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
