### PR TITLE
image-balena: Decouple boot directory generation from rootfs task

### DIFF
--- a/meta-balena-common/classes/image-balena.bbclass
+++ b/meta-balena-common/classes/image-balena.bbclass
@@ -123,7 +123,7 @@ read_only_rootfs_hook_append () {
 }
 
 # Generate the boot partition directory and deploy it to rootfs
-resin_boot_dirgen_and_deploy () {
+do_resin_boot_dirgen_and_deploy () {
     echo "Generating work directory for resin-boot partition..."
     rm -rf ${BALENA_BOOT_WORKDIR}
     for BALENA_BOOT_PARTITION_FILE in ${BALENA_BOOT_PARTITION_FILES}; do
@@ -365,11 +365,13 @@ ROOTFS_POSTPROCESS_COMMAND += " \
     generate_compressed_kernel_module_deps ; \
     add_image_flag_file ; \
     os_release_extra_data ; \
-    resin_boot_dirgen_and_deploy ; \
     resin_root_quirks ; \
     resin_boot_sanity_handler ; \
     balena_udev_rules_sanity_handler ; \
     "
+
+addtask resin_boot_dirgen_and_deploy after do_rootfs before do_image_complete
+
 IMAGE_POSTPROCESS_COMMAND =+ " \
     deploy_image_license_manifest ; \
     fix_hddimg_symlink ; \


### PR DESCRIPTION
The boot partition needs to be generated before creating the balenaos-img
but is not part of the root filesystem generation.

The decoupling allows to build just the docker rootfs image without
having to build the balenaos-img target.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
