### PR TITLE
update-balena-supervisor: Improve obtaining the supervisor directory

### DIFF
--- a/meta-balena-common/recipes-containers/balena-supervisor/balena-supervisor/update-balena-supervisor
+++ b/meta-balena-common/recipes-containers/balena-supervisor/balena-supervisor/update-balena-supervisor
@@ -141,7 +141,7 @@ else
 fi
 
 setSupervisorConfig() {
-    svconfigdir=$(ls /etc/ | grep "supervisor" | head -n 1)
+    svconfigdir=$(basename "$(ls -d /etc/*-supervisor)")
 
     # Store the tagged image string so resin-supervisor.service can pick it up
     sed -e "s|SUPERVISOR_IMAGE=.*|SUPERVISOR_IMAGE=$image_name|" -e "s|SUPERVISOR_TAG=.*|SUPERVISOR_TAG=$tag|" "/etc/${svconfigdir}/supervisor.conf" > $UPDATECONF


### PR DESCRIPTION
…name

There are better ways of getting the supervisor
configuration directory name, let's switch to
them to improve robustness.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
