### PR TITLE
recipes-core: add a 'network connectivity wait' service

### DIFF
--- a/meta-balena-common/recipes-connectivity/balena-net-connectivity-wait/balena-net-connectivity-wait.bb
+++ b/meta-balena-common/recipes-connectivity/balena-net-connectivity-wait/balena-net-connectivity-wait.bb
@@ -1,0 +1,35 @@
+DESCRIPTION = "balena full network connectivity checker"
+SECTION = "console/utils"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${BALENA_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = " \
+    file://balena-net-connectivity-wait \
+    file://balena-net-connectivity-wait.service \
+    file://balena-net-connectivity-wait.target \
+    "
+S = "${WORKDIR}"
+
+inherit allarch systemd
+
+PACKAGES = "${PN}"
+
+SYSTEMD_SERVICE_${PN} = " \
+	balena-net-connectivity-wait.service \
+	balena-net-connectivity-wait.target \
+	"
+RDEPENDS_${PN} = "bash"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0775 ${WORKDIR}/balena-net-connectivity-wait ${D}${bindir}/balena-net-connectivity-wait
+
+    if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        install -d ${D}${systemd_unitdir}/system
+        install -c -m 0644 ${WORKDIR}/balena-net-connectivity-wait.service ${D}${systemd_unitdir}/system
+        install -c -m 0644 ${WORKDIR}/balena-net-connectivity-wait.target ${D}${systemd_unitdir}/system
+        sed -i -e 's,@BASE_BINDIR@,${base_bindir},g' \
+        -e 's,@BINDIR@,${bindir},g' \
+            ${D}${systemd_unitdir}/system/balena-net-connectivity-wait.service
+    fi
+}

--- a/meta-balena-common/recipes-connectivity/balena-net-connectivity-wait/balena-net-connectivity-wait/balena-net-connectivity-wait
+++ b/meta-balena-common/recipes-connectivity/balena-net-connectivity-wait/balena-net-connectivity-wait/balena-net-connectivity-wait
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright 2021 Balena Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+. /usr/libexec/os-helpers-logging
+
+info "Waiting for full network connectivity."
+
+# See https://developer.gnome.org/NetworkManager/stable/nm-dbus-types.html#NMState
+# for details of connectivity states.
+NM_STATE_CONNECTED_GLOBAL=70
+
+# Check the status first so that we don't wait for an event that
+# will never come.
+# This test is for standalone script operation as normally we start
+# this at boot before NetworkManager is running to ensure that we
+# don't miss any StateChanged events.
+while read -r line; do
+	STATUS=$(echo $line | grep uint32 | cut -d' ' -f3)
+	if [ "$STATUS" == "$NM_STATE_CONNECTED_GLOBAL" ]; then
+		info "Full network connectivity detected."
+		exit 0
+	fi
+done < <(dbus-send --system --dest=org.freedesktop.NetworkManager --print-reply /org/freedesktop/NetworkManager \
+org.freedesktop.DBus.Properties.Get string:"org.freedesktop.NetworkManager" string:"State" 2>&1)
+
+# Wait for a status change event.
+while read -r line; do
+	STATUS=$(echo $line | grep uint32 | cut -d' ' -f2)
+	if [ "$STATUS" == "$NM_STATE_CONNECTED_GLOBAL" ]; then
+		info "Full network connectivity detected."
+		exit 0
+	fi
+done < <(dbus-monitor --system "type='signal',sender='org.freedesktop.NetworkManager', \
+path='/org/freedesktop/NetworkManager',interface='org.freedesktop.NetworkManager',member='StateChanged'")
+
+# In normal circumstances we don't expect the script to reach this point.
+fail "Unexpected error occurred."

--- a/meta-balena-common/recipes-connectivity/balena-net-connectivity-wait/balena-net-connectivity-wait/balena-net-connectivity-wait.service
+++ b/meta-balena-common/recipes-connectivity/balena-net-connectivity-wait/balena-net-connectivity-wait/balena-net-connectivity-wait.service
@@ -1,0 +1,27 @@
+# Copyright 2021 Balena Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=Wait for full network connectivity
+Requires=dbus.service
+After=dbus.service
+Before=balena-net-connectivity-wait.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=@BINDIR@/balena-net-connectivity-wait
+
+[Install]
+WantedBy=balena-net-connectivity-wait.target

--- a/meta-balena-common/recipes-connectivity/balena-net-connectivity-wait/balena-net-connectivity-wait/balena-net-connectivity-wait.target
+++ b/meta-balena-common/recipes-connectivity/balena-net-connectivity-wait/balena-net-connectivity-wait/balena-net-connectivity-wait.target
@@ -1,0 +1,18 @@
+# Copyright 2021 Balena Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=Wait for full network connectivity
+RefuseManualStart=yes
+After=network.target

--- a/meta-balena-common/recipes-core/packagegroups/packagegroup-balena-connectivity.bb
+++ b/meta-balena-common/recipes-core/packagegroups/packagegroup-balena-connectivity.bb
@@ -1,11 +1,11 @@
-SUMMARY = "Resin Connectivity Package Group"
+SUMMARY = "Balena Connectivity Package Group"
 LICENSE = "Apache-2.0"
 
 PR = "r0"
 
 inherit packagegroup
 
-# By default resin uses networkmanager
+# By default balena uses networkmanager
 NETWORK_MANAGER_PACKAGES ?= "networkmanager"
 
 CONNECTIVITY_MODULES = ""
@@ -20,6 +20,7 @@ CONNECTIVITY_FIRMWARES ?= " \
 CONNECTIVITY_PACKAGES = " \
     ${NETWORK_MANAGER_PACKAGES} \
     avahi-daemon \
+    balena-net-connectivity-wait \
     dnsmasq \
     dropbear \
     openvpn \


### PR DESCRIPTION
Add a new systemd service to check for full network connectivity. This service is required because the default NetworkManager (NM) connectivity checker doesn't differentiate between the CONNECTED_LOCAL, CONNECTED_SITE and CONNECTED_GLOBAL states. This service checks for the CONNECTED_GLOBAL state only and can be used to delay the start of other services which require full network access to be available. This can help to avoid startup problems on networks with slow DNS access or that utilise a captive portal.

The script does an initial oneshot check of the NM state to make sure that we don't wait for an event that doesn't come. This check is redundant at boot time due to the fact that the service is started before NM to ensure that no NM DBus events are missed. The initial check is useful in circumstances where you want to run the script standalone or post-boot.

Other services that wish to make use of this service and wait for full network connectivity should add the following entries to their
systemd unit definition:

Requires=balena-net-connectivity-wait.target
After=balena-net-connectivity-wait.target

Change-type: minor
Changelog-entry: recipes-core: add a 'network connectivity wait' service
Signed-off-by: Mark Corbin <mark@balena.io>

--

Tested on a RPi3 under balenaOS v2.80.8 using a test service as follows:
```
[Unit]
Description=Test Service
Requires=balena-net-connectivity-wait.target
After=balena-net-connectivity-wait.target

[Service]
Type=oneshot
RemainAfterExit=yes
ExecStart=echo 'FULL NETWORK'

[Install]
WantedBy=multi-user.target
```
'Full connectivity' tested by booting with Ethernet connected to a switch, but with the switch uplink disconnected from the internet.
'Partial connectivity' tested by booting with 'address=/#/192.168.12.1' in the device /etc/dnsmasq.conf file to simulate a captive portal/partial DNS.
'No connectivity' tested by booting with the Ethernet cable disconnected.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [x] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
