### PR TITLE
resin-mounts/etc-fake-hwclock: add dependency on resin-state services

### DIFF
--- a/meta-balena-common/recipes-support/resin-mounts/resin-mounts/etc-fake-hwclock.mount
+++ b/meta-balena-common/recipes-support/resin-mounts/resin-mounts/etc-fake-hwclock.mount
@@ -1,5 +1,7 @@
 [Unit]
 Description=Bind mount for /etc/fake-hwclock
+Requires=resin-state.service resin-state-reset.service
+After=resin-state.service resin-state-reset.service
 
 [Mount]
 What=/mnt/state/root-overlay/etc/fake-hwclock


### PR DESCRIPTION
Added a dependency on resin-state.service and resin-state-reset.service to etc-fake-hwclock.mount.

On initial boot after flashing a device the resin-state-reset.service was running after etc-fake-hwclock.mount causing the bind mount point /mnt/state/root-overlay/etc/fake-hwclock to be deleted after it had been mounted. This resulted in a failure to save the date/time at shutdown which caused problems with persistent logging at next boot. Subsequent boots are unaffected as resin-state-reset does not run. Adding a dependency on the resin-state services ensures that the bind mount point is created after the state reset has been performed.

This issue was noticed when running the testbot unmanaged OS image persistent logging test. When running a managed OS image the device normally reboots fairly immediately after connecting to the balena-cloud host and receiving parameter updates, so this issue is not usually noticeable.

This fix was tested using a RPi3 build and a local testbot rig. The Leviathan tests were edited to only run the 'persistent logging' test which had previously failed due to this issue. The test was run 10 consecutive times on the new code without any errors being reported.

Change-type: patch
Connects-to: #2146 #2143
Changelog-entry: resin-mounts/etc-fake-hwclock: add dependency on resin-state services
Signed-off-by: Mark Corbin <mark@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [x] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
