### PR TITLE
kernel-resin: Apply aufs patches if aufs is present in kernel config

### DIFF
--- a/meta-balena-common/classes/kernel-resin.bbclass
+++ b/meta-balena-common/classes/kernel-resin.bbclass
@@ -632,7 +632,8 @@ python do_kernel_resin_aufs_fetch_and_unpack() {
     if balena_storage == "overlay2":
         if int(kernelversion_major) < 4:
             bb.fatal("overlay2 is only available from kernel version 4.0. Can't use overlay2 as BALENA_STORAGE.")
-        return
+        if not bb.utils.contains("RESIN_CONFIGS", "aufs", True, False, d):
+            return
 
     # Everything from here is for aufs
     if os.path.isdir(kernelsource + "/fs/aufs"):
@@ -766,12 +767,12 @@ python do_kernel_resin_aufs_fetch_and_unpack() {
 
 # add our task to task queue - we need the kernel version (so we need to have the sources unpacked and patched) in order to know what aufs patches version we fetch and unpack
 addtask kernel_resin_aufs_fetch_and_unpack after do_patch before do_configure
-kernel_resin_aufs_fetch_and_unpack[vardeps] += "BALENA_STORAGE"
+kernel_resin_aufs_fetch_and_unpack[vardeps] += " BALENA_STORAGE RESIN_CONFIGS"
 
 # copy needed aufs files and apply aufs patches
 apply_aufs_patches () {
     # bail out if it looks like the kernel source tree already has the fs/aufs directory
-    if [ -d ${S}/fs/aufs ] || [ "${BALENA_STORAGE}" != "aufs" ]; then
+    if [ -d ${S}/fs/aufs ] || ! ${@bb.utils.contains('RESIN_CONFIGS','aufs','true','false',d)}; then
         exit
     fi
     cp -r ${WORKDIR}/aufs_standalone/Documentation ${WORKDIR}/aufs_standalone/fs ${S}


### PR DESCRIPTION
Allow installing and patching aufs even if BALENA_STORAGE is overlay2

Change-type: patch
Changelog-entry: Apply aufs patches if aufs is present in kernel config
Signed-off-by: Kyle Harding <kyle@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [x] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
