### PR TITLE
repo.yml: Move balena-supervisor reference to balena-os

### DIFF
--- a/repo.yml
+++ b/repo.yml
@@ -8,7 +8,7 @@ backports:
 
 upstream:
   - repo: 'balena-supervisor'
-    url: 'https://github.com/balena-io/balena-supervisor'
+    url: 'https://github.com/balena-os/balena-supervisor'
   - repo: 'healthdog'
     url: 'https://github.com/balena-os/healthdog-rs'
   - repo: 'os-config'


### PR DESCRIPTION
The balena-supervisor repository has been moved to balena-os so the
repo.yml file needs to be corrected for nested changelogs to work again.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
