### PR TITLE
Add device tree test to unmanaged suite

### DIFF
--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -115,7 +115,6 @@ module.exports = {
     );
   },
   tests: [
-    "./tests/device-tree",
     "./tests/fingerprint",
     "./tests/os-release",
     "./tests/chrony",
@@ -130,5 +129,6 @@ module.exports = {
     "./tests/connectivity",
     "./tests/engine-healthcheck",
     "./tests/udev",
+    "./tests/device-tree",
   ],
 };

--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -115,6 +115,7 @@ module.exports = {
     );
   },
   tests: [
+    "./tests/device-tree",
     "./tests/fingerprint",
     "./tests/os-release",
     "./tests/chrony",

--- a/tests/suites/os/tests/device-tree/dtoverlay.sh
+++ b/tests/suites/os/tests/device-tree/dtoverlay.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cat /mnt/boot/config.txt | grep -r "dtoverlay" /mnt/boot/config.txt | awk -F= 'BEGIN { ORS="," }; {print "\""$2"\""}' | head -c -1

--- a/tests/suites/os/tests/device-tree/dtparam.sh
+++ b/tests/suites/os/tests/device-tree/dtparam.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cat /mnt/boot/config.txt | grep -r "dtparam" /mnt/boot/config.txt | awk -F= 'BEGIN { ORS="," }; {print "\""$2"\="$3"\""}' | head -c -1

--- a/tests/suites/os/tests/device-tree/index.js
+++ b/tests/suites/os/tests/device-tree/index.js
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+const request = require("request-promise");
+const SUPERVISOR_PORT = 48484;
+
+module.exports = {
+  title: "Device Tree tests",
+  tests: [
+    {
+      title: "DToverlay & DTparam tests",
+      run: async function (test) {
+        const ip = await this.context.get().worker.ip(this.context.get().link);
+
+        // Wait for supervisor API to start
+        await this.context.get().utils.waitUntil(async () => {
+          return (
+            (await request({
+              method: "GET",
+              uri: `http://${ip}:${SUPERVISOR_PORT}/ping`,
+            })) === "OK"
+          );
+        }, false);
+
+        const targetState = {
+          // Whichever target state becomes successful. Add it here. 
+        }
+
+        // FETCH SUPERVISOR KEY from DB
+        // you can get it from the db with the following command sequence in a host terminal:
+        // balena exec - ti resin_supervisor node
+        // sqlite3 = require('sqlite3')
+        // db = new sqlite3.Database('/data/database.sqlite')
+        // db.all('select * from apiSecret', console.log)
+        // Select the key with the global label
+
+        // Setting the DToverlay variables
+        // Understand why this doesn't need credentials or SUPERVISOR_API_KEY
+        const setTargetState = await request({
+          method: "POST",
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          json: true,
+          body: targetState,
+          uri: `http://${ip}:${SUPERVISOR_PORT}/v2/local/target-state`,
+        });
+
+        test.equal(setTargetState, { "status": "success", "message": "OK" }, "DToverlay & DTparam configured successfully");
+
+        await this.context.get().utils.waitUntil(async () => {
+          test.comment("Waiting for DUT to come back online...");
+          return (
+            (await this.context
+              .get()
+              .worker.executeCommandInHostOS(
+                '[[ ! -f /tmp/reboot-check ]] && echo "pass"',
+                this.context.get().link
+              )) === "pass"
+          );
+        }, false);
+
+        // Get the current target state of device
+        const currentState = await request({
+          method: "GET",
+          uri: `http://${ip}:${SUPERVISOR_PORT}/v2/local/target-state`,
+        });
+
+        test.equal(currentState.state.local.config["HOST_CONFIG_dtoverlay"], targetState.local.config["HOST_CONFIG_dtoverlay"], "DToverlay successfully set by Supervisor")
+        test.equal(currentState.state.local.config["HOST_CONFIG_dtparam"], targetState.local.config["HOST_CONFIG_dtparam"], "DTparam successfully set by Supervisor")
+
+        const overlayConfigTxt = this.context
+          .get()
+          .worker.executeCommandInHostOS(
+            `cat /mnt/boot/config.txt | grep SOMETHING_DTOVERLAY`,
+            this.context.get().link
+          );
+
+        test.equal(overlayConfigTxt, targetState.local.config["HOST_CONFIG_dtoverlay"], "DToverlay successfully set in config.txt")
+
+        const paramConfigTxt = this.context
+          .get()
+          .worker.executeCommandInHostOS(
+            `cat /mnt/boot/config.txt | grep SOMETHING_DTPARAM`,
+            this.context.get().link
+          );
+
+        test.equal(paramConfigTxt, targetState.local.config["HOST_CONFIG_dtparam"], "DTparam successfully set in config.txt")
+
+      },
+    },
+  ],
+};

--- a/tests/suites/os/tests/device-tree/index.js
+++ b/tests/suites/os/tests/device-tree/index.js
@@ -16,91 +16,114 @@
 
 const request = require("request-promise");
 const SUPERVISOR_PORT = 48484;
+const fs = require('fs');
 
 module.exports = {
-  title: "Device Tree tests",
-  tests: [
-    {
-      title: "DToverlay & DTparam tests",
-      run: async function (test) {
-        const ip = await this.context.get().worker.ip(this.context.get().link);
+	title: "Device Tree tests",
+	tests: [
+		{
+			title: "DToverlay & DTparam tests",
+			run: async function (test) {
+				const ip = await this.context.get().worker.ip(this.context.get().link);
 
-        // Wait for supervisor API to start
-        await this.context.get().utils.waitUntil(async () => {
-          return (
-            (await request({
-              method: "GET",
-              uri: `http://${ip}:${SUPERVISOR_PORT}/ping`,
-            })) === "OK"
-          );
-        }, false);
+				// Wait for supervisor API to start
+				await this.context.get().utils.waitUntil(async () => {
+					return (
+						(await request({
+							method: "GET",
+							uri: `http://${ip}:${SUPERVISOR_PORT}/ping`,
+						})) === "OK"
+					);
+				}, false);
 
-        const targetState = {
-          // Whichever target state becomes successful. Add it here. 
-        }
+				const targetState = {
+					"local": {
+						"name": "local",
+						"config": {
+							"HOST_CONFIG_dtoverlay": "\"vc4-fkms-v3d\",\"i2c0\",\"i2c1\",\"i2c3\"",
+							"HOST_CONFIG_dtparam": "\"i2c_arm=on\",\"spi=on\",\"audio=on\",\"foo=bar\",\"level=42\"",
+							"SUPERVISOR_PERSISTENT_LOGGING": "true",
+							"SUPERVISOR_LOCAL_MODE": "true"
+						},
+						"apps": {}
+					},
+					"dependent": {
+						"apps": [],
+						"devices": []
+					}
+				}
 
-        // FETCH SUPERVISOR KEY from DB
-        // you can get it from the db with the following command sequence in a host terminal:
-        // balena exec - ti resin_supervisor node
-        // sqlite3 = require('sqlite3')
-        // db = new sqlite3.Database('/data/database.sqlite')
-        // db.all('select * from apiSecret', console.log)
-        // Select the key with the global label
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						'touch /tmp/reboot-check',
+						this.context.get().link,
+					);
 
-        // Setting the DToverlay variables
-        // Understand why this doesn't need credentials or SUPERVISOR_API_KEY
-        const setTargetState = await request({
-          method: "POST",
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          json: true,
-          body: targetState,
-          uri: `http://${ip}:${SUPERVISOR_PORT}/v2/local/target-state`,
-        });
+				// Setting the device tree variables using Supervisor API 
+				const setTargetState = await request({
+					method: "POST",
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					json: true,
+					body: targetState,
+					uri: `http://${ip}:${SUPERVISOR_PORT}/v2/local/target-state`,
+				});
 
-        test.equal(setTargetState, { "status": "success", "message": "OK" }, "DToverlay & DTparam configured successfully");
+				test.same(setTargetState, { status: "success", message: "OK" }, "DToverlay & DTparam configured successfully through Supervisor API");
 
-        await this.context.get().utils.waitUntil(async () => {
-          test.comment("Waiting for DUT to come back online...");
-          return (
-            (await this.context
-              .get()
-              .worker.executeCommandInHostOS(
-                '[[ ! -f /tmp/reboot-check ]] && echo "pass"',
-                this.context.get().link
-              )) === "pass"
-          );
-        }, false);
+				await this.context.get().utils.waitUntil(async () => {
+					test.comment("Waiting for DUT to come back online after reboot...");
+					return (
+						(await this.context
+							.get()
+							.worker.executeCommandInHostOS(
+								'[[ ! -f /tmp/reboot-check ]] && echo "pass"',
+								this.context.get().link
+							)) === "pass"
+					);
+				}, false);
 
-        // Get the current target state of device
-        const currentState = await request({
-          method: "GET",
-          uri: `http://${ip}:${SUPERVISOR_PORT}/v2/local/target-state`,
-        });
+				await this.context.get().utils.waitUntil(async () => {
+					test.comment("Waiting for supervisor to be ready after reboot...");
+					return (
+						(await request({
+							method: "GET",
+							uri: `http://${ip}:${SUPERVISOR_PORT}/ping`,
+						})) === "OK"
+					);
+				}, false);
 
-        test.equal(currentState.state.local.config["HOST_CONFIG_dtoverlay"], targetState.local.config["HOST_CONFIG_dtoverlay"], "DToverlay successfully set by Supervisor")
-        test.equal(currentState.state.local.config["HOST_CONFIG_dtparam"], targetState.local.config["HOST_CONFIG_dtparam"], "DTparam successfully set by Supervisor")
+				// Get the current target state of device
+				const currentState = await request({
+					method: "GET",
+					uri: `http://${ip}:${SUPERVISOR_PORT}/v2/local/target-state`,
+					json: true
+				});
 
-        const overlayConfigTxt = this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            `cat /mnt/boot/config.txt | grep SOMETHING_DTOVERLAY`,
-            this.context.get().link
-          );
+				test.equal(currentState.state.local.config.HOST_CONFIG_dtoverlay, targetState.local.config.HOST_CONFIG_dtoverlay, "DToverlay successfully set in target state")
+				test.equal(currentState.state.local.config.HOST_CONFIG_dtparam, targetState.local.config.HOST_CONFIG_dtparam, "DTparam successfully set in target state")
 
-        test.equal(overlayConfigTxt, targetState.local.config["HOST_CONFIG_dtoverlay"], "DToverlay successfully set in config.txt")
+				const dtoverlay = fs.readFileSync(`${__dirname}/dtoverlay.sh`).toString();
+				const dtparam = fs.readFileSync(`${__dirname}/dtparam.sh`).toString();
 
-        const paramConfigTxt = this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            `cat /mnt/boot/config.txt | grep SOMETHING_DTPARAM`,
-            this.context.get().link
-          );
+				const overlayConfigTxt = await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						`cd /tmp && ${dtoverlay}`,
+						this.context.get().link
+					);
 
-        test.equal(paramConfigTxt, targetState.local.config["HOST_CONFIG_dtparam"], "DTparam successfully set in config.txt")
-
-      },
-    },
-  ],
+				test.equal(overlayConfigTxt, targetState.local.config.HOST_CONFIG_dtoverlay, "DToverlay successfully configured in the config.txt")
+				const paramConfigTxt = await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						`cd /tmp && ${dtparam}`,
+						this.context.get().link
+					);
+				test.equal(paramConfigTxt, targetState.local.config.HOST_CONFIG_dtparam, "DTparam successfully configured in the config.txt")
+			},
+		},
+	],
 };

--- a/tests/suites/os/tests/device-tree/index.js
+++ b/tests/suites/os/tests/device-tree/index.js
@@ -24,7 +24,7 @@ module.exports = {
 		{
 			title: "DToverlay & DTparam tests",
 			run: async function (test) {
-				const ip = await this.context.get().worker.ip(this.context.get().link);
+				let ip = await this.context.get().worker.ip(this.context.get().link);
 
 				// Wait for supervisor API to start
 				await this.context.get().utils.waitUntil(async () => {
@@ -84,6 +84,9 @@ module.exports = {
 							)) === "pass"
 					);
 				}, false);
+
+				// IP of the device sometimes change after reboots, hence initalising again
+				ip = await this.context.get().worker.ip(this.context.get().link);
 
 				await this.context.get().utils.waitUntil(async () => {
 					test.comment("Waiting for supervisor to be ready after reboot...");


### PR DESCRIPTION
Device tree tests are meant to check if DToverlays and DTparams are being applied accurately on unmanaged OS. I have made some minor indentation changes as well to other tests.

I am keeping device-tree tests at the top of the suite.js to hack Jenkins and get the test being added in this PR implemented and run first. I would also like to test if having this new test doesn't affect other tests in the queue.

In the final change, I do want device-tree tests to be at the bottom. So don't merge before that happens, will make the change. Once we get the first run going. 