### PR TITLE
meta-balena-common: kernel-headers-test: simplify example module Make…

### DIFF
--- a/meta-balena-common/recipes-kernel/linux/files/Dockerfile
+++ b/meta-balena-common/recipes-kernel/linux/files/Dockerfile
@@ -22,9 +22,9 @@ ARG kernel_arch
 ARG cross_compile_prefix
 # Compile external hello module using header sources
 RUN ARCH=${kernel_arch} CROSS_COMPILE=${cross_compile_prefix} make -C /usr/src/app/kernel_source/*/build modules_prepare
-RUN ARCH=${kernel_arch} CROSS_COMPILE=${cross_compile_prefix} KERNEL_TREE_PATH=/usr/src/app/kernel_source/*/build/ MODULE_PATH=/usr/src/app/example_module_headers_src  make -C /usr/src/app/example_module_headers_src
+RUN ARCH=${kernel_arch} CROSS_COMPILE=${cross_compile_prefix} make -C /usr/src/app/kernel_source/*/build/ M=/usr/src/app/example_module_headers_src
 
 # Compile external hello module using pre-built headers
 # We run modules_prepare again because the tools pre-compiled are actually the target device arch. While we cross-compile for testing.
 RUN ARCH=${kernel_arch} CROSS_COMPILE=${cross_compile_prefix} make -C /usr/src/app/kernel_modules_headers/ modules_prepare
-RUN ARCH=${kernel_arch} CROSS_COMPILE=${cross_compile_prefix} KERNEL_TREE_PATH=/usr/src/app/kernel_modules_headers/ MODULE_PATH=/usr/src/app/example_module_headers_built  make -C /usr/src/app/example_module_headers_built
+RUN ARCH=${kernel_arch} CROSS_COMPILE=${cross_compile_prefix} make -C /usr/src/app/kernel_modules_headers/ M=/usr/src/app/example_module_headers_built

--- a/meta-balena-common/recipes-kernel/linux/files/example_module/Makefile
+++ b/meta-balena-common/recipes-kernel/linux/files/example_module/Makefile
@@ -1,15 +1,1 @@
-KERNEL_TREE_PATH?=/lib/modules/$(shell uname -r)/build
-MODULE_PATH?=$(PWD)
-EXTRA_CFLAGS="-DDEBUG"
-
-obj-m+=hello.o
-
-all: hello.ko
-
-hello.ko: hello.c
-	make -C $(KERNEL_TREE_PATH) M=$(MODULE_PATH) modules
-
-clean:
-	make -C $(KERNEL_TREE_PATH) M=$(MODULE_PATH) clean
-
-.PHONY: all clean
+obj-m := hello.o


### PR DESCRIPTION
…file

The example kernel module has some unnecessary variables and targets.
Simplify this makefile by passing the kernel source directory to make,
and using the M variable to build the module.

Changelog-entry: kernel-headers-test: simplify example module Makefile
Signed-off-by: Joseph Kogut <joseph@balena.io>
