### PR TITLE
udev: Silence warnings from resin_update_state_probe

### DIFF
--- a/meta-balena-common/recipes-core/systemd/systemd/60-resin-update-state.rules
+++ b/meta-balena-common/recipes-core/systemd/systemd/60-resin-update-state.rules
@@ -1,5 +1,6 @@
-ACTION=="remove", GOTO="resin_update_state_end"
+ACTION!="add|change", GOTO="resin_update_state_end"
 SUBSYSTEM!="block", GOTO="resin_update_state_end"
+KERNEL=="loop*|ram*|zram*", GOTO="resin_update_state_end"
 
 # Identify balena partitions by the resin-* filesystem label
 ENV{ID_FS_LABEL_ENC}=="resin-*", IMPORT{program}="/lib/udev/resin_update_state_probe $devnode $env{ID_FS_LABEL_ENC} $parent"

--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -106,5 +106,6 @@ module.exports = {
 		// './tests/boot-splash',
 		'./tests/connectivity',
 		'./tests/engine-healthcheck',
+		'./tests/udev',
 	],
 };

--- a/tests/suites/os/tests/udev.js
+++ b/tests/suites/os/tests/udev.js
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+module.exports = {
+	title: 'udev tests',
+	tests: [
+		{
+			title: 'Ramdisks, zram and loop devices are not scanned for rootfs',
+			run: async function(test) {
+
+				// This is an artificial condition - it is difficult to say at any moment whether
+				// all the devices have been brought up as some of them may take longer than others.
+				// This waits for the engine to start which should mean the system is up and running.
+				await this.context.get().utils.waitUntil(async () => {
+					return (
+						(await this.context
+							.get()
+							.worker.executeCommandInHostOS(
+								`systemctl is-active --quiet balena.service && echo "pass"`,
+								this.context.get().link,
+							)) === 'pass'
+					);
+				});
+
+				test.is(
+					await this.context
+						.get()
+						.worker.executeCommandInHostOS(
+							`journalctl -u systemd-udevd.service | grep "Failed to substitute variable" >/dev/null 2>&1 || echo "pass"`,
+							this.context.get().link,
+						),
+					"pass",
+					"Udev logs have no warnings from scanning ramdisks, zram or loop devices for rootfs."
+				);
+			},
+		},
+	],
+};


### PR DESCRIPTION
At this moment `resin_update_state_probe` is scanning pretty much every block device for rootfs. This include ramdisks, zram and loop devices which, when scanned, even spam warnings in logs. This patch updates the udev rule to skip such devices and only trigger on add or change events.

We are also suspecting this rule may be causing performance issues during first boot but after looking deeper I am not sure this is the case.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
