### PR TITLE
wifi: remove listed example as it's discontinued

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ Check [docs/rollbacks.md](docs/rollbacks.md) for the rollback documentation
 We currently tested and provide explicit support for the following WiFi adapters:
 
 * bcm43143 based adapters
-    * Example: Official RPI WiFi adapter [link](http://thepihut.com/collections/new-products/products/official-raspberry-pi-wifi-adapter)
 
 ### Modems
 


### PR DESCRIPTION
Quick fix on the README, removed link to the official Raspberry Pi WiFi dongle since it's now been discontinued.
This is required to remove it from the docs in this page: https://www.balena.io/docs/reference/hardware/wifi-dongles/
Related docs release party PR: https://github.com/balena-io/docs/pull/1672

Change-type: patch
Signed-off-by: Tomás Migone <tomas@balena.io>