### PR TITLE
Add cloud test suite 

### DIFF
--- a/tests/suites/cloud/conf.js
+++ b/tests/suites/cloud/conf.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 balena
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+// Test identification
+const id = `${Math.random().toString(36).substring(2, 10)}`;
+
+module.exports = (options) => {
+  return {
+    id,
+    balenaOS: {
+      download: {
+        type: options.downloadType,
+        version: options.downloadVersion,
+        source: options.downloadSource,
+      },
+      network: {
+        wired: options.networkWired,
+        wireless: options.networkWireless,
+      },
+    },
+    balena: {
+      application: {
+        env: {
+          delta: options.supervisorDelta || false,
+        },
+      },
+      apiKey: options.balenaApiKey,
+      apiUrl: options.balenaApiUrl,
+      organization: options.organization
+    },
+  };
+};

--- a/tests/suites/cloud/package.json
+++ b/tests/suites/cloud/package.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": {
+    "balena-image-fs": "^7.0.6",
+    "balena-sdk": "^15.34.1",
+    "bluebird": "^3.5.3",
+    "bluebird-retry": "^0.11.0",
+    "dockerode": "^3.2.1",
+    "fs-extra": "^8.1.0",
+    "lodash": "^4.17.11",
+    "request": "^2.88.0",
+    "request-promise": "^4.2.4"
+  }
+}

--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2018 balena
+ *
+ * @license Apache-2.0
+ */
+
+"use strict";
+
+const Bluebird = require("bluebird");
+const fse = require("fs-extra");
+const { join } = require("path");
+const { homedir } = require("os");
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+// required for unwrapping images
+const imagefs = require('balena-image-fs');
+const stream = require('stream');
+const pipeline = util.promisify(stream.pipeline);
+
+module.exports = {
+  title: "Managed BalenaOS release suite",
+  run: async function () {
+    const Worker = this.require("common/worker");
+    const BalenaOS = this.require("components/os/balenaos");
+    const Balena = this.require("components/balena/sdk");
+    // used for `preload`
+    const CLI = this.require("components/balena/cli");
+
+    await fse.ensureDir(this.suite.options.tmpdir);
+
+    // add objects to the context, so that they can be used across all the tests in this suite
+    this.suite.context.set({
+      cloud: new Balena(this.suite.options.balena.apiUrl, this.getLogger()),
+      balena: {
+        name: this.suite.options.id,
+        application: `${this.suite.options.balena.organization}/${this.suite.options.id}`,
+        organization: this.suite.options.balena.organization,
+        sshKey: { label: this.suite.options.id },
+      },
+      cli: new CLI(this.suite.options.balena.apiUrl, this.getLogger()),
+      sshKeyPath: join(homedir(), "id"),
+      utils: this.require("common/utils"),
+      worker: new Worker(this.suite.deviceType.slug, this.getLogger()),
+    });
+
+    // Network definitions - these are given to the testbot via the config sent via the config.js
+    if (this.suite.options.balenaOS.network.wired === true) {
+      this.suite.options.balenaOS.network.wired = {
+        nat: true,
+      };
+    } else {
+      delete this.suite.options.balenaOS.network.wired;
+    }
+    if (this.suite.options.balenaOS.network.wireless === true) {
+      this.suite.options.balenaOS.network.wireless = {
+        ssid: this.suite.options.id,
+        psk: `${this.suite.options.id}_psk`,
+        nat: true,
+      };
+    } else {
+      delete this.suite.options.balenaOS.network.wireless;
+    }
+
+    // Authenticating balenaSDK
+    this.log("Logging into balena with balenaSDK");
+    await this.context
+      .get()
+      .cloud.balena.auth.loginWithToken(this.suite.options.balena.apiKey);
+
+    // create a balena application
+    this.log("Creating application in cloud...");
+    await this.context.get().cloud.balena.models.application.create({
+      name: this.suite.options.id,
+      deviceType: this.suite.deviceType.slug,
+      organization: this.context.get().balena.organization,
+    });
+
+    // remove application when tests are done
+    this.suite.teardown.register(() => {
+      this.log("Removing application");
+      try {
+        return this.context
+        .get()
+        .cloud.balena.models.application.remove(
+          this.context.get().balena.application
+        );
+      } catch(e){
+        this.log(`Error while removing application...`)
+      }
+    });
+
+    // Push a single container application
+    this.log(`Cloning getting started repo...`);
+    this.suite.context.set({
+      appPath: `${__dirname}/app`
+    })
+    await exec(
+      `git clone https://github.com/balena-io-examples/balena-node-hello-world.git ${this.context.get().appPath}`
+    );
+    this.log(`Pushing release to app...`);
+    const initialCommit = await this.context.get().cloud.pushReleaseToApp(this.context.get().balena.application, `${__dirname}/app`)
+    this.suite.context.set({
+      balena: {
+        initialCommit: initialCommit
+      }
+    })
+
+    // create an ssh key, so we can ssh into DUT later
+    await this.context
+      .get()
+      .cloud.balena.models.key.create(
+        this.context.get().balena.sshKey.label,
+        await this.context
+          .get()
+          .utils.createSSHKey(this.context.get().sshKeyPath)
+      );
+    this.suite.teardown.register(() => {
+      return Bluebird.resolve(
+        this.context
+          .get()
+          .cloud.removeSSHKey(this.context.get().balena.sshKey.label)
+      );
+    });
+
+    // generate a uuid
+    this.suite.context.set({
+      balena: {
+        uuid: this.context.get().cloud.balena.models.device.generateUniqueKey(),
+      },
+    });
+
+    this.suite.context.set({
+      os: new BalenaOS(
+        {
+          deviceType: this.suite.deviceType.slug,
+          network: this.suite.options.balenaOS.network,
+        },
+        this.getLogger()
+      ),
+    });
+
+    // unpack OS
+    await this.context.get().os.fetch();
+
+    // If this is a flasher image, and we are using qemu, unwrap
+		if (
+			this.suite.deviceType.data.storage.internal &&
+			process.env.WORKER_TYPE === `qemu`
+		) {
+			const RAW_IMAGE_PATH = `/opt/balena-image-${this.suite.deviceType.slug}.balenaos-img`;
+			const OUTPUT_IMG_PATH = '/data/downloads/unwrapped.img';
+			console.log(`Unwrapping file ${this.context.get().os.image.path}`);
+			console.log(`Looking for ${RAW_IMAGE_PATH}`);
+			try {
+				await imagefs.interact(
+					this.context.get().os.image.path,
+					2,
+					async (fsImg) => {
+						await pipeline(
+							fsImg.createReadStream(RAW_IMAGE_PATH),
+							fse.createWriteStream(OUTPUT_IMG_PATH),
+						);
+					},
+				);
+
+				this.context.get().os.image.path = OUTPUT_IMG_PATH;
+				console.log(`Unwrapped flasher image!`);
+			} catch (e) {
+				// If the outer image doesn't contain an image for installation, ignore the error
+				if (e.code === 'ENOENT') {
+					console.log('Not a flasher image, skipping unwrap');
+				} else {
+					throw e;
+				}
+			}
+		}
+
+    await this.context.get().os.readOsRelease();
+
+    // get config.json for application
+    let config = await this.context
+      .get()
+      .cloud.balena.models.os.getConfig(this.context.get().balena.application, {
+        version: this.context.get().os.contract.version,
+      });
+
+    config.uuid = this.context.get().balena.uuid;
+
+    //register the device with the application, add the api key to the config.json
+    let deviceApiKey = await this.context
+      .get()
+      .cloud.balena.models.device.register(
+        this.context.get().balena.application,
+        this.context.get().balena.uuid
+      );
+    config.deviceApiKey = deviceApiKey.api_key;
+
+    // get newly registered device id, add to config.json
+    await Bluebird.delay(1000 * 10);
+    let devId = await this.context
+      .get()
+      .cloud.balena.models.device.get(this.context.get().balena.uuid);
+    config.deviceId = devId.id;
+    config.persistentLogging = true;
+
+    // get ready to populate DUT image config.json with the attributes we just generated
+    this.context.get().os.addCloudConfig(config);
+
+    // Teardown the worker when the tests end
+    this.suite.teardown.register(() => {
+      this.log("Worker teardown");
+      return this.context.get().worker.teardown();
+    });
+
+    // preload image with the single container application
+    this.log(`Device uuid should be ${this.context.get().balena.uuid}`)
+    this.log("Preloading image...");
+    await this.context.get().os.configure();
+    await this.context.get().cli.preload(this.context.get().os.image.path, {
+      app: this.context.get().balena.application,
+      commit: initialCommit,
+      pin: true,
+    });
+
+    this.log("Setting up worker");
+    await this.context
+      .get()
+      .worker.network(this.suite.options.balenaOS.network);
+
+    await this.context.get().worker.off();
+    await this.context.get().worker.flash(this.context.get().os.image.path);
+    await this.context.get().worker.on();
+
+    this.log("Waiting for device to be reachable");
+    await this.context.get().utils.waitUntil(async() => {
+      console.log(`checking device is online in the dashboard....`)
+      
+      let isOnline =  await this.context
+        .get()
+        .cloud.balena.models.device.isOnline(this.context.get().balena.uuid);
+
+      console.log(isOnline);
+      return isOnline === true
+    });
+
+    // Retrieving journalctl logs
+    this.suite.teardown.register(async () => {
+      await this.context.get().worker.archiveLogs(this.id, this.context.get().link);
+    });
+
+    this.log("Device is online and provisioned successfully");
+    await this.context.get().utils.waitUntil(async () => {
+      this.log("Trying to ssh into device");
+      let hostname = await this.context
+      .get()
+      .cloud.executeCommandInHostOS(
+        "cat /etc/hostname",
+        this.context.get().balena.uuid
+      )
+      return hostname === this.context.get().balena.uuid.slice(0, 7)
+    }, false);
+
+    this.log("Unpinning");
+    await this.context.get().utils.waitUntil(async () => {
+      this.log(`Unpinning device from release`)
+      await this.context
+      .get()
+      .cloud.balena.models.device.trackApplicationRelease(
+        this.context.get().balena.uuid
+      );
+
+      let unpinned = await this.context
+      .get()
+      .cloud.balena.models.device.isTrackingApplicationRelease(this.context.get().balena.uuid)
+
+      return unpinned
+    }, false);
+
+    // wait until the service is running before continuing
+    await this.context.get().cloud.waitUntilServicesRunning(
+      this.context.get().balena.uuid,
+      [`main`],
+      this.context.get().balena.initialCommit
+    )
+  },
+  tests: [
+    "./tests/preload",
+    "./tests/supervisor",
+    "./tests/multicontainer",
+  ],
+};

--- a/tests/suites/cloud/tests/multicontainer/index.js
+++ b/tests/suites/cloud/tests/multicontainer/index.js
@@ -1,0 +1,218 @@
+/* Copyright 2019 balena
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+const waitUntilServicesRunning = async(that, uuid, services, commit, test) => {
+  await that.context.get().utils.waitUntil(async () => {
+    test.comment(`Waiting for device: ${uuid} to run services: ${services} at commit: ${commit}`);
+    let deviceServices = await that.context.get().cloud.balena.models.device.getWithServiceDetails(
+      uuid
+      );
+    let running = false
+    running = services.every((service) => {
+      return (deviceServices.current_services[service][0].status === "Running") && (deviceServices.current_services[service][0].commit === commit)
+    })
+    return running;
+  }, false, 50)
+}
+
+module.exports = {
+  title: "Multicontainer app tests",
+  run: async function (test) {
+    const moveApplicationName = `${
+      this.context.get().balena.application
+    }_MoveDevice`;
+
+    // create new application
+    await this.context.get().cloud.balena.models.application.create({
+      name: `${this.context.get().balena.name}_MoveDevice`,
+      deviceType: this.context.get().os.deviceType,
+      organization: this.context.get().balena.organization,
+    });
+
+    this.context.set({
+      moveApp: moveApplicationName,
+    });
+
+    this.suite.context.set({
+      moveApp: moveApplicationName,
+    });
+
+    // Remove this app at the end of the test suite
+    this.suite.teardown.register(() => {
+      this.log(`Removing application ${moveApplicationName}`);
+      try{
+        return this.context
+        .get()
+        .cloud.balena.models.application.remove(moveApplicationName);
+      }catch(e){
+        this.log(`Error while removing application...`)
+      }
+    });
+
+    // push multicontainer app release to new app
+    test.comment(`Cloning repo...`);
+    await exec(
+      `git clone https://github.com/balena-io-examples/multicontainer-getting-started.git ${__dirname}/app`
+    );
+
+    test.comment(`Pushing release...`);
+    const initialCommit = await this.context.get().cloud.pushReleaseToApp(moveApplicationName, `${__dirname}/app`)
+    this.suite.context.set({
+      multicontainer: {
+        initialCommit: initialCommit
+      }
+    })
+  },
+  tests: [
+    {
+      title: "Move device to multicontainer App",
+      run: async function (test) {
+        // move device to new app
+        await this.context
+          .get()
+          .cloud.balena.models.device.move(
+            this.context.get().balena.uuid,
+            this.context.get().moveApp
+          );
+
+        await waitUntilServicesRunning(
+          this,
+          this.context.get().balena.uuid, 
+          [`frontend`, `proxy`, `data`], 
+          this.context.get().multicontainer.initialCommit,
+          test
+        )
+
+        test.ok(true, "All services running");
+      },
+    },
+    {
+      title: "Set device environment variables",
+      run: async function (test) {
+        let key = "deviceVar";
+        let value = "value";
+
+        // set device variable
+        await this.context
+          .get()
+          .cloud.balena.models.device.envVar.set(
+            this.context.get().balena.uuid,
+            key,
+            value
+          );
+
+        // Check that device env variable is present in each service
+        let services  = [`frontend`, `proxy`, `data`]
+        await this.context.get().utils.waitUntil(async () => {
+          let results = {}
+          for (let service of services){
+            let env = await this.context.get().cloud.executeCommandInContainer(`env`, service, this.context.get().balena.uuid)
+            if (env.includes(`${key}=${value}\n`)){
+              results[service] = true
+            } else {
+              results[service] = false
+            }
+          }
+          return services.every((service) => {
+            return results[service] === true
+          })
+        }, false, 30);
+
+        test.ok(true, `Should see device env variable`);
+      },
+    },
+    {
+      title: "Set service environment variables",
+      run: async function (test) {
+        let key = "serviceVar";
+        let value = "value";
+
+        let services = await this.context
+          .get()
+          .cloud.balena.models.device.getWithServiceDetails(
+            this.context.get().balena.uuid
+          );
+
+        // set device service variable for frontend service
+        await this.context
+          .get()
+          .cloud.balena.models.device.serviceVar.set(
+            this.context.get().balena.uuid,
+            services.current_services.frontend[0].service_id,
+            key,
+            value
+          );
+
+        // Check to see if variable is present in front end service
+        await this.context.get().utils.waitUntil(async () => {
+          test.comment("Checking to see if variables are visible...");
+          let env = await this.context.get().cloud.executeCommandInContainer(`env`, `frontend`, this.context.get().balena.uuid)
+
+          return env.includes(`${key}=${value}\n`);
+        }, false, 30);
+        test.ok(true, `Should service env var in service it was set for`);
+      },
+    },
+    {
+      title: "Move device back to original app",
+      run: async function (test) {
+        // move device to new app
+        await this.context
+          .get()
+          .cloud.balena.models.device.move(
+            this.context.get().balena.uuid,
+            this.context.get().balena.application
+          );
+
+        // get latest commit
+        let commit = await this.context
+        .get()
+        .cloud.balena.models.application.getTargetReleaseHash(
+          this.context.get().balena.application
+        )
+
+        await waitUntilServicesRunning(
+          this,
+          this.context.get().balena.uuid, 
+          [`main`], 
+          commit,
+          test
+        )
+
+        test.ok(
+          true,
+          `Device should have been moved back to original app, and be running its service`
+        );
+
+        // wait until cloud sees device as running original service release - this will allow us to delete the application after
+        await this.context.get().utils.waitUntil(async() => {
+          let deviceHash = await this.context.get().cloud.balena.models.device.getTargetReleaseHash(
+            this.context.get().balena.uuid
+          )
+          return deviceHash === commit
+        })
+
+        test.ok(
+          true,
+          `Device has original app release hash`
+        )
+      },
+    },
+  ],
+};

--- a/tests/suites/cloud/tests/preload/index.js
+++ b/tests/suites/cloud/tests/preload/index.js
@@ -1,0 +1,33 @@
+"use strict";
+const Bluebird = require("bluebird");
+module.exports = {
+  title: "Image preload test",
+  run: async function (test) {
+    // make sure DUT is online
+    await this.context.get().utils.waitUntil(() => {
+      return this.context
+        .get()
+        .cloud.balena.models.device.isOnline(this.context.get().balena.uuid);
+    }, false);
+
+    // wait until the service is running
+    await this.context.get().cloud.waitUntilServicesRunning(
+      this.context.get().balena.uuid, 
+      [`main`], 
+      this.context.get().balena.initialCommit
+    )
+
+    test.ok(true, `Preload commit hash should be ${this.context.get().balena.initialCommit}`);
+
+    // give it some time to be sure no release is downloaded
+    await Bluebird.delay(1000*60)
+
+    let downloadedLog = await this.context.get().cloud.checkLogsContain(
+      this.context.get().balena.uuid, 
+      `Downloading`, 
+      `Supervisor starting`
+    );
+
+    test.ok(!downloadedLog, `Device should run application without downloading`);
+  },
+};

--- a/tests/suites/cloud/tests/supervisor/index.js
+++ b/tests/suites/cloud/tests/supervisor/index.js
@@ -1,0 +1,167 @@
+`use strict`;
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+const waitUntilServicesRunning = async(that, uuid, services, commit, test) => {
+  test.comment(`Waiting for device: ${uuid} to run services: ${services} at commit: ${commit}`);
+  await that.context.get().utils.waitUntil(async () => {
+    let deviceServices = await that.context.get().cloud.balena.models.device.getWithServiceDetails(
+      uuid
+      );
+    let running = false
+    running = services.every((service) => {
+      return (deviceServices.current_services[service][0].status === "Running") && (deviceServices.current_services[service][0].commit === commit)
+    })
+    return running;
+  }, false, 50)
+}
+
+module.exports = {
+  title: "Supervisor test suite",
+  tests: [
+    {
+      title: "Provisioning without deltas",
+      run: async function (test) {
+        test.comment(`Disabling deltas`);
+        await this.context
+          .get()
+          .cloud.balena.models.device.configVar.set(
+            this.context.get().balena.uuid,
+            "BALENA_SUPERVISOR_DELTA",
+            0
+          );
+        
+        // add a comment to the end of the server.js file, to trigger a delta when pushing
+        await exec(`echo "//comment" >> ${this.context.get().appPath}/server.js`);
+        test.comment(`Pushing release...`);
+
+        let secondCommit = await this.context.get().cloud.pushReleaseToApp(
+          this.context.get().balena.application, 
+          `${this.context.get().appPath}`
+        );
+
+        await waitUntilServicesRunning(
+          this,
+          this.context.get().balena.uuid, 
+          [`main`], 
+          secondCommit,
+          test
+        )
+
+        // device should have downloaded application without mentioning that deltas are being used
+        let usedDeltas = await this.context.get().cloud.checkLogsContain(
+          this.context.get().balena.uuid, 
+          `Downloading delta for image`, 
+          `Applied configuration change {"SUPERVISOR_DELTA":"0"}`
+        );
+
+        test.is(
+          !usedDeltas,
+          true,
+          `Device shouldn't use deltas to download new release`
+        );
+        
+        // re-enable deltas to save time later
+        await this.context
+        .get()
+        .cloud.balena.models.device.configVar.set(
+          this.context.get().balena.uuid,
+          "BALENA_SUPERVISOR_DELTA",
+          1
+        );
+      },
+    },
+    {
+      title: "Override lock test",
+      run: async function (test) {
+        let firstCommit = await this.context.get().cloud.balena.models.application.getTargetReleaseHash(
+          this.context.get().balena.application
+        )
+
+        // create a lockfile
+        let createLockfile = await this.context.get().cloud.executeCommandInContainer(
+          `bash -c '(flock -x -n 200)200>/tmp/balena/updates.lock'`, 
+          `main`,
+          this.context.get().balena.uuid)
+
+        // push release to application
+        await exec(`echo "//comment" >> ${this.context.get().appPath}/server.js`);
+        test.comment(`Pushing release...`);
+        let secondCommit = await this.context.get().cloud.pushReleaseToApp(
+          this.context.get().balena.application, 
+          `${this.context.get().appPath}` // push original release to application (node hello world)
+        );
+
+        // check original application is downloaded - shouldn't be installed
+        await this.context.get().utils.waitUntil(async () => {
+          test.comment(
+            "Checking if release is downloaded, but not installed..."
+          );
+          let services = await this.context
+            .get()
+            .cloud.balena.models.device.getWithServiceDetails(
+              this.context.get().balena.uuid
+            );
+          let downloaded = false;
+          let originalRunning = false;
+          services.current_services.main.forEach((service) => {
+            if (
+              service.commit === secondCommit &&
+              service.status === "Downloaded"
+            ) {
+              downloaded = true;
+            }
+
+            if (
+              service.commit === firstCommit &&
+              service.status === "Running"
+            ) {
+              originalRunning = true;
+            }
+          });
+          return downloaded && originalRunning;
+        }, false, 50);
+
+        test.ok(
+          true,
+          `Release should be downloaded, but not running due to lockfile`
+        );
+
+        let updatesLocked = await this.context.get().cloud.checkLogsContain(
+          this.context.get().balena.uuid, 
+          `Updates are locked`,           
+        );
+
+        test.ok(updatesLocked, `Update lock message should appear in logs`)
+
+        // enable lock override
+        await this.context
+          .get()
+          .cloud.balena.models.device.configVar.set(
+            this.context.get().balena.uuid,
+            "BALENA_SUPERVISOR_OVERRIDE_LOCK",
+            1
+          );
+
+        await waitUntilServicesRunning(
+          this,
+          this.context.get().balena.uuid, 
+          [`main`], 
+          secondCommit,
+          test
+        )
+
+        test.ok(
+          true,
+          `Second release should now be running, as override lock was enabled`
+        );
+
+        // remove lockfile
+        let removeLockfile = await this.context.get().cloud.executeCommandInContainer(
+          `rm /tmp/balena/updates.lock`, 
+          `main`,
+          this.context.get().balena.uuid)
+      },
+    },
+  ],
+};

--- a/tests/suites/config.js
+++ b/tests/suites/config.js
@@ -32,4 +32,22 @@ module.exports = [{
 		balenaApplication: process.env.BALENA_CLOUD_APP_NAME,
 		apiKey: process.env.BALENA_CLOUD_API_KEY,
 	},
+},
+{
+	deviceType: 'raspberrypi3',
+	suite: `${__dirname}/../suites/cloud`,
+	config: {
+		networkWired: false,
+		networkWireless: true,
+		downloadType: 'local',
+		interactiveTests: false,
+		balenaApiKey: process.env.BALENA_CLOUD_API_KEY,
+		balenaApiUrl: 'balena-cloud.com',
+		organization: process.env.BALENA_CLOUD_ORG
+	},
+	image: `${__dirname}/balena.img.gz`,
+	workers: {
+		balenaApplication: process.env.BALENA_CLOUD_APP_NAME,
+		apiKey: process.env.BALENA_CLOUD_API_KEY,
+	},
 }];


### PR DESCRIPTION
This PR adds equivalent automated tests for the following testlodge tests:

- TC43 Pre-load  and pin release
- TC38 Move device to multicontainer app
- TC132 Apply device variables
- TC128 Move device back to app
- TC09 normal provisioning without deltas
- ~~TC26 supervisor reload test~~ (covered in https://github.com/balena-os/meta-balena/pull/2342)
- TC49 Override lock

These tests differ from the `os` test suite, which tests unmanaged OS features in that they require a managed device.

This PR requires the following to be merged first: 
- https://github.com/balena-os/leviathan/pull/402 (this PR adds some helpers to leviathan for interacting with balenaCloud
- https://github.com/balena-os/leviathan/pull/393 (this allows us to run multiple suites on either the same testbot, or multiple in parallel if possible)
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
