### PR TITLE
tests: Add a suite for checking HUPs

### DIFF
--- a/tests/config.js
+++ b/tests/config.js
@@ -1,0 +1,37 @@
+module.exports = [{
+	deviceType: `raspberrypi3`,
+	suite: `${__dirname}/../suites/os`,
+	config: {
+		networkWired: false,
+		networkWireless: true,
+		downloadType: 'local',
+		interactiveTests: false, // redundant
+		balenaApiKey: process.env.BALENA_CLOUD_API_KEY,
+		balenaApiUrl: 'balena-cloud.com',
+		organization: process.env.BALENA_CLOUD_ORG
+	},
+	image: `${__dirname}/balena.img.gz`,
+	workers: {
+		balenaApplication: process.env.BALENA_CLOUD_APP_NAME,
+		apiKey: process.env.BALENA_CLOUD_API_KEY,
+	},
+},
+{
+	deviceType: `raspberrypi3`,
+	suite: `${__dirname}/../suites/hup`,
+	config: {
+		networkWired: false,
+		networkWireless: true,
+		downloadType: 'gunzip',
+		downloadVersion: 'latest',
+		interactiveTests: false, // redundant
+		balenaApiKey: process.env.BALENA_CLOUD_API_KEY,
+		balenaApiUrl: 'balena-cloud.com',
+		organization: process.env.BALENA_CLOUD_ORG
+	},
+	image: `${__dirname}/balena-image.docker`,
+	workers: {
+		balenaApplication: process.env.BALENA_CLOUD_APP_NAME,
+		apiKey: process.env.BALENA_CLOUD_API_KEY,
+	},
+}];

--- a/tests/suites/.editorconfig
+++ b/tests/suites/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[Makefile]
+indent_style = tab

--- a/tests/suites/.eslintrc.json
+++ b/tests/suites/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+	"env": {
+		"browser": false,
+		"commonjs": true,
+		"es6": true,
+		"node": true
+	},
+	"plugins": ["lodash", "jsdoc", "prettier"],
+	"extends": ["standard", "prettier"],
+	"parserOptions": {
+		"sourceType": "module"
+	},
+	"settings": {
+		"jsdoc": {
+			"additionalTagNames": {
+				"customTags": ["fulfil"]
+			}
+		}
+	},
+	"rules": { "standard/computed-property-even-spacing": "off" }
+}

--- a/tests/suites/.prettierrc
+++ b/tests/suites/.prettierrc
@@ -1,0 +1,5 @@
+{
+	"singleQuote": true,
+	"trailingComma": "all",
+	"useTabs": true
+}

--- a/tests/suites/Dockerfile
+++ b/tests/suites/Dockerfile
@@ -1,0 +1,19 @@
+# syntax = docker/dockerfile:1
+
+FROM node:12-alpine AS base
+
+WORKDIR /src
+COPY package*.json ./
+RUN npm ci
+
+COPY .eslintrc.json .prettierrc ./
+COPY os ./os
+COPY hup ./hup
+
+FROM base AS lint
+RUN npm run lint
+
+FROM base AS prettify
+RUN --mount=type=bind,src=./os,target=./os,rw \
+    --mount=type=bind,src=./hup,target=./hup,rw \
+    npm run prettify

--- a/tests/suites/Makefile
+++ b/tests/suites/Makefile
@@ -1,0 +1,6 @@
+
+lint:
+	docker build --target=lint .
+
+prettify:
+	docker build --target=prettify .

--- a/tests/suites/config.js
+++ b/tests/suites/config.js
@@ -22,8 +22,8 @@ module.exports = [{
 	config: {
 		networkWired: false,
 		networkWireless: true,
-		downloadType: 'gunzip',
 		downloadVersion: 'latest',
+		downloadType: 'gunzip',
 		interactiveTests: false, // redundant
 		balenaApiKey: process.env.BALENA_CLOUD_API_KEY,
 		balenaApiUrl: 'balena-cloud.com',

--- a/tests/suites/hup/README.md
+++ b/tests/suites/hup/README.md
@@ -1,0 +1,27 @@
+
+# Hostapp UPdate tests
+
+Test the transition between balenaOS releases via the `hostapp-update` mechanism.
+
+## setup
+
+1. Run a registry on the testbot
+2. Push the "os-under-test" to the registry
+3. Run tests, repeating the following:
+	1. Flash the DUT with the latest balenaOS release (`balena os download --version latest ...`)
+	2. _do test case specific stuff before running hup script_
+	3. Run `hostapp-update -i <testbot>:5000/hostapp`
+	4. _do test case specific stuff before reboot_
+	5. Wait for the DUT to come back online
+	6. _do test case specific stuff after reboot_
+
+# current tests
+
+* [smoke test](./tests/smoke.js): check if we can HUP successfully
+
+## TODO
+
+* [self-serve-dashboard](./tests/self-serve-dashboard.js)
+* [rollback-altboot](./tests/rollback-altboot.js)
+* [rollback-health](./tests/rollback-health.js)
+* [storage migration](./tests/storagemigration.js)

--- a/tests/suites/hup/conf.js
+++ b/tests/suites/hup/conf.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 balena
+ *
+ * @license Apache-2.0
+ */
+
+'use strict';
+
+// Device identification
+function uid(a) {
+	return a
+		? (a ^ (Math.random() * 16)).toString(16)
+		: ([1e15] + 1e15).replace(/[01]/g, uid);
+}
+// Test identification
+const id = `${Math.random()
+	.toString(36)
+	.substring(2, 10)}`;
+
+module.exports = options => {
+	return {
+		id,
+		balena: {
+			apiUrl: options.balenaApiUrl,
+		},
+		balenaOS: {
+			config: {
+				uuid: uid(),
+				pubKey: options.osPubkey,
+			},
+			download: {
+				type: options.downloadType,
+				version: options.downloadVersion,
+				source: options.downloadSource,
+			},
+			network: {
+				wired: options.networkWired,
+				wireless: options.networkWireless,
+			},
+		},
+	};
+};

--- a/tests/suites/hup/package.json
+++ b/tests/suites/hup/package.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "balena-image-fs": "^7.0.6",
+    "bluebird": "^3.5.3",
+    "bluebird-retry": "^0.11.0",
+    "dockerode": "^2.5.8",
+    "fs-extra": "^8.1.0"
+  }
+}

--- a/tests/suites/hup/package.json
+++ b/tests/suites/hup/package.json
@@ -1,8 +1,6 @@
 {
   "dependencies": {
-    "balena-image-fs": "^7.0.6",
     "bluebird": "^3.5.3",
-    "bluebird-retry": "^0.11.0",
     "dockerode": "^2.5.8",
     "fs-extra": "^8.1.0"
   }

--- a/tests/suites/hup/suite.js
+++ b/tests/suites/hup/suite.js
@@ -1,0 +1,460 @@
+/*
+ * Copyright 2021 balena
+ *
+ * @license Apache-2.0
+ */
+
+"use strict";
+
+const fs = require("fs");
+const fse = require("fs-extra");
+const { join } = require("path");
+const { homedir } = require("os");
+const imagefs = require('balena-image-fs');
+const Docker = require('dockerode');
+const retry = require('bluebird-retry');
+const exec = require('bluebird').promisify(require('child_process').exec);
+
+const fetchOS = async (that, version) => {
+    if (version === "latest") {
+      // make sure we always flash the development variant of the latest
+      // OS release
+      const versions = await that.context.get().sdk.balena.models.os.getSupportedVersions(
+          that.suite.deviceType.slug,
+        );
+      version = versions.latest.replace('prod', 'dev');
+    }
+
+    const path = join(that.suite.options.tmpdir, `base_${version}.img`)
+
+    let attempt = 0;
+    const dlOp = async () => {
+      attempt++;
+      that.log(`Fetching balenaOS version ${version}, attempt ${attempt}...`);
+
+      // TODO take version into account for caching...
+      // how does this work for `latest`?
+      if (await fse.pathExists(path)) {
+        that.log(`[Cached used]`);
+        return path;
+      }
+
+      // TODO progress
+      const stream = await that.context.get().sdk.getDownloadStream(
+          that.suite.deviceType.slug,
+          version,
+        );
+      await new Promise((resolve, reject) => {
+        stream.pipe(fs.createWriteStream(path))
+          .on("finish", resolve)
+          .on("error", reject);
+        });
+
+      return path
+    };
+
+    that.suite.teardown.register(async () => {
+        console.log("Base image teardown");
+        fse.unlinkSync(path);
+      });
+
+    return retry(dlOp, { max_retries: 3, interval: 500 });
+};
+
+// configureOS
+// FIXME all of this can go once https://github.com/balena-os/leviathan/pull/433
+// becomes available
+const injectBalenaConfiguration = (image, configuration) => {
+  // taken from: https://github.com/balena-io/leviathan/blob/master/core/lib/components/os/balenaos.js#L31
+  return imagefs.interact(image, 1, async (fs) => {
+    return require("util").promisify(fs.writeFile)("/config.json",
+      JSON.stringify(configuration));
+  });
+};
+const injectNetworkConfiguration = async (image, configuration) => {
+  // taken from: https://github.com/balena-io/leviathan/blob/master/core/lib/components/os/balenaos.js#L43
+  if (configuration.wireless == null) {
+    return;
+  }
+  if (configuration.wireless.ssid == null) {
+    throw new Error(
+      `Invalide wireless configuration: ${configuration.wireless}`,
+    );
+  }
+
+  const wifiConfiguration = [
+    '[connection]',
+    'id=balena-wifi',
+    'type=wifi',
+    '[wifi]',
+    'hidden=true',
+    'mode=infrastructure',
+    `ssid=${configuration.wireless.ssid}`,
+    '[ipv4]',
+    'method=auto',
+    '[ipv6]',
+    'addr-gen-mode=stable-privacy',
+    'method=auto',
+  ];
+
+  if (configuration.wireless.psk) {
+    Reflect.apply(wifiConfiguration.push, wifiConfiguration, [
+      '[wifi-security]',
+      'auth-alg=open',
+      'key-mgmt=wpa-psk',
+      `psk=${configuration.wireless.psk}`,
+    ]);
+  }
+
+  await imagefs.interact(image, 1, async (fs) => {
+    return require("util").promisify(fs.writeFile)("/system-connections/balena-wifi",
+      wifiConfiguration.join('\n'));
+  });
+};
+const configureOS = async (that, imagePath, network, configJson) => {
+  that.log(`Configuring base image`);
+  await injectBalenaConfiguration(imagePath, configJson);
+  await injectNetworkConfiguration(imagePath, network);
+};
+
+const runRegistry = async (that, seedWithImage) => {
+  const docker = new Docker();
+  const registryImage = 'registry:2';
+
+  that.log("Pulling registry image");
+  await docker.pull(registryImage);
+
+  const container = await docker.createContainer({
+    Image: registryImage,
+    HostConfig: {
+      AutoRemove: true,
+      Mounts: [{
+        Type: 'tmpfs',
+        Target: '/var/lib/registry'
+      }],
+      PortBindings: {
+        "5000/tcp": [{
+          "HostPort": "5000",
+        }],
+      },
+    }
+
+  }).then((container) => {
+    that.log("Starting registry");
+    return container.start();
+  });
+
+  that.suite.teardown.register(async () => {
+    that.log(`Teardown registry`);
+    try {
+      await container.kill();
+    } catch (err) {
+      that.log(`Error removing registry container: ${err}`);
+    }
+  });
+
+  that.log("Loading image into registry");
+  const imageName = await docker.loadImage(seedWithImage)
+    .then(res => {
+      return new Promise((resolve, reject) => {
+        var bufs = [];
+        res.on('error', err => reject(err));
+        res.on('data', data => bufs.push(data));
+        res.on('end', () => resolve(JSON.parse(Buffer.concat(bufs))));
+      });
+    })
+    .then(json => {
+      const str = json.stream.split('Loaded image ID: ');
+      if (str.length === 2) {
+        return str[1].trim();
+      }
+      throw new Error('failed to parse image name from loadImage stream');
+    });
+
+  const image = await docker.getImage(imageName);
+  const ref = 'localhost:5000/hostapp';
+
+  await image.tag({ repo: ref, tag: 'latest' });
+  const tagged = await docker.getImage(ref);
+  const digest = await tagged.push({ ref })
+    .then(res => {
+      return new Promise((resolve, reject) => {
+        var bufs = [];
+        res.on('error', err => reject(err));
+        res.on('data', data => bufs.push(JSON.parse(data)));
+        res.on('end', () => resolve(bufs));
+      });
+    })
+    .then(output => {
+      for (let json of output) {
+        if (json.error) {
+          throw new Error(json.error);
+        }
+        if (json.aux && json.aux.Digest) {
+          return json.aux.Digest;
+        }
+      }
+      throw new Error('no digest');
+    });
+  await image.remove();
+
+  // this parses the IP of the wlan0 interface which is the gateway for the DUT
+  // TODO should this be a common func?
+  const testbotIP = (await exec(`ip addr | awk '/inet.*wlan0/{print $2}' | cut -d\/ -f1`)).trim();
+  const hostappRef = `${testbotIP}:5000/hostapp@${digest}`;
+  that.log(`Registry upload complete: ${hostappRef}`);
+
+  that.suite.context.set({
+    hup: {
+      payload: hostappRef,
+    }
+  })
+}
+
+const doHUP = async (that, test, mode, hostapp, target) => {
+  test.comment(`Starting HUP`);
+
+  let hupLog;
+  switch (mode) {
+    case 'local':
+      if (await that.context.get().worker.executeCommandInHostOS(
+        `[[ -f ${hostapp} ]] && echo exists`,
+        target,
+      ) !== 'exists') {
+        throw new Error(
+          `Target image doesn't exists at location "${hostapp}"`,
+        );
+      }
+      test.comment(`Running: hostapp-update -f ${hostapp}`);
+      // TODO do we need to print the output here?
+      hupLog = await that.context.get().worker.executeCommandInHostOS(
+        `hostapp-update -f ${hostapp}`,
+        target,
+      );
+      break;
+
+    case 'image':
+      test.comment(`Running: hostapp-update -i ${hostapp}`);
+      hupLog = await that.context.get().worker.executeCommandInHostOS(
+        `hostapp-update -i ${hostapp}`,
+        target,
+      );
+      break;
+
+    default:
+      throw new Error(`Unsupported HUP mode: ${mode}`);
+  }
+
+  const hupLogPath = join(that.suite.options.tmpdir, `hup.log`);
+  fs.writeFileSync(hupLogPath, hupLog);
+  await that.archiver.add(hupLogPath);
+
+  test.comment(`Finished HUP`);
+};
+
+const doReboot = async (that, test, target) => {
+  test.comment(`Rebooting DUT`);
+  await that.context.get().worker.executeCommandInHostOS(
+    `touch /tmp/reboot-check && systemd-run --on-active=2 reboot`,
+    target,
+  );
+  await that.context.get().utils.waitUntil(async () => {
+    return (
+      (await that.context.get().worker.executeCommandInHostOS(
+        '[[ ! -f /tmp/reboot-check ]] && echo pass || echo fail',
+        target,
+      )) === 'pass'
+    );
+  }, true);
+  test.comment(`DUT is back`);
+};
+
+const getOSVersion = async (that, target) => {
+  // maybe https://github.com/balena-io/leviathan/blob/master/core/lib/components/balena/sdk.js#L210
+  // will do? that one works entirely on the device though...
+  const output = await that.context.get().worker
+    .executeCommandInHostOS(
+      "cat /etc/os-release",
+      target
+    );
+  let match;
+  output
+    .split("\n")
+    .every(x => {
+      if (x.startsWith("VERSION=")) {
+        match = x.split("=")[1];
+        return false;
+      }
+      return true;
+    })
+  return match.replace(/"/g, '');
+}
+
+const initDUT = async (that, test, target) => {
+  test.comment(`Initializing DUT for HUP test`);
+
+  test.comment(`Flashing DUT`);
+  await that.context.get().worker.off();
+  await that.context.get().worker.flash(that.context.get().hup.baseOsImage);
+  await that.context.get().worker.on();
+
+  test.comment(`Waiting for DUT to be reachable`);
+  await that.context.get().utils.waitUntil(async () => {
+      return (
+        (await that.context.get().worker.executeCommandInHostOS(
+            '[[ -f /etc/hostname ]] && echo pass || echo fail',
+            target,
+          )) === 'pass'
+      );
+    }, true);
+  test.comment(`DUT flashed`);
+
+  test.comment(`Configuring DUT to use test suite registry`);
+  // TODO rework this after https://github.com/balena-os/meta-balena/pull/2175
+  // FIXME we should probably use a shared testbotIP method with the runRegistry helper...
+  await that.context.get().worker.executeCommandInHostOS(
+    `mount -o remount,rw / && sed -e "s/driver=systemd/driver=systemd --insecure-registry=$(ip route | awk '/default/{print $3}'):5000/" -i /lib/systemd/system/balena-host.service && systemctl daemon-reload && systemctl restart balena-host && mount -o remount,ro /`,
+    target,
+  );
+  test.comment(`DUT ready`);
+
+  that.teardown.register(async () => {
+    await that.context.get().hup.archiveLogs(this,
+      test, target);
+  })
+}
+
+const archiveLogs = async (that, test, target) => {
+  test.comment(`Archiving HUP artifacts`);
+
+  const rollback = await that.context.get().worker.executeCommandInHostOS(
+    `journalctl --no-pager --no-hostname --unit rollback-health`,
+    target,
+  );
+  const rollbackLogs = join(that.suite.options.tmpdir, `rollback-health.log`);
+  fs.writeFileSync(rollbackLogs, rollback);
+  await that.archiver.add(rollbackLogs);
+
+  const journal = await that.context
+    .get()
+    .worker.executeCommandInHostOS(
+      `journalctl --no-pager --no-hostname --list-boots | awk '{print $1}' | xargs -I{} sh -c 'set -x; journalctl --no-pager --no-hostname -n500 -a -b {};'`,
+      target,
+    );
+  const journalLogs = join(that.suite.options.tmpdir, `journal.log`);
+  fs.writeFileSync(journalLogs, journal);
+  await that.archiver.add(journalLogs);
+}
+
+module.exports = {
+  title: "Hostapp update suite",
+
+  run: async function () {
+    const Worker = this.require("common/worker");
+    const BalenaOS = this.require("components/os/balenaos");
+    const Balena = this.require("components/balena/sdk");
+
+    await fse.ensureDir(this.suite.options.tmpdir);
+
+    this.suite.context.set({
+      utils: this.require("common/utils"),
+      sdk: new Balena(this.suite.options.balena.apiUrl, this.getLogger()),
+      sshKeyPath: join(homedir(), "id"),
+      link: `${this.suite.options.balenaOS.config.uuid.slice(0, 7)}.local`,
+      worker: new Worker(this.suite.deviceType.slug, this.getLogger()),
+    });
+
+    // Network definitions {{{
+    if (this.suite.options.balenaOS.network.wired === true) {
+      this.suite.options.balenaOS.network.wired = {
+        nat: true,
+      };
+    } else {
+      delete this.suite.options.balenaOS.network.wired;
+    }
+    if (this.suite.options.balenaOS.network.wireless === true) {
+      this.suite.options.balenaOS.network.wireless = {
+        ssid: this.suite.options.id,
+        psk: `${this.suite.options.id}_psk`,
+        nat: true,
+      };
+    } else {
+      delete this.suite.options.balenaOS.network.wireless;
+    }
+    // }}}
+
+    this.suite.context.set({
+      os: new BalenaOS(
+        {
+          deviceType: this.suite.deviceType.slug,
+          network: this.suite.options.balenaOS.network,
+          configJson: {
+            uuid: this.suite.options.balenaOS.config.uuid,
+            os: {
+              sshKeys: [
+                await this.context
+                  .get()
+                  .utils.createSSHKey(this.context.get().sshKeyPath),
+              ],
+            },
+            // persistentLogging is managed by the supervisor and only read at first boot
+            persistentLogging: true,
+          },
+        },
+        this.getLogger()
+      ),
+
+      hup: {
+        doHUP:        doHUP,
+        doReboot:     doReboot,
+        fetchOS:      fetchOS,
+        configureOS:  configureOS,
+        getOSVersion: getOSVersion,
+        initDUT:      initDUT,
+        runRegistry:  runRegistry,
+        archiveLogs:  archiveLogs,
+      },
+    });
+
+    this.suite.teardown.register(() => {
+      this.log("Worker teardown");
+      return this.context.get().worker.teardown();
+    });
+
+    this.log("Setting up worker");
+    await this.context
+      .get()
+      .worker.network(this.suite.options.balenaOS.network);
+
+    // Unpack target OS image .gz
+    await this.context.get().os.fetch({
+      type: this.suite.options.balenaOS.download.type,
+      version: this.suite.options.balenaOS.download.version,
+      releaseInfo: this.suite.options.balenaOS.releaseInfo,
+    });
+
+    const path = await this.context.get().hup.fetchOS(
+      this,
+      this.suite.options.balenaOS.download.version,
+    );
+    await this.context.get().hup.configureOS(
+      this,
+      path,
+      this.suite.options.balenaOS.network,
+      this.context.get().os.configJson,
+    );
+    this.suite.context.set({
+      hup: {
+        baseOsImage: path
+      }
+    });
+
+    await this.context.get().hup.runRegistry(this, this.context.get().os.image.path);
+  },
+  tests: [
+    "./tests/smoke",
+    // "./tests/self-serve-dashboard",
+    // "./tests/rollback-altboot",
+    // "./tests/rollback-health",
+  ],
+};

--- a/tests/suites/hup/tests/smoke.js
+++ b/tests/suites/hup/tests/smoke.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 balena
+ *
+ * @license Apache-2.0
+ */
+
+'use strict';
+
+module.exports = {
+  title: 'Smoke test',
+  run: async function (test) {
+    await this.context.get().hup.initDUT(
+      this, test, this.context.get().link);
+
+    const before = await this.context.get().hup.getOSVersion(
+      this, this.context.get().link);
+    test.comment(`VERSION (before): ${before}`);
+
+    await this.context.get().hup.doHUP(this, test, 'image', this.context.get().hup.payload, this.context.get().link);
+
+    test.comment(`Reducing amount of time needed for rollback-health to fail`)
+    // reduce number of failures needed to trigger rollback
+    await this.context.get().worker.executeCommandInHostOS(
+        `sed -i -e "s/COUNT=.*/COUNT=1/g" -e "s/TIMEOUT=.*/TIMEOUT=10/g" $(find /mnt/sysroot/inactive/ | grep "bin/rollback-health")`,
+        this.context.get().link,
+      );
+
+    await this.context.get().hup.doReboot(this, test, this.context.get().link);
+
+    const after = await this.context.get().hup.getOSVersion(
+      this, this.context.get().link);
+    test.comment(`VERSION (after): ${after}`);
+
+    test.comment(`Waiting for rollback-health...`);
+    await this.context.get().utils.waitUntil(async () => {
+      return (
+        (await this.context.get().worker.executeCommandInHostOS(
+          `systemctl status rollback-health.service`,
+          this.context.get().link,
+        )) !== 'active'
+      );
+    }, true);
+
+    test.is(
+      await this.context.get().worker.executeCommandInHostOS(
+        `[ -f /mnt/state/rollback-health-triggered ] && echo fail || echo pass`,
+        this.context.get().link),
+      "pass",
+      "Rollback-health should succeed health checks.",
+    );
+
+    test.is(
+      await this.context.get().worker.executeCommandInHostOS(
+        `[ -f /mnt/state/rollback-health-failed ] && echo fail || echo pass`,
+        this.context.get().link),
+      "pass",
+      "Rollback-health should succeed running previous hooks.",
+    );
+
+    test.comment(`Successful hostapp-update from ${before} to ${after}`);
+  },
+};

--- a/tests/suites/package-lock.json
+++ b/tests/suites/package-lock.json
@@ -1,0 +1,1813 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"@types/json5": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+			"integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+			"dev": true
+		},
+		"acorn": {
+			"version": "5.7.4",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+			"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+			"dev": true
+		},
+		"acorn-jsx": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"dev": true,
+			"requires": {
+				"acorn": "^3.0.4"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+					"dev": true
+				}
+			}
+		},
+		"ajv": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"dev": true,
+			"requires": {
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
+			}
+		},
+		"ajv-keywords": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+			"dev": true
+		},
+		"ansi-escapes": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+			"dev": true
+		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"array-includes": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
+			"integrity": "sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.18.0-next.2",
+				"get-intrinsic": "^1.1.1",
+				"is-string": "^1.0.5"
+			}
+		},
+		"array.prototype.flat": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
+			"integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.18.0-next.1"
+			}
+		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
+			"requires": {
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				}
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"buffer-from": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
+		},
+		"call-bind": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.2"
+			}
+		},
+		"caller-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"dev": true,
+			"requires": {
+				"callsites": "^0.2.0"
+			}
+		},
+		"callsites": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"dev": true
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"chardet": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+			"dev": true
+		},
+		"circular-json": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"dev": true
+		},
+		"cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
+			"requires": {
+				"restore-cursor": "^2.0.0"
+			}
+		},
+		"cli-width": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+			"integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+			"dev": true
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"comment-parser": {
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.5.5.tgz",
+			"integrity": "sha512-oB3TinFT+PV3p8UwDQt71+HkG03+zwPwikDlKU6ZDmql6QX2zFlQ+G0GGSDqyJhdZi4PSlzFBm+YJ+ebOX3Vgw==",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"concat-stream": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
+			}
+		},
+		"contains-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-1.0.0.tgz",
+			"integrity": "sha1-NFizMhhWA+ju0Y9RjUoQiIo6vJE=",
+			"dev": true,
+			"requires": {
+				"normalize-path": "^2.1.1",
+				"path-starts-with": "^1.0.0"
+			}
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
+		},
+		"cross-spawn": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"dev": true,
+			"requires": {
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			}
+		},
+		"debug": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+			"dev": true,
+			"requires": {
+				"ms": "^2.1.1"
+			}
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
+		},
+		"define-properties": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"dev": true,
+			"requires": {
+				"object-keys": "^1.0.12"
+			}
+		},
+		"doctrine": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
+			"requires": {
+				"esutils": "^2.0.2"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"dev": true,
+			"requires": {
+				"is-arrayish": "^0.2.1"
+			}
+		},
+		"es-abstract": {
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+			"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"es-to-primitive": "^1.2.1",
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.2",
+				"is-callable": "^1.2.3",
+				"is-negative-zero": "^2.0.1",
+				"is-regex": "^1.1.2",
+				"is-string": "^1.0.5",
+				"object-inspect": "^1.9.0",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.2",
+				"string.prototype.trimend": "^1.0.4",
+				"string.prototype.trimstart": "^1.0.4",
+				"unbox-primitive": "^1.0.0"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+			"dev": true,
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"eslint": {
+			"version": "4.19.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+			"dev": true,
+			"requires": {
+				"ajv": "^5.3.0",
+				"babel-code-frame": "^6.22.0",
+				"chalk": "^2.1.0",
+				"concat-stream": "^1.6.0",
+				"cross-spawn": "^5.1.0",
+				"debug": "^3.1.0",
+				"doctrine": "^2.1.0",
+				"eslint-scope": "^3.7.1",
+				"eslint-visitor-keys": "^1.0.0",
+				"espree": "^3.5.4",
+				"esquery": "^1.0.0",
+				"esutils": "^2.0.2",
+				"file-entry-cache": "^2.0.0",
+				"functional-red-black-tree": "^1.0.1",
+				"glob": "^7.1.2",
+				"globals": "^11.0.1",
+				"ignore": "^3.3.3",
+				"imurmurhash": "^0.1.4",
+				"inquirer": "^3.0.6",
+				"is-resolvable": "^1.0.0",
+				"js-yaml": "^3.9.1",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.3.0",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.2",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.8.2",
+				"path-is-inside": "^1.0.2",
+				"pluralize": "^7.0.0",
+				"progress": "^2.0.0",
+				"regexpp": "^1.0.1",
+				"require-uncached": "^1.0.3",
+				"semver": "^5.3.0",
+				"strip-ansi": "^4.0.0",
+				"strip-json-comments": "~2.0.1",
+				"table": "4.0.2",
+				"text-table": "~0.2.0"
+			}
+		},
+		"eslint-config-prettier": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.3.0.tgz",
+			"integrity": "sha512-sZwhSTHVVz78+kYD3t5pCWSYEdVSBR0PXnwjDRsUs8ytIrK8PLXw+6FKp8r3Z7rx4ZszdetWlXYKOHoUrrwPlA==",
+			"dev": true,
+			"requires": {
+				"get-stdin": "^6.0.0"
+			}
+		},
+		"eslint-config-standard": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-11.0.0.tgz",
+			"integrity": "sha512-oDdENzpViEe5fwuRCWla7AXQd++/oyIp8zP+iP9jiUPG6NBj3SHgdgtl/kTn00AjeN+1HNvavTKmYbMo+xMOlw==",
+			"dev": true
+		},
+		"eslint-import-resolver-node": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+			"integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+			"dev": true,
+			"requires": {
+				"debug": "^2.6.9",
+				"resolve": "^1.13.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
+		"eslint-module-utils": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz",
+			"integrity": "sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==",
+			"dev": true,
+			"requires": {
+				"debug": "^3.2.7",
+				"pkg-dir": "^2.0.0"
+			}
+		},
+		"eslint-plugin-import": {
+			"version": "2.23.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.0.tgz",
+			"integrity": "sha512-W5v1f7Cbam6BwbSSKtN6+yoUAms07ozbqAEhLOtf5erEqRv7w67PeZuAuBThaUkzdq2GfBx/5GBvxF+NWJshrQ==",
+			"dev": true,
+			"requires": {
+				"array-includes": "^3.1.3",
+				"array.prototype.flat": "^1.2.4",
+				"contains-path": "^1.0.0",
+				"debug": "^2.6.9",
+				"doctrine": "^2.1.0",
+				"eslint-import-resolver-node": "^0.3.4",
+				"eslint-module-utils": "^2.6.1",
+				"find-up": "^2.0.0",
+				"has": "^1.0.3",
+				"is-core-module": "^2.4.0",
+				"minimatch": "^3.0.4",
+				"object.values": "^1.1.3",
+				"pkg-up": "^2.0.0",
+				"read-pkg-up": "^3.0.0",
+				"resolve": "^1.20.0",
+				"tsconfig-paths": "^3.9.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
+		"eslint-plugin-jsdoc": {
+			"version": "3.15.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.15.1.tgz",
+			"integrity": "sha512-xIQ+ajO6M6zsu5XEn5+1QyE1/P1w/l3yAXPCToZjRcrsKsg5yLTsYnrkdoJZJegE70dTZZwQ5bYPCjEbPey6cw==",
+			"dev": true,
+			"requires": {
+				"comment-parser": "^0.5.1",
+				"jsdoctypeparser": "^2.0.0-alpha-8",
+				"lodash": "^4.17.11"
+			}
+		},
+		"eslint-plugin-lodash": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-lodash/-/eslint-plugin-lodash-2.7.0.tgz",
+			"integrity": "sha512-sIEzx85Sy+Higf4W+oLCIyh7ym0OEcmJCzY8ukptlGfkcyVagzYBjhUt1JfkcpT4qZC68+7TzceJSqLu+qwYMg==",
+			"dev": true,
+			"requires": {
+				"lodash": "~4.17.0"
+			}
+		},
+		"eslint-plugin-node": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
+			"integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
+			"dev": true,
+			"requires": {
+				"ignore": "^3.3.6",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.3.3",
+				"semver": "^5.4.1"
+			}
+		},
+		"eslint-plugin-prettier": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz",
+			"integrity": "sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==",
+			"dev": true,
+			"requires": {
+				"prettier-linter-helpers": "^1.0.0"
+			}
+		},
+		"eslint-plugin-promise": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz",
+			"integrity": "sha512-JiFL9UFR15NKpHyGii1ZcvmtIqa3UTwiDAGb8atSffe43qJ3+1czVGN6UtkklpcJ2DVnqvTMzEKRaJdBkAL2aQ==",
+			"dev": true
+		},
+		"eslint-plugin-standard": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.1.0.tgz",
+			"integrity": "sha512-fVcdyuKRr0EZ4fjWl3c+gp1BANFJD1+RaWa2UPYfMZ6jCtp5RG00kSaXnK/dE5sYzt4kaWJ9qdxqUfc0d9kX0w==",
+			"dev": true
+		},
+		"eslint-scope": {
+			"version": "3.7.3",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+			"integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+			"dev": true,
+			"requires": {
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
+			}
+		},
+		"eslint-visitor-keys": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+			"dev": true
+		},
+		"espree": {
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+			"dev": true,
+			"requires": {
+				"acorn": "^5.5.0",
+				"acorn-jsx": "^3.0.0"
+			}
+		},
+		"esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
+		},
+		"esquery": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+			"dev": true,
+			"requires": {
+				"estraverse": "^5.1.0"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"dev": true
+				}
+			}
+		},
+		"esrecurse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
+			"requires": {
+				"estraverse": "^5.2.0"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"dev": true
+				}
+			}
+		},
+		"estraverse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true
+		},
+		"external-editor": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+			"dev": true,
+			"requires": {
+				"chardet": "^0.4.0",
+				"iconv-lite": "^0.4.17",
+				"tmp": "^0.0.33"
+			}
+		},
+		"fast-deep-equal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+			"dev": true
+		},
+		"fast-diff": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
+		},
+		"figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.5"
+			}
+		},
+		"file-entry-cache": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"dev": true,
+			"requires": {
+				"flat-cache": "^1.2.1",
+				"object-assign": "^4.0.1"
+			}
+		},
+		"find-up": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"dev": true,
+			"requires": {
+				"locate-path": "^2.0.0"
+			}
+		},
+		"flat-cache": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+			"integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+			"dev": true,
+			"requires": {
+				"circular-json": "^0.3.1",
+				"graceful-fs": "^4.1.2",
+				"rimraf": "~2.6.2",
+				"write": "^0.2.1"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"functional-red-black-tree": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"dev": true
+		},
+		"get-intrinsic": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1"
+			}
+		},
+		"get-stdin": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+			"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+			"dev": true
+		},
+		"glob": {
+			"version": "7.1.7",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true
+		},
+		"graceful-fs": {
+			"version": "4.2.6",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+			"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+			"dev": true
+		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^2.0.0"
+			}
+		},
+		"has-bigints": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+			"dev": true
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"has-symbols": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+			"dev": true
+		},
+		"hosted-git-info": {
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+			"dev": true
+		},
+		"iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
+		},
+		"ignore": {
+			"version": "3.3.10",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+			"dev": true
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"inquirer": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.0",
+				"cli-cursor": "^2.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^2.0.4",
+				"figures": "^2.0.0",
+				"lodash": "^4.3.0",
+				"mute-stream": "0.0.7",
+				"run-async": "^2.2.0",
+				"rx-lite": "^4.0.8",
+				"rx-lite-aggregates": "^4.0.8",
+				"string-width": "^2.1.0",
+				"strip-ansi": "^4.0.0",
+				"through": "^2.3.6"
+			}
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
+		},
+		"is-bigint": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+			"integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
+			"dev": true
+		},
+		"is-boolean-object": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+			"integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2"
+			}
+		},
+		"is-callable": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+			"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+			"dev": true
+		},
+		"is-core-module": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+			"integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.3"
+			}
+		},
+		"is-date-object": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+			"integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
+			"dev": true
+		},
+		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
+		},
+		"is-negative-zero": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+			"dev": true
+		},
+		"is-number-object": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+			"integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
+			"dev": true
+		},
+		"is-regex": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+			"integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"has-symbols": "^1.0.2"
+			}
+		},
+		"is-resolvable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"dev": true
+		},
+		"is-string": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+			"integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
+			"dev": true
+		},
+		"is-symbol": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.2"
+			}
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"dev": true,
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			}
+		},
+		"jsdoctypeparser": {
+			"version": "2.0.0-alpha-8",
+			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-2.0.0-alpha-8.tgz",
+			"integrity": "sha1-uvE3+44qVYgQrc8Z0tKi9oDpCl8=",
+			"dev": true
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
+		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
+		},
+		"json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
+		},
+		"json5": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.0"
+			}
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
+			}
+		},
+		"load-json-file": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
+			}
+		},
+		"locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"dev": true,
+			"requires": {
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true
+		},
+		"lru-cache": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"dev": true,
+			"requires": {
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
+			}
+		},
+		"mimic-fn": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimist": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"dev": true
+		},
+		"mkdirp": {
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.5"
+			}
+		},
+		"ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true
+		},
+		"mute-stream": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
+		},
+		"normalize-package-data": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+			"dev": true,
+			"requires": {
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			}
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
+			"requires": {
+				"remove-trailing-separator": "^1.0.1"
+			}
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
+		},
+		"object-inspect": {
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+			"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+			"dev": true
+		},
+		"object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true
+		},
+		"object.assign": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3",
+				"has-symbols": "^1.0.1",
+				"object-keys": "^1.1.1"
+			}
+		},
+		"object.values": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
+			"integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.18.0-next.2",
+				"has": "^1.0.3"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"onetime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "^1.0.0"
+			}
+		},
+		"optionator": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+			"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+			"dev": true,
+			"requires": {
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.6",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"word-wrap": "~1.2.3"
+			}
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
+		},
+		"p-limit": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"dev": true,
+			"requires": {
+				"p-try": "^1.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"dev": true,
+			"requires": {
+				"p-limit": "^1.1.0"
+			}
+		},
+		"p-try": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+			"dev": true
+		},
+		"parse-json": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+			"dev": true,
+			"requires": {
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
+			}
+		},
+		"path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+			"dev": true
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"path-is-inside": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
+		},
+		"path-starts-with": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/path-starts-with/-/path-starts-with-1.0.0.tgz",
+			"integrity": "sha1-soJDAV6LE43lcmgqxS2kLmRq2E4=",
+			"dev": true,
+			"requires": {
+				"normalize-path": "^2.1.1"
+			}
+		},
+		"path-type": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+			"dev": true,
+			"requires": {
+				"pify": "^3.0.0"
+			}
+		},
+		"pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+			"dev": true
+		},
+		"pkg-dir": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"dev": true,
+			"requires": {
+				"find-up": "^2.1.0"
+			}
+		},
+		"pkg-up": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+			"dev": true,
+			"requires": {
+				"find-up": "^2.1.0"
+			}
+		},
+		"pluralize": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+			"dev": true
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
+		},
+		"prettier": {
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+			"integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+			"dev": true
+		},
+		"prettier-linter-helpers": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+			"integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+			"dev": true,
+			"requires": {
+				"fast-diff": "^1.1.2"
+			}
+		},
+		"process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
+		},
+		"progress": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"dev": true
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
+		},
+		"read-pkg": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+			"dev": true,
+			"requires": {
+				"load-json-file": "^4.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^3.0.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+			"dev": true,
+			"requires": {
+				"find-up": "^2.0.0",
+				"read-pkg": "^3.0.0"
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"dev": true,
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"regexpp": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+			"integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+			"dev": true
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
+		},
+		"require-uncached": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"dev": true,
+			"requires": {
+				"caller-path": "^0.1.0",
+				"resolve-from": "^1.0.0"
+			}
+		},
+		"resolve": {
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+			"dev": true,
+			"requires": {
+				"is-core-module": "^2.2.0",
+				"path-parse": "^1.0.6"
+			}
+		},
+		"resolve-from": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"dev": true
+		},
+		"restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
+			"requires": {
+				"onetime": "^2.0.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"rimraf": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
+		},
+		"run-async": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+			"dev": true
+		},
+		"rx-lite": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+			"dev": true
+		},
+		"rx-lite-aggregates": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"dev": true,
+			"requires": {
+				"rx-lite": "*"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
+		},
+		"semver": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"dev": true
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
+			"requires": {
+				"shebang-regex": "^1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
+		},
+		"signal-exit": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+			"dev": true
+		},
+		"slice-ansi": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"dev": true,
+			"requires": {
+				"is-fullwidth-code-point": "^2.0.0"
+			}
+		},
+		"spdx-correct": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+			"integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+			"dev": true,
+			"requires": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-exceptions": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+			"dev": true
+		},
+		"spdx-expression-parse": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+			"dev": true,
+			"requires": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-license-ids": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+			"integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+			"dev": true
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
+			"requires": {
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
+			}
+		},
+		"string.prototype.trimend": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+			"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3"
+			}
+		},
+		"string.prototype.trimstart": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+			"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3"
+			}
+		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"strip-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				}
+			}
+		},
+		"strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"dev": true
+		},
+		"strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
+		},
+		"table": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+			"dev": true,
+			"requires": {
+				"ajv": "^5.2.3",
+				"ajv-keywords": "^2.1.0",
+				"chalk": "^2.1.0",
+				"lodash": "^4.17.4",
+				"slice-ansi": "1.0.0",
+				"string-width": "^2.1.1"
+			}
+		},
+		"text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
+		"tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
+			"requires": {
+				"os-tmpdir": "~1.0.2"
+			}
+		},
+		"tsconfig-paths": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+			"integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+			"dev": true,
+			"requires": {
+				"@types/json5": "^0.0.29",
+				"json5": "^1.0.1",
+				"minimist": "^1.2.0",
+				"strip-bom": "^3.0.0"
+			}
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "~1.1.2"
+			}
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
+		},
+		"unbox-primitive": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has-bigints": "^1.0.1",
+				"has-symbols": "^1.0.2",
+				"which-boxed-primitive": "^1.0.2"
+			}
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
+			"requires": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
+		"which-boxed-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+			"dev": true,
+			"requires": {
+				"is-bigint": "^1.0.1",
+				"is-boolean-object": "^1.1.0",
+				"is-number-object": "^1.0.4",
+				"is-string": "^1.0.5",
+				"is-symbol": "^1.0.3"
+			}
+		},
+		"word-wrap": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"dev": true
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"write": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"dev": true,
+			"requires": {
+				"mkdirp": "^0.5.1"
+			}
+		},
+		"yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
+		}
+	}
+}

--- a/tests/suites/package.json
+++ b/tests/suites/package.json
@@ -1,7 +1,7 @@
 {
 	"scripts": {
-		"prettify": "prettier --config ../.prettierrc --write \"{os,release}/**/*.js\"",
-		"lint": "eslint -c ../.eslintrc.* lib tests"
+		"prettify": "prettier --config ./.prettierrc --write \"{os,hup}/**/*.js\"",
+		"lint": "eslint -c ./.eslintrc.* os hup"
 	},
 	"devDependencies": {
 		"eslint": "^4.19.1",


### PR DESCRIPTION
There is an overview over what this is doing here https://github.com/balena-os/meta-balena/blob/rgz/hup-tests/tests/suites/hup/README.md

This depends on:

- [x] https://github.com/balena-os/leviathan/pull/391
- [x] worker queue needs to load-balance rather than duplicate suite-runs, https://github.com/balena-os/leviathan/pull/393
- [x] multi-suite config.js is included with this PR
- [x] substitute device type in config.js if present https://github.com/balena-os/balena-yocto-scripts/pull/212
- [x] jenkins single-suite config.js generation is disabled
