### PR TITLE
kernel: Always include overlayfs support

### DIFF
--- a/meta-balena-common/classes/kernel-resin.bbclass
+++ b/meta-balena-common/classes/kernel-resin.bbclass
@@ -163,15 +163,12 @@ BALENA_CONFIGS[balena] ?= " \
     CONFIG_KEYS=y \
     CONFIG_MEMCG=y \
     CONFIG_MEMCG_SWAP=y \
+    CONFIG_OVERLAY_FS=y \
     "
 
 BALENA_CONFIGS[aufs] = " \
     CONFIG_AUFS_FS=y \
     CONFIG_AUFS_XATTR=y \
-    "
-
-BALENA_CONFIGS[overlay2] = " \
-    CONFIG_OVERLAY_FS=y \
     "
 
 BALENA_CONFIGS[apple_hfs] = " \


### PR DESCRIPTION
This is needed in preparation for storage migration.
When running hostapp-update, we need to create the target hostapp on
overlayfs, which implies the OS we update from can support both drivers

Change-type: minor
Signed-off-by: Robert Günzler <robertg@balena.io>