### PR TITLE
prevent failed teardown from making test suite hang

### DIFF
--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -76,7 +76,9 @@ module.exports = {
     // Register a teardown function execute at the end of the test, regardless of a pass or fail
     this.suite.teardown.register(() => {
       this.log("Removing image");
-      fse.unlinkSync("/data/image"); // Delete the unpacked an modified image from the testbot cache to prevent use in the next suite
+      if (fse.existsSync("/data/image")) {
+        fse.unlinkSync("/data/image"); // Delete the unpacked an modified image from the testbot cache to prevent use in the next suite
+      }
       this.log("Worker teardown");
       return this.context.get().worker.teardown();
     });


### PR DESCRIPTION
This is to prevent situations such as this: https://jenkins.dev.resin.io/job/leviathan-raspberry-pi/852/console

where for some reason the unpacked image didn't exist (probably due to an earlier failure), and when attempting to remove it there is an error and the suite hangs and doesn't exit. This patch simply checks the path exists before trying to remove it

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
