### PR TITLE
Update os-config from v1.2.0 to v1.2.1

### DIFF
--- a/meta-balena-common/recipes-core/os-config/os-config_1.2.1.bb
+++ b/meta-balena-common/recipes-core/os-config/os-config_1.2.1.bb
@@ -8,7 +8,7 @@ inherit cargo
 # how to get os-config could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/os-config/1.2.0"
 SRC_URI += "git://git@github.com/balena-os/os-config.git;protocol=ssh;nobranch=1"
-SRCREV = "46048edd57f3dbe4c03f192f28e85e6a7f1aaca7"
+SRCREV = "72c4eddc15e7378b59cf283e360bf92466ba31c7"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 


### PR DESCRIPTION
Includes rename of resin-supervisor to balena-supervisor.

Connects-to: https://github.com/balena-os/meta-balena/pull/2171
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
