### PR TITLE
update-balena-supervisor: Refactor script to ensure target version is ran

### DIFF
--- a/meta-balena-common/recipes-containers/balena-supervisor/balena-supervisor/update-balena-supervisor
+++ b/meta-balena-common/recipes-containers/balena-supervisor/balena-supervisor/update-balena-supervisor
@@ -140,12 +140,21 @@ else
     tag=$UPDATER_SUPERVISOR_TAG
 fi
 
+setSupervisorConfig() {
+    svconfigdir=$(ls /etc/ | grep "supervisor" | head -n 1)
+
+    # Store the tagged image string so resin-supervisor.service can pick it up
+    sed -e "s|SUPERVISOR_IMAGE=.*|SUPERVISOR_IMAGE=$image_name|" -e "s|SUPERVISOR_TAG=.*|SUPERVISOR_TAG=$tag|" "/etc/${svconfigdir}/supervisor.conf" > $UPDATECONF
+}
+
 # Get image id of tag. This will be non-empty only in case it's already downloaded.
 echo "Getting image id..."
 imageid=$($DOCKER inspect -f '{{.Id}}' "$image_name:$tag") || imageid=""
 
 if [ -n "$imageid" ]; then
     echo "Supervisor $image_name:$tag already downloaded."
+    # Since target Supervisor version is downloaded ensure the device is configured to use it
+    setSupervisorConfig
     exit 0
 fi
 
@@ -163,8 +172,8 @@ else
     error_handler "supervisor pull failed"
 fi
 
-# Store the tagged image string so balena-supervisor.service can pick it up
-sed -e "s|SUPERVISOR_IMAGE=.*|SUPERVISOR_IMAGE=$image_name|" -e "s|SUPERVISOR_TAG=.*|SUPERVISOR_TAG=$tag|" /etc/balena-supervisor/supervisor.conf > $UPDATECONF
+# Ensure device has newly pulled image as the version to run
+setSupervisorConfig
 
 # Run supervisor with the device-type-specific options.
 # We give a specific name to the container to guarantee only one running.


### PR DESCRIPTION
This is a rebase of [PR 2180](https://github.com/balena-os/meta-balena/pull/2180) by Miguel, which improves stability for the
supervisor update.

Change-type: patch
Signed-off-by: Miguel Casqueira <miguel@balena.io>
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Currently, the SV does not get updated when HUP-ing a Pi4 from 2.41 to v2.80.0. @20k-ultra looked into this and determined that what is happening is this issue: https://github.com/balena-os/meta-balena/issues/2179 and it should be fixed by https://github.com/balena-os/meta-balena/pull/2180 , which we rebase in this PR.

Internal discussion: https://www.flowdock.com/app/rulemotion/r-supervisor/threads/O8fifLL0sgPfQY5WDOezv3Ime4u

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
