### PR TITLE
kernel-resin: enable CONFIG_KEXEC_CORE for crashkernel support

### DIFF
--- a/meta-balena-common/classes/kernel-resin.bbclass
+++ b/meta-balena-common/classes/kernel-resin.bbclass
@@ -102,6 +102,7 @@ BALENA_CONFIGS ?= " \
     task-accounting \
     ipv6_mroute \
     disable_hung_panic \
+    kexec \
     "
 
 #
@@ -566,6 +567,11 @@ BALENA_CONFIGS[uprobes] = " \
 
 BALENA_CONFIGS[disable_hung_panic] = " \
     CONFIG_BOOTPARAM_HUNG_TASK_PANIC=n \
+    "
+
+# enable kexec for crashkernel support
+BALENA_CONFIGS[kexec] = " \
+    CONFIG_KEXEC_CORE=y \
     "
 
 ###########


### PR DESCRIPTION
Ramoops is a module that allows for logging oopses to  memory, and can
be useful for remotely debugging a system that's oopsing or panicking.
However, booting another kernel will typically clobber the buffer
ramoops dumps to, so typically the output has to be retrieved from the
bootloader shell after the panic, before the kernel boots again.

The kernel allows reserving memory with the crashkernel parameter for
the purpose of loading a capture kernel into memory, which is kexec'd
after a panic. Once booted, the capture kernel allows dumping an image
of the crashed kernel's memory for debugging.

This parameter restricts the kernel from touching the specified region,
so the capture kernel remains intact in memory. It can be abused for
other purposes, however, such as reserving a region of memory for
ramoops to dump to that will remain intact across boots.

For example, the following parameters can be added to a kernel:
    crashkernel=1M@32M ramoops.mem_address=0x2000000 ramoops.mem_size=0x100000

This reserves a 1M region of memory at a 32M offset, then tells ramoops
to use it for recording oopses and panics.

After rebooting from a panic, the log can be extracted from a file in
pstore like so:

    mount -t pstore pstore /mnt
    cat /mnt/ftrace-ramoops

This is preferable to the method suggested by the documentation, which
uses the ram= parameter to place an upper limit on the amount of memory
used by the kernel. Creating a persistent reserved block of memory with
the crashkernel= parameter leaves most of the system memory available to
the OS and applications.

Enable CONFIG_KEXEC_CORE by default to allow for reserving blocks of
memory with the crashkernel= parameter.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
