### PR TITLE
initrdscripts: always use by-uuid symlink looking for flasher rootfs

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/rootfs
+++ b/meta-balena-common/recipes-core/initrdscripts/files/rootfs
@@ -24,7 +24,9 @@ rootfs_run() {
             if [ "`echo ${bootparam_root} | cut -c1-5`" = "UUID=" ]; then
                 root_uuid=`echo $bootparam_root | cut -c6-`
                 # If the UUIDs have been regenerated there is no by-uuid link
-                if [ -L "/dev/disk/by-uuid/$root_uuid" ];then
+                # Flasher does not use our dynamically generated UUIDs,
+                # we always want to use the by-uuid link for it
+                if [ "${bootparam_flasher}" = "true" ] || [ -L "/dev/disk/by-uuid/$root_uuid" ]; then
                     bootparam_root="/dev/disk/by-uuid/$root_uuid"
                 else
                     bootparam_root="/dev/disk/by-state/active"


### PR DESCRIPTION
If the device with flasher rootfs is slow to bring up and rootfs is defined
as UUID=xxx the waiting loop in rootfs initrd script would assume UUIDs have
just been regenerated and wait for a by-state symlink instead. This only works
for the OS - flasher does not use the dynamically generated UUIDs
therefore we always want to use the by-uuid link for it.

Change-type: patch
Signed-off-by: Michal Toman <michalt@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
