### PR TITLE
balena-os: Add preferred provider for Go native

### DIFF
--- a/meta-balena-common/conf/distro/include/balena-os.inc
+++ b/meta-balena-common/conf/distro/include/balena-os.inc
@@ -102,3 +102,4 @@ PREFERRED_VERSION_libstd-rs = "1.36.0"
 
 # balena-engine go version requirement
 GOVERSION = "1.16.2"
+PREFERRED_PROVIDER_go-native = "go-native"


### PR DESCRIPTION
With Go 1.16 a precompiled go-binary-native that provides go-native was
introduced to bootstrap the Go compilation.
Specify to use the go-native recipe and not go-binary-native when
requiring go-native.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
