### PR TITLE
bluez5: Disable PnP Device Information service

### DIFF
--- a/meta-balena-common/recipes-connectivity/bluez5/files/main.conf
+++ b/meta-balena-common/recipes-connectivity/bluez5/files/main.conf
@@ -1,2 +1,5 @@
+[General]
+DeviceID=false
+
 [Policy]
 AutoEnable=true


### PR DESCRIPTION
This reverts to the behavior before bluez v5.56 as it interferes with user defined
Device Information profiles.

For more information: https://github.com/bluez/bluez/issues/101

Change-type: patch
Signed-off-by: Zahari Petkov <zahari@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
