### PR TITLE
linux: Add out-of-tree module gb-netlink recipe

### DIFF
--- a/meta-balena-common/recipes-kernel/gb-netlink/gb-netlink.bb
+++ b/meta-balena-common/recipes-kernel/gb-netlink/gb-netlink.bb
@@ -1,0 +1,18 @@
+SUMMARY = "Out-of-tree Greybus module to communicate with the Linux Greybus facilities through userspace"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e8c1458438ead3c34974bc0be3a03ed6"
+
+inherit module
+
+SRC_URI = "git://git@github.com/cfriedt/gb-netlink.git;branch=gb_netlink"
+SRCREV = "518363b7bbefe31d65d3e9757e8759e28e5f6917"
+S = "${WORKDIR}/git"
+
+EXTRA_OEMAKE += "KERNELDIR='${STAGING_KERNEL_DIR}'"
+
+module_do_install() {
+    install -d ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/kernel/drivers/greybus/
+	install -m 0644 *.ko ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/kernel/drivers/greybus/
+}
+
+KERNEL_MODULE_AUTOLOAD += "gb-netlink"


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
