### PR TITLE
Add boot-splash test to unmanaged suite

### DIFF
--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -124,8 +124,7 @@ module.exports = {
     "./tests/variables",
     "./tests/led",
     "./tests/config-json",
-    // The boot splash test is currently disabled because of the excessive time spent on it.
-    // './tests/boot-splash',
+    "./tests/boot-splash",
     "./tests/connectivity",
     "./tests/engine-healthcheck",
     "./tests/udev",


### PR DESCRIPTION
This PR adds an equivalent test for testlodge TC96.

The test contains a reference image of the balena boot-splash screen. During the test, the DUT is rebooted, and the HDMI output of the DUT is captured, and compared to this reference image. If the boot-splash is detected on the HDMI output o the DUT, the test will pass. All captured frames are archived and sent back to jenkins at the end of the test.


Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
