### PR TITLE
hostapp-update: convert absolute symlinks to relative

### DIFF
--- a/meta-balena-common/recipes-containers/hostapp-update/files/hostapp-update
+++ b/meta-balena-common/recipes-containers/hostapp-update/files/hostapp-update
@@ -60,10 +60,10 @@ if [ ! -f "$SYSROOT/etc/machine-id" ]; then
 	touch "$SYSROOT/etc/machine-id"
 fi
 if [ ! -L "$SYSROOT/sbin/init" ]; then
-	ln -sf /current/boot/init "$SYSROOT/sbin/init"
+	ln -sf ../current/boot/init "$SYSROOT/sbin/init"
 fi
 if [ ! -L "$SYSROOT/boot" ]; then
-	ln -sf /current/boot "$SYSROOT/boot"
+	ln -sf current/boot "$SYSROOT/boot"
 fi
 
 # Remove previous hostapp


### PR DESCRIPTION
Symlinks to /boot and /sbin/init are absolute, which breaks them when
the sysroot is mounted under another system.

Convert them to relative links, so they work in all cases.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
