### PR TITLE
images: Remove generation of legacy resinhup images

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,6 @@ Before bitbake-ing with meta-balena support, a few flags can be changed in the c
 Editing of local.conf is to be done after source-ing.
 See below for explanation on such build flags.
 
-### Generation of host OS update bundles
-
-In order to generate update balena host OS bundles, edit the build's local.conf adding:
-
-RESINHUP = "yes"
-
 ### Configure custom network manager
 
 By default balena uses NetworkManager on host OS to provide connectivity. If you want to change and use other providers, list your packages using NETWORK_MANAGER_PACKAGES. You can add this variable to local.conf. Here is an example:

--- a/meta-balena-common/classes/image-balena.bbclass
+++ b/meta-balena-common/classes/image-balena.bbclass
@@ -271,22 +271,6 @@ resin_root_quirks () {
     fi
 }
 
-resinhup_backwards_compatible_link () {
-    if [ -d "${IMGDEPLOYDIR}" ]; then
-        # Check if we are running on a poky version which deploys to IMGDEPLOYDIR instead
-        # of DEPLOY_DIR_IMAGE (poky morty introduced this change)
-        DEPLOY_IMAGE_TAR="${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.tar"
-        BALENA_HUP_BUNDLE="${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.resinhup-tar"
-    else
-        IMAGE_NAME_SUFFIX=".rootfs"
-        DEPLOY_IMAGE_TAR="${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.tar"
-        BALENA_HUP_BUNDLE="${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.resinhup-tar"
-    fi
-    if [ -f ${DEPLOY_IMAGE_TAR} ]; then
-        ln -fsv ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.tar ${BALENA_HUP_BUNDLE}
-    fi
-}
-
 add_image_flag_file () {
     echo "DO NOT REMOVE THIS FILE" > ${DEPLOY_DIR_IMAGE}/${BALENA_FLAG_FILE}
 }
@@ -383,7 +367,6 @@ addtask resin_boot_dirgen_and_deploy after do_rootfs before do_image_complete
 IMAGE_POSTPROCESS_COMMAND =+ " \
     deploy_image_license_manifest ; \
     fix_hddimg_symlink ; \
-    resinhup_backwards_compatible_link ; \
     "
 IMAGE_PREPROCESS_COMMAND += "remove_backup_files ; "
 

--- a/meta-balena-common/recipes-core/images/balena-image.bb
+++ b/meta-balena-common/recipes-core/images/balena-image.bb
@@ -16,8 +16,7 @@ IMAGE_OVERHEAD_FACTOR = "1.0"
 IMAGE_ROOTFS_EXTRA_SPACE = "0"
 IMAGE_ROOTFS_MAXSIZE = "${IMAGE_ROOTFS_SIZE}"
 
-# Generated resinhup-tar based on RESINHUP variable
-IMAGE_FSTYPES = "${@bb.utils.contains('RESINHUP', 'yes', 'tar', '', d)}"
+IMAGE_FSTYPES = ""
 
 inherit core-image image-balena features_check
 

--- a/meta-balena-common/recipes-core/images/balena-image.bb
+++ b/meta-balena-common/recipes-core/images/balena-image.bb
@@ -16,7 +16,7 @@ IMAGE_OVERHEAD_FACTOR = "1.0"
 IMAGE_ROOTFS_EXTRA_SPACE = "0"
 IMAGE_ROOTFS_MAXSIZE = "${IMAGE_ROOTFS_SIZE}"
 
-IMAGE_FSTYPES = ""
+IMAGE_FSTYPES = "balenaos-img"
 
 inherit core-image image-balena features_check
 


### PR DESCRIPTION
These image types are no longer generated and are not used for hostOS
updates any longer.

Changelog-entry: Remove legacy resinhup images.
Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
