### PR TITLE
docker-disk: fix building with cgroups v2

### DIFF
--- a/meta-balena-common/recipes-containers/docker-disk/files/Dockerfile
+++ b/meta-balena-common/recipes-containers/docker-disk/files/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:19.03.10-dind
+FROM docker:20.10.6-dind
 RUN apk add --update util-linux shadow e2fsprogs && rm -rf /var/cache/apk/*
 ADD entry.sh /entry.sh
 RUN chmod a+x /entry.sh


### PR DESCRIPTION
Bump docker-disk base image from docker:19.03.10-dind to
docker:20.10.06-dind.

This fixes building on distros that default to cgroups v2, as support
was added to Docker 20.10.

Change-type: patch
Changelog-entry: docker-disk: fix building with cgroups v2
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
