### PR TITLE
patch: Reactivate persistent logging tests

### DIFF
--- a/tests/suites/os/tests/config-json.js
+++ b/tests/suites/os/tests/config-json.js
@@ -45,8 +45,8 @@ module.exports = {
 	title: 'Config.json configuration tests',
 	tests: [
 		{
-			title: '[Disabled] persistentLogging configuration test',
-			run: async function(test) {
+			title: 'persistentLogging configuration test',
+			run: async function (test) {
 				const bootCount = parseInt(
 					await this.context
 						.get()
@@ -74,30 +74,18 @@ module.exports = {
 						),
 				);
 
-				if (testcount === bootCount + 1) {
-					console.log(
-						'Device should show previous boot records - Test Successful',
-					);
-				} else {
-					console.log(
-						'Test Unsuccesful, expected 2 reboots in the logs, observed ' +
-							testcount,
-					);
-				}
-
-				// Test disabled till https://github.com/balena-os/meta-balena/issues/1919 gets resolved
-				// test.is(
-				// parseInt(
-				// 	await this.context
-				// 		.get()
-				// 		.worker.executeCommandInHostOS(
-				// 			'journalctl --list-boots | wc -l',
-				// 			this.context.get().link,
-				// 		),
-				// ),
-				// 	bootCount + 1,
-				// 	'Device should show previous boot records',
-				// );
+				test.is(
+					parseInt(
+						await this.context
+							.get()
+							.worker.executeCommandInHostOS(
+								'journalctl --list-boots | wc -l',
+								this.context.get().link,
+							),
+					),
+					bootCount + 1,
+					'Device should show previous boot records',
+				);
 			},
 		},
 		{


### PR DESCRIPTION
With the merge of #2114, we can hopefully reactivate the persistent logging tests.

