### PR TITLE
device-progress: do not force an exit code

### DIFF
--- a/meta-balena-common/recipes-support/resin-device-progress/resin-device-progress/resin-device-progress
+++ b/meta-balena-common/recipes-support/resin-device-progress/resin-device-progress/resin-device-progress
@@ -76,5 +76,3 @@ curl -s -X PATCH "${API_ENDPOINT}/v6/device(uuid='${UUID}')" \
      --data-urlencode "provisioning_progress=$PERCENTAGE" \
      --data-urlencode "provisioning_state=$STATE" \
      --data-urlencode "status=configuring"
-
-exit 0


### PR DESCRIPTION
this script is only used during provisioning and HUP. in provisioning we `|| true` anyway, and
in HUP we would like to use the exit code for retrying

Signed-off-by: Matthew McGinn <matthew@balena.io>
Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
