### PR TITLE
patch: Make OS test suite compatible with current helpers

### DIFF
--- a/tests/suites/Makefile
+++ b/tests/suites/Makefile
@@ -3,4 +3,4 @@ lint:
 	docker build --target=lint .
 
 prettify:
-	docker build --target=prettify .
+	DOCKER_BUILDKIT=1 docker build --target=prettify .

--- a/tests/suites/config.js
+++ b/tests/suites/config.js
@@ -4,7 +4,6 @@ module.exports = [{
 	config: {
 		networkWired: false,
 		networkWireless: true,
-		downloadType: 'local',
 		interactiveTests: false, // redundant
 		balenaApiKey: process.env.BALENA_CLOUD_API_KEY,
 		balenaApiUrl: 'balena-cloud.com',
@@ -23,7 +22,6 @@ module.exports = [{
 		networkWired: false,
 		networkWireless: true,
 		downloadVersion: 'latest',
-		downloadType: 'gunzip',
 		interactiveTests: false, // redundant
 		balenaApiKey: process.env.BALENA_CLOUD_API_KEY,
 		balenaApiUrl: 'balena-cloud.com',

--- a/tests/suites/hup/suite.js
+++ b/tests/suites/hup/suite.js
@@ -4,306 +4,321 @@
  * @license Apache-2.0
  */
 
-"use strict";
+'use strict';
 
-const fs = require("fs");
-const fse = require("fs-extra");
-const { join } = require("path");
-const { homedir } = require("os");
+const fs = require('fs');
+const fse = require('fs-extra');
+const { join } = require('path');
+const { homedir } = require('os');
 const Docker = require('dockerode');
 const exec = require('bluebird').promisify(require('child_process').exec);
 
 // Starts registry, uploads target image to registry
 const runRegistry = async (that, seedWithImage) => {
-  const docker = new Docker();
-  const registryImage = 'registry:2';
+	const docker = new Docker();
+	const registryImage = 'registry:2';
 
-  that.log("Pulling registry image");
-  await docker.pull(registryImage);
+	that.log('Pulling registry image');
+	await docker.pull(registryImage);
 
-  const container = await docker.createContainer({
-    Image: registryImage,
-    HostConfig: {
-      AutoRemove: true,
-      Mounts: [{
-        Type: 'tmpfs',
-        Target: '/var/lib/registry'
-      }],
-      PortBindings: {
-        "5000/tcp": [{
-          "HostPort": "5000",
-        }],
-      },
-    }
+	const container = await docker
+		.createContainer({
+			Image: registryImage,
+			HostConfig: {
+				AutoRemove: true,
+				Mounts: [
+					{
+						Type: 'tmpfs',
+						Target: '/var/lib/registry',
+					},
+				],
+				PortBindings: {
+					'5000/tcp': [
+						{
+							HostPort: '5000',
+						},
+					],
+				},
+			},
+		})
+		.then(container => {
+			that.log('Starting registry');
+			return container.start();
+		});
 
-  }).then((container) => {
-    that.log("Starting registry");
-    return container.start();
-  });
+	that.suite.teardown.register(async () => {
+		that.log(`Teardown registry`);
+		try {
+			await container.kill();
+		} catch (err) {
+			that.log(`Error removing registry container: ${err}`);
+		}
+	});
 
-  that.suite.teardown.register(async () => {
-    that.log(`Teardown registry`);
-    try {
-      await container.kill();
-    } catch (err) {
-      that.log(`Error removing registry container: ${err}`);
-    }
-  });
+	that.log('Loading image into registry');
+	const imageName = await docker
+		.loadImage(seedWithImage)
+		.then(res => {
+			return new Promise((resolve, reject) => {
+				var bufs = [];
+				res.on('error', err => reject(err));
+				res.on('data', data => bufs.push(data));
+				res.on('end', () => resolve(JSON.parse(Buffer.concat(bufs))));
+			});
+		})
+		.then(json => {
+			const str = json.stream.split('Loaded image ID: ');
+			if (str.length === 2) {
+				return str[1].trim();
+			}
+			throw new Error('failed to parse image name from loadImage stream');
+		});
 
-  that.log("Loading image into registry");
-  const imageName = await docker.loadImage(seedWithImage)
-    .then(res => {
-      return new Promise((resolve, reject) => {
-        var bufs = [];
-        res.on('error', err => reject(err));
-        res.on('data', data => bufs.push(data));
-        res.on('end', () => resolve(JSON.parse(Buffer.concat(bufs))));
-      });
-    })
-    .then(json => {
-      const str = json.stream.split('Loaded image ID: ');
-      if (str.length === 2) {
-        return str[1].trim();
-      }
-      throw new Error('failed to parse image name from loadImage stream');
-    });
+	const image = await docker.getImage(imageName);
+	const ref = 'localhost:5000/hostapp';
 
-  const image = await docker.getImage(imageName);
-  const ref = 'localhost:5000/hostapp';
+	await image.tag({ repo: ref, tag: 'latest' });
+	const tagged = await docker.getImage(ref);
+	const digest = await tagged
+		.push({ ref })
+		.then(res => {
+			return new Promise((resolve, reject) => {
+				var bufs = [];
+				res.on('error', err => reject(err));
+				res.on('data', data => bufs.push(JSON.parse(data)));
+				res.on('end', () => resolve(bufs));
+			});
+		})
+		.then(output => {
+			for (let json of output) {
+				if (json.error) {
+					throw new Error(json.error);
+				}
+				if (json.aux && json.aux.Digest) {
+					return json.aux.Digest;
+				}
+			}
+			throw new Error('no digest');
+		});
+	await image.remove();
 
-  await image.tag({ repo: ref, tag: 'latest' });
-  const tagged = await docker.getImage(ref);
-  const digest = await tagged.push({ ref })
-    .then(res => {
-      return new Promise((resolve, reject) => {
-        var bufs = [];
-        res.on('error', err => reject(err));
-        res.on('data', data => bufs.push(JSON.parse(data)));
-        res.on('end', () => resolve(bufs));
-      });
-    })
-    .then(output => {
-      for (let json of output) {
-        if (json.error) {
-          throw new Error(json.error);
-        }
-        if (json.aux && json.aux.Digest) {
-          return json.aux.Digest;
-        }
-      }
-      throw new Error('no digest');
-    });
-  await image.remove();
+	// this parses the IP of the wlan0 interface which is the gateway for the DUT
+	// Replace the logic below when this merged https://github.com/balena-os/leviathan/pull/442
+	const testbotIP = (
+		await exec(`ip addr | awk '/inet.*wlan0/{print $2}' | cut -d\/ -f1`)
+	).trim();
+	const hostappRef = `${testbotIP}:5000/hostapp@${digest}`;
+	that.log(`Registry upload complete: ${hostappRef}`);
 
-  // this parses the IP of the wlan0 interface which is the gateway for the DUT
-  // Replace the logic below when this merged https://github.com/balena-os/leviathan/pull/442
-  const testbotIP = (await exec(`ip addr | awk '/inet.*wlan0/{print $2}' | cut -d\/ -f1`)).trim();
-  const hostappRef = `${testbotIP}:5000/hostapp@${digest}`;
-  that.log(`Registry upload complete: ${hostappRef}`);
-
-  that.suite.context.set({
-    hup: {
-      payload: hostappRef,
-    }
-  })
-}
+	that.suite.context.set({
+		hup: {
+			payload: hostappRef,
+		},
+	});
+};
 
 // Executes the HUP process on the DUT
 const doHUP = async (that, test, mode, hostapp, target) => {
-  test.comment(`Starting HUP`);
+	test.comment(`Starting HUP`);
 
-  let hupLog;
-  switch (mode) {
-    case 'local':
-      if (await that.context.get().worker.executeCommandInHostOS(
-        `[[ -f ${hostapp} ]] && echo exists`,
-        target,
-      ) !== 'exists') {
-        throw new Error(
-          `Target image doesn't exists at location "${hostapp}"`,
-        );
-      }
-      test.comment(`Running: hostapp-update -f ${hostapp}`);
-      hupLog = await that.context.get().worker.executeCommandInHostOS(
-        `hostapp-update -f ${hostapp}`,
-        target,
-      );
-      break;
+	let hupLog;
+	switch (mode) {
+		case 'local':
+			if (
+				(await that.context
+					.get()
+					.worker.executeCommandInHostOS(
+						`[[ -f ${hostapp} ]] && echo exists`,
+						target,
+					)) !== 'exists'
+			) {
+				throw new Error(`Target image doesn't exists at location "${hostapp}"`);
+			}
+			test.comment(`Running: hostapp-update -f ${hostapp}`);
+			hupLog = await that.context
+				.get()
+				.worker.executeCommandInHostOS(`hostapp-update -f ${hostapp}`, target);
+			break;
 
-    case 'image':
-      test.comment(`Running: hostapp-update -i ${hostapp}`);
-      hupLog = await that.context.get().worker.executeCommandInHostOS(
-        `hostapp-update -i ${hostapp}`,
-        target,
-      );
-      break;
+		case 'image':
+			test.comment(`Running: hostapp-update -i ${hostapp}`);
+			hupLog = await that.context
+				.get()
+				.worker.executeCommandInHostOS(`hostapp-update -i ${hostapp}`, target);
+			break;
 
-    default:
-      throw new Error(`Unsupported HUP mode: ${mode}`);
-  }
+		default:
+			throw new Error(`Unsupported HUP mode: ${mode}`);
+	}
 
-  const hupLogPath = join(that.suite.options.tmpdir, `hup.log`);
-  fs.writeFileSync(hupLogPath, hupLog);
-  await that.archiver.add(hupLogPath);
+	const hupLogPath = join(that.suite.options.tmpdir, `hup.log`);
+	fs.writeFileSync(hupLogPath, hupLog);
+	await that.archiver.add(hupLogPath);
 
-  test.comment(`Finished HUP`);
+	test.comment(`Finished HUP`);
 };
 
 const initDUT = async (that, test, target) => {
-  test.comment(`Initializing DUT for HUP test`);
+	test.comment(`Initializing DUT for HUP test`);
 
-  test.comment(`Flashing DUT`);
-  await that.context.get().worker.off();
-  await that.context.get().worker.flash(that.context.get().os.image.path);
-  await that.context.get().worker.on();
+	test.comment(`Flashing DUT`);
+	await that.context.get().worker.off();
+	await that.context.get().worker.flash(that.context.get().os.image.path);
+	await that.context.get().worker.on();
 
-  test.comment(`Waiting for DUT to be reachable`);
-  await that.context.get().utils.waitUntil(async () => {
-      return (
-        (await that.context.get().worker.executeCommandInHostOS(
-            '[[ -f /etc/hostname ]] && echo pass || echo fail',
-            target,
-          )) === 'pass'
-      );
-    }, true);
-  test.comment(`DUT flashed`);
+	test.comment(`Waiting for DUT to be reachable`);
+	await that.context.get().utils.waitUntil(async () => {
+		return (
+			(await that.context
+				.get()
+				.worker.executeCommandInHostOS(
+					'[[ -f /etc/hostname ]] && echo pass || echo fail',
+					target,
+				)) === 'pass'
+		);
+	}, true);
+	test.comment(`DUT flashed`);
 
-  test.comment(`Configuring DUT to use test suite registry`);
-  // TODO rework this after https://github.com/balena-os/meta-balena/pull/2175
-  // FIXME we should probably use a shared testbotIP method with the runRegistry helper...
-  await that.context.get().worker.executeCommandInHostOS(
-    `mount -o remount,rw / && sed -e "s/driver=systemd/driver=systemd --insecure-registry=$(ip route | awk '/default/{print $3}'):5000/" -i /lib/systemd/system/balena-host.service && systemctl daemon-reload && systemctl restart balena-host && mount -o remount,ro /`,
-    target,
-  );
-  test.comment(`DUT ready`);
+	test.comment(`Configuring DUT to use test suite registry`);
+	// TODO rework this after https://github.com/balena-os/meta-balena/pull/2175
+	// FIXME we should probably use a shared testbotIP method with the runRegistry helper...
+	await that.context
+		.get()
+		.worker.executeCommandInHostOS(
+			`mount -o remount,rw / && sed -e "s/driver=systemd/driver=systemd --insecure-registry=$(ip route | awk '/default/{print $3}'):5000/" -i /lib/systemd/system/balena-host.service && systemctl daemon-reload && systemctl restart balena-host && mount -o remount,ro /`,
+			target,
+		);
+	test.comment(`DUT ready`);
 
-  that.teardown.register(async () => {
-    await that.context.get().hup.archiveLogs(that,
-      test, target);
-  })
-}
+	that.teardown.register(async () => {
+		await that.context.get().hup.archiveLogs(that, test, target);
+	});
+};
 
 const archiveLogs = async (that, test, target) => {
-  test.comment(`Archiving HUP artifacts`);
+	test.comment(`Archiving HUP artifacts`);
 
-  const rollback = await that.context.get().worker.executeCommandInHostOS(
-    `journalctl --no-pager --no-hostname --unit rollback-health`,
-    target,
-  );
-  const rollbackLogs = join(that.suite.options.tmpdir, `rollback-health.log`);
-  fs.writeFileSync(rollbackLogs, rollback);
-  await that.archiver.add(rollbackLogs);
+	const rollback = await that.context
+		.get()
+		.worker.executeCommandInHostOS(
+			`journalctl --no-pager --no-hostname --unit rollback-health`,
+			target,
+		);
+	const rollbackLogs = join(that.suite.options.tmpdir, `rollback-health.log`);
+	fs.writeFileSync(rollbackLogs, rollback);
+	await that.archiver.add(rollbackLogs);
 
-  const journal = await that.context
-    .get()
-    .worker.executeCommandInHostOS(
-      `journalctl --no-pager --no-hostname --list-boots | awk '{print $1}' | xargs -I{} sh -c 'set -x; journalctl --no-pager --no-hostname -n500 -a -b {};'`,
-      target,
-    );
-  const journalLogs = join(that.suite.options.tmpdir, `journal.log`);
-  fs.writeFileSync(journalLogs, journal);
-  await that.archiver.add(journalLogs);
-}
+	const journal = await that.context
+		.get()
+		.worker.executeCommandInHostOS(
+			`journalctl --no-pager --no-hostname --list-boots | awk '{print $1}' | xargs -I{} sh -c 'set -x; journalctl --no-pager --no-hostname -n500 -a -b {};'`,
+			target,
+		);
+	const journalLogs = join(that.suite.options.tmpdir, `journal.log`);
+	fs.writeFileSync(journalLogs, journal);
+	await that.archiver.add(journalLogs);
+};
 
 module.exports = {
-  title: "Hostapp update suite",
+	title: 'Hostapp update suite',
 
-  run: async function () {
-    const Worker = this.require("common/worker");
-    const BalenaOS = this.require("components/os/balenaos");
-    const Balena = this.require("components/balena/sdk");
+	run: async function() {
+		const Worker = this.require('common/worker');
+		const BalenaOS = this.require('components/os/balenaos');
+		const Balena = this.require('components/balena/sdk');
 
-    await fse.ensureDir(this.suite.options.tmpdir);
+		await fse.ensureDir(this.suite.options.tmpdir);
 
-    this.suite.context.set({
-      utils: this.require("common/utils"),
-      sdk: new Balena(this.suite.options.balena.apiUrl, this.getLogger()),
-      sshKeyPath: join(homedir(), "id"),
-      link: `${this.suite.options.balenaOS.config.uuid.slice(0, 7)}.local`,
-      worker: new Worker(this.suite.deviceType.slug, this.getLogger()),
-    });
+		this.suite.context.set({
+			utils: this.require('common/utils'),
+			sdk: new Balena(this.suite.options.balena.apiUrl, this.getLogger()),
+			sshKeyPath: join(homedir(), 'id'),
+			link: `${this.suite.options.balenaOS.config.uuid.slice(0, 7)}.local`,
+			worker: new Worker(this.suite.deviceType.slug, this.getLogger()),
+		});
 
-    // Network definitions
-    if (this.suite.options.balenaOS.network.wired === true) {
-      this.suite.options.balenaOS.network.wired = {
-        nat: true,
-      };
-    } else {
-      delete this.suite.options.balenaOS.network.wired;
-    }
-    if (this.suite.options.balenaOS.network.wireless === true) {
-      this.suite.options.balenaOS.network.wireless = {
-        ssid: this.suite.options.id,
-        psk: `${this.suite.options.id}_psk`,
-        nat: true,
-      };
-    } else {
-      delete this.suite.options.balenaOS.network.wireless;
-    }
+		// Network definitions
+		if (this.suite.options.balenaOS.network.wired === true) {
+			this.suite.options.balenaOS.network.wired = {
+				nat: true,
+			};
+		} else {
+			delete this.suite.options.balenaOS.network.wired;
+		}
+		if (this.suite.options.balenaOS.network.wireless === true) {
+			this.suite.options.balenaOS.network.wireless = {
+				ssid: this.suite.options.id,
+				psk: `${this.suite.options.id}_psk`,
+				nat: true,
+			};
+		} else {
+			delete this.suite.options.balenaOS.network.wireless;
+		}
 
-    this.suite.context.set({
-      hup: {
-        doHUP:        doHUP,
-        initDUT:      initDUT,
-        runRegistry:  runRegistry,
-        archiveLogs:  archiveLogs,
-      }
-    })
+		this.suite.context.set({
+			hup: {
+				doHUP: doHUP,
+				initDUT: initDUT,
+				runRegistry: runRegistry,
+				archiveLogs: archiveLogs,
+			},
+		});
 
-    // Downloads the balenaOS image we hup from
-    const path = await this.context.get().sdk.fetchOS(
-      this.suite.options.balenaOS.download.version,
-      this.suite.deviceType.slug
-    );
+		// Downloads the balenaOS image we hup from
+		const path = await this.context
+			.get()
+			.sdk.fetchOS(
+				this.suite.options.balenaOS.download.version,
+				this.suite.deviceType.slug,
+			);
 
-    this.suite.context.set({
-      os: new BalenaOS(
-        {
-          deviceType: this.suite.deviceType.slug,
-          network: this.suite.options.balenaOS.network,
-          image: `${path}`,
-          configJson: {
-            uuid: this.suite.options.balenaOS.config.uuid,
-            os: {
-              sshKeys: [
-                await this.context
-                  .get()
-                  .utils.createSSHKey(this.context.get().sshKeyPath),
-              ],
-            },
-            // persistentLogging is managed by the supervisor and only read at first boot
-            persistentLogging: true,
-          },
-        },
-        this.getLogger()
-      ),
-      hupOs: new BalenaOS(
-        { },
-        this.getLogger()
-      ),
-    });
-    this.suite.teardown.register(() => {
-      this.log("Worker teardown");
-      return this.context.get().worker.teardown();
-    });
+		this.suite.context.set({
+			os: new BalenaOS(
+				{
+					deviceType: this.suite.deviceType.slug,
+					network: this.suite.options.balenaOS.network,
+					image: `${path}`,
+					configJson: {
+						uuid: this.suite.options.balenaOS.config.uuid,
+						os: {
+							sshKeys: [
+								await this.context
+									.get()
+									.utils.createSSHKey(this.context.get().sshKeyPath),
+							],
+						},
+						// persistentLogging is managed by the supervisor and only read at first boot
+						persistentLogging: true,
+					},
+				},
+				this.getLogger(),
+			),
+			hupOs: new BalenaOS({}, this.getLogger()),
+		});
+		this.suite.teardown.register(() => {
+			this.log('Worker teardown');
+			return this.context.get().worker.teardown();
+		});
 
-    this.log("Setting up worker");
-    await this.context
-      .get()
-      .worker.network(this.suite.options.balenaOS.network);
+		this.log('Setting up worker');
+		await this.context
+			.get()
+			.worker.network(this.suite.options.balenaOS.network);
 
-    // Unpack both base and target OS images
-    await this.context.get().os.fetch();
-    await this.context.get().hupOs.fetch();
-    // configure the image
-    await this.context.get().os.configure()
-    // Starts the registry
-    await this.context.get().hup.runRegistry(this, this.context.get().hupOs.image.path);
-  },
-  tests: [
-    "./tests/smoke",
-    // "./tests/self-serve-dashboard",
-    // "./tests/rollback-altboot",
-    // "./tests/rollback-health",
-  ],
+		// Unpack both base and target OS images
+		await this.context.get().os.fetch();
+		await this.context.get().hupOs.fetch();
+		// configure the image
+		await this.context.get().os.configure();
+		// Starts the registry
+		await this.context
+			.get()
+			.hup.runRegistry(this, this.context.get().hupOs.image.path);
+	},
+	tests: [
+		'./tests/smoke',
+		// "./tests/self-serve-dashboard",
+		// "./tests/rollback-altboot",
+		// "./tests/rollback-health",
+	],
 };

--- a/tests/suites/hup/tests/smoke.js
+++ b/tests/suites/hup/tests/smoke.js
@@ -7,55 +7,76 @@
 'use strict';
 
 module.exports = {
-  title: 'Smoke test',
-  run: async function (test) {
-    await this.context.get().hup.initDUT(
-      this, test, this.context.get().link);
+	title: 'Smoke test',
+	run: async function(test) {
+		await this.context.get().hup.initDUT(this, test, this.context.get().link);
 
-    const before = await this.context.get().worker.getOSVersion(this.context.get().link);
-    test.comment(`VERSION (before): ${before}`);
+		const before = await this.context
+			.get()
+			.worker.getOSVersion(this.context.get().link);
+		test.comment(`VERSION (before): ${before}`);
 
-    await this.context.get().hup.doHUP(this, test, 'image', this.context.get().hup.payload, this.context.get().link);
+		await this.context
+			.get()
+			.hup.doHUP(
+				this,
+				test,
+				'image',
+				this.context.get().hup.payload,
+				this.context.get().link,
+			);
 
-    test.comment(`Reducing amount of time needed for rollback-health to fail`)
-    // reduce number of failures needed to trigger rollback
-    await this.context.get().worker.executeCommandInHostOS(
-      `sed -i -e "s/COUNT=.*/COUNT=1/g" -e "s/TIMEOUT=.*/TIMEOUT=10/g" $(find /mnt/sysroot/inactive/ | grep "bin/rollback-health")`,
-      this.context.get().link,
-    );
+		test.comment(`Reducing amount of time needed for rollback-health to fail`);
+		// reduce number of failures needed to trigger rollback
+		await this.context
+			.get()
+			.worker.executeCommandInHostOS(
+				`sed -i -e "s/COUNT=.*/COUNT=1/g" -e "s/TIMEOUT=.*/TIMEOUT=10/g" $(find /mnt/sysroot/inactive/ | grep "bin/rollback-health")`,
+				this.context.get().link,
+			);
 
-    await this.context.get().worker.rebootDut(this.context.get().link);
+		await this.context.get().worker.rebootDut(this.context.get().link);
 
-    const after = await this.context.get().worker.getOSVersion(this.context.get().link);
-    test.comment(`VERSION (after): ${after}`);
+		const after = await this.context
+			.get()
+			.worker.getOSVersion(this.context.get().link);
+		test.comment(`VERSION (after): ${after}`);
 
-    // The rollback-health service should always run regardless of the scenario
-    test.comment(`Waiting for rollback-health service to start ...`);
-    await this.context.get().utils.waitUntil(async () => {
-      return (
-        (await this.context.get().worker.executeCommandInHostOS(
-          `systemctl is-active rollback-health.service`,
-          this.context.get().link,
-        )) === 'active'
-      );
-    }, false);
+		// The rollback-health service should always run regardless of the scenario
+		test.comment(`Waiting for rollback-health service to start ...`);
+		await this.context.get().utils.waitUntil(async () => {
+			return (
+				(await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						`systemctl is-active rollback-health.service`,
+						this.context.get().link,
+					)) === 'active'
+			);
+		}, false);
 
-    test.is(
-      await this.context.get().worker.executeCommandInHostOS(
-        `[ -f /mnt/state/rollback-health-triggered ] && echo fail || echo pass`,
-        this.context.get().link),
-      "pass",
-      "Rollback-health should succeed health checks.",
-    );
+		test.is(
+			await this.context
+				.get()
+				.worker.executeCommandInHostOS(
+					`[ -f /mnt/state/rollback-health-triggered ] && echo fail || echo pass`,
+					this.context.get().link,
+				),
+			'pass',
+			'Rollback-health should succeed health checks.',
+		);
 
-    test.is(
-      await this.context.get().worker.executeCommandInHostOS(
-        `[ -f /mnt/state/rollback-health-failed ] && echo fail || echo pass`,
-        this.context.get().link),
-      "pass",
-      "Rollback-health should succeed running previous hooks.",
-    );
+		test.is(
+			await this.context
+				.get()
+				.worker.executeCommandInHostOS(
+					`[ -f /mnt/state/rollback-health-failed ] && echo fail || echo pass`,
+					this.context.get().link,
+				),
+			'pass',
+			'Rollback-health should succeed running previous hooks.',
+		);
 
-    test.comment(`Successful hostapp-update from ${before} to ${after}`);
-  },
+		test.comment(`Successful hostapp-update from ${before} to ${after}`);
+	},
 };

--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -94,13 +94,10 @@ module.exports = {
 
     // Register a teardown function execute at the end of the test, regardless of a pass or fail
     this.suite.teardown.register(() => {
-      this.log("Removing image");
-      if (fse.existsSync("/data/image")) {
-        fse.unlinkSync("/data/image"); // Delete the unpacked an modified image from the testbot cache to prevent use in the next suite
-      }
       this.log("Worker teardown");
       return this.context.get().worker.teardown();
     });
+
     this.log("Setting up worker");
 
 
@@ -115,11 +112,7 @@ module.exports = {
       .worker.network(this.suite.options.balenaOS.network);
 
     // Unpack OS image .gz
-    await this.context.get().os.fetch({
-      type: this.suite.options.balenaOS.download.type,
-      version: this.suite.options.balenaOS.download.version,
-      releaseInfo: this.suite.options.balenaOS.releaseInfo,
-    });
+    await this.context.get().os.fetch();
 
     // Configure OS image
     await this.context.get().os.configure();

--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -4,150 +4,149 @@
  * @license Apache-2.0
  */
 
-"use strict";
+'use strict';
 
-const assert = require("assert");
-const fse = require("fs-extra");
-const { join } = require("path");
-const { homedir } = require("os");
+const assert = require('assert');
+const fse = require('fs-extra');
+const { join } = require('path');
+const { homedir } = require('os');
 
+async function getJournalLogs(that) {
+	// there may be quite a lot in the persistant logs, so we want to check if there's any persistant logs first in /var/logs/journal
+	let logs = '';
+	try {
+		logs = await that.context
+			.get()
+			.worker.executeCommandInHostOS(
+				`journalctl -a --no-pager`,
+				that.context.get().link,
+			);
+	} catch (e) {
+		that.log(`Couldn't retrieve journal logs with error ${e}`);
+	}
 
-async function getJournalLogs(that){
-  // there may be quite a lot in the persistant logs, so we want to check if there's any persistant logs first in /var/logs/journal
-  let logs = ""
-  try{
-    logs = await that.context.get().worker.executeCommandInHostOS(
-    `journalctl -a --no-pager`,
-    that.context.get().link
-    )
-  }catch(e){
-    that.log(`Couldn't retrieve journal logs with error ${e}`)
-  }
-
-  const logPath = "/tmp/journal.log";
-  fse.writeFileSync(logPath, logs);
-  await that.archiver.add(logPath);
-} 
-
+	const logPath = '/tmp/journal.log';
+	fse.writeFileSync(logPath, logs);
+	await that.archiver.add(logPath);
+}
 
 module.exports = {
-  title: "Unmanaged BalenaOS release suite",
-  run: async function (test) {
-    // The worker class contains methods to interact with the DUT, such as flashing, or executing a command on the device
-    const Worker = this.require("common/worker");
+	title: 'Unmanaged BalenaOS release suite',
+	run: async function(test) {
+		// The worker class contains methods to interact with the DUT, such as flashing, or executing a command on the device
+		const Worker = this.require('common/worker');
 
-    // The balenaOS class contains information on the OS image to be flashed, and methods to configure it
-    const BalenaOS = this.require("components/os/balenaos");
+		// The balenaOS class contains information on the OS image to be flashed, and methods to configure it
+		const BalenaOS = this.require('components/os/balenaos');
 
-    await fse.ensureDir(this.suite.options.tmpdir);
+		await fse.ensureDir(this.suite.options.tmpdir);
 
-    // The suite contex is an object that is shared across all tests. Setting something into the context makes it accessible by every test
-    this.suite.context.set({
-      utils: this.require("common/utils"),
-      sshKeyPath: join(homedir(), "id"),
-      link: `${this.suite.options.balenaOS.config.uuid.slice(0, 7)}.local`,
-      worker: new Worker(this.suite.deviceType.slug, this.getLogger()),
-    });
+		// The suite contex is an object that is shared across all tests. Setting something into the context makes it accessible by every test
+		this.suite.context.set({
+			utils: this.require('common/utils'),
+			sshKeyPath: join(homedir(), 'id'),
+			link: `${this.suite.options.balenaOS.config.uuid.slice(0, 7)}.local`,
+			worker: new Worker(this.suite.deviceType.slug, this.getLogger()),
+		});
 
-    // Network definitions - here we check what network configuration is selected for the DUT for the suite, and add the appropriate configuration options (e.g wifi credentials)
-    if (this.suite.options.balenaOS.network.wired === true) {
-      this.suite.options.balenaOS.network.wired = {
-        nat: true,
-      };
-    } else {
-      delete this.suite.options.balenaOS.network.wired;
-    }
-    if (this.suite.options.balenaOS.network.wireless === true) {
-      this.suite.options.balenaOS.network.wireless = {
-        ssid: this.suite.options.id,
-        psk: `${this.suite.options.id}_psk`,
-        nat: true,
-      };
-    } else {
-      delete this.suite.options.balenaOS.network.wireless;
-    }
+		// Network definitions - here we check what network configuration is selected for the DUT for the suite, and add the appropriate configuration options (e.g wifi credentials)
+		if (this.suite.options.balenaOS.network.wired === true) {
+			this.suite.options.balenaOS.network.wired = {
+				nat: true,
+			};
+		} else {
+			delete this.suite.options.balenaOS.network.wired;
+		}
+		if (this.suite.options.balenaOS.network.wireless === true) {
+			this.suite.options.balenaOS.network.wireless = {
+				ssid: this.suite.options.id,
+				psk: `${this.suite.options.id}_psk`,
+				nat: true,
+			};
+		} else {
+			delete this.suite.options.balenaOS.network.wireless;
+		}
 
-    // Create an instance of the balenOS object, containing information such as device type, and config.json options
-    this.suite.context.set({
-      os: new BalenaOS(
-        {
-          deviceType: this.suite.deviceType.slug,
-          network: this.suite.options.balenaOS.network,
-          configJson: {
-            uuid: this.suite.options.balenaOS.config.uuid,
-            os: {
-              sshKeys: [
-                await this.context
-                  .get()
-                  .utils.createSSHKey(this.context.get().sshKeyPath),
-              ],
-            },
-            // persistentLogging is managed by the supervisor and only read at first boot
-            persistentLogging: true,
-            // Set local mode so we can perform local pushes of containers to the DUT
-            localMode: true,
-          },
-        },
-        this.getLogger()
-      ),
-    });
+		// Create an instance of the balenOS object, containing information such as device type, and config.json options
+		this.suite.context.set({
+			os: new BalenaOS(
+				{
+					deviceType: this.suite.deviceType.slug,
+					network: this.suite.options.balenaOS.network,
+					configJson: {
+						uuid: this.suite.options.balenaOS.config.uuid,
+						os: {
+							sshKeys: [
+								await this.context
+									.get()
+									.utils.createSSHKey(this.context.get().sshKeyPath),
+							],
+						},
+						// persistentLogging is managed by the supervisor and only read at first boot
+						persistentLogging: true,
+						// Set local mode so we can perform local pushes of containers to the DUT
+						localMode: true,
+					},
+				},
+				this.getLogger(),
+			),
+		});
 
-    // Register a teardown function execute at the end of the test, regardless of a pass or fail
-    this.suite.teardown.register(() => {
-      this.log("Worker teardown");
-      return this.context.get().worker.teardown();
-    });
+		// Register a teardown function execute at the end of the test, regardless of a pass or fail
+		this.suite.teardown.register(() => {
+			this.log('Worker teardown');
+			return this.context.get().worker.teardown();
+		});
 
-    this.log("Setting up worker");
+		this.log('Setting up worker');
 
+		this.suite.teardown.register(async () => {
+			this.log('Retreiving journal logs...');
+			await getJournalLogs(this);
+		});
 
-    this.suite.teardown.register(async() => {
-      this.log("Retreiving journal logs...");
-      await getJournalLogs(this)
-    })
+		// Create network AP on testbot
+		await this.context
+			.get()
+			.worker.network(this.suite.options.balenaOS.network);
 
-    // Create network AP on testbot
-    await this.context
-      .get()
-      .worker.network(this.suite.options.balenaOS.network);
+		// Unpack OS image .gz
+		await this.context.get().os.fetch();
 
-    // Unpack OS image .gz
-    await this.context.get().os.fetch();
+		// Configure OS image
+		await this.context.get().os.configure();
 
-    // Configure OS image
-    await this.context.get().os.configure();
+		// Flash the DUT
+		await this.context.get().worker.off(); // Ensure DUT is off before starting tests
+		await this.context.get().worker.flash(this.context.get().os.image.path);
+		await this.context.get().worker.on();
 
-    // Flash the DUT
-    await this.context.get().worker.off(); // Ensure DUT is off before starting tests
-    await this.context.get().worker.flash(this.context.get().os.image.path);
-    await this.context.get().worker.on();
-
-    this.log("Waiting for device to be reachable");
-    assert.equal(
-      await this.context
-        .get()
-        .worker.executeCommandInHostOS(
-          "cat /etc/hostname",
-          this.context.get().link
-        ),
-      this.context.get().link.split(".")[0],
-      "Device should be reachable"
-    );
-  },
-  tests: [
-    "./tests/fingerprint",
-    "./tests/os-release",
-    "./tests/chrony",
-    "./tests/kernel-overlap",
-    "./tests/bluetooth",
-    "./tests/healthcheck",
-    "./tests/variables",
-    "./tests/led",
-    "./tests/config-json",
-    "./tests/boot-splash",
-    "./tests/connectivity",
-    "./tests/engine-healthcheck",
-    "./tests/udev",
-    "./tests/device-tree",
-  ],
+		this.log('Waiting for device to be reachable');
+		assert.equal(
+			await this.context
+				.get()
+				.worker.executeCommandInHostOS(
+					'cat /etc/hostname',
+					this.context.get().link,
+				),
+			this.context.get().link.split('.')[0],
+			'Device should be reachable',
+		);
+	},
+	tests: [
+		'./tests/fingerprint',
+		'./tests/os-release',
+		'./tests/chrony',
+		'./tests/kernel-overlap',
+		'./tests/bluetooth',
+		'./tests/healthcheck',
+		'./tests/variables',
+		'./tests/led',
+		'./tests/config-json',
+		'./tests/boot-splash',
+		'./tests/connectivity',
+		'./tests/engine-healthcheck',
+		'./tests/udev',
+		'./tests/device-tree',
+	],
 };

--- a/tests/suites/os/tests/bluetooth/index.js
+++ b/tests/suites/os/tests/bluetooth/index.js
@@ -1,6 +1,5 @@
 const Bluebird = require("bluebird");
 const exec = Bluebird.promisify(require("child_process").exec);
-const retry = require("bluebird-retry");
 
 module.exports = {
   title: "Bluetooth tests",
@@ -53,7 +52,7 @@ module.exports = {
         test.is(
           scan.includes(btNameParsed[2]),
           true,
-          "DUT should be able to see testbot when scanning for bluetooth devicess"
+          "DUT should be able to see testbot when scanning for bluetooth devices"
         );
       },
     },

--- a/tests/suites/os/tests/bluetooth/index.js
+++ b/tests/suites/os/tests/bluetooth/index.js
@@ -1,60 +1,60 @@
-const Bluebird = require("bluebird");
-const exec = Bluebird.promisify(require("child_process").exec);
+const Bluebird = require('bluebird');
+const exec = Bluebird.promisify(require('child_process').exec);
 
 module.exports = {
-  title: "Bluetooth tests",
-  deviceType: {
-    type: "object",
-    required: ["data"],
-    properties: {
-      data: {
-        type: "object",
-        required: ["connectivity"],
-        properties: {
-          connectivity: {
-            type: "object",
-            required: ["bluetooth"],
-            properties: {
-              bluetooth: {
-                type: "boolean",
-                const: true,
-              },
-            },
-          },
-        },
-      },
-    },
-  },
-  tests: [
-    {
-      title: "Bluetooth scanning test",
-      run: async function (test) {
-        // get the testbot bluetooth name
-        let btName = await exec("bluetoothctl show | grep Name");
-        let btNameParsed = /(.*): (.*)/.exec(btName); // the bluetoothctl command returns "Name: <btname>", so extract the <btname here>
+	title: 'Bluetooth tests',
+	deviceType: {
+		type: 'object',
+		required: ['data'],
+		properties: {
+			data: {
+				type: 'object',
+				required: ['connectivity'],
+				properties: {
+					connectivity: {
+						type: 'object',
+						required: ['bluetooth'],
+						properties: {
+							bluetooth: {
+								type: 'boolean',
+								const: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	tests: [
+		{
+			title: 'Bluetooth scanning test',
+			run: async function(test) {
+				// get the testbot bluetooth name
+				let btName = await exec('bluetoothctl show | grep Name');
+				let btNameParsed = /(.*): (.*)/.exec(btName); // the bluetoothctl command returns "Name: <btname>", so extract the <btname here>
 
-        // make testbot bluetooth discoverable
-        await exec("bluetoothctl discoverable on");
+				// make testbot bluetooth discoverable
+				await exec('bluetoothctl discoverable on');
 
-        // scan for bluetooth devices on DUT, we retry a couple of times
-        let scan = "";
-        await this.context.get().utils.waitUntil(async () => {
-          test.comment("Scanning for bluetooth devices...");
-          scan = await this.context
-            .get()
-            .worker.executeCommandInHostOS(
-              "hcitool scan",
-              this.context.get().link
-            );
-          return scan.includes(btNameParsed[2]);
-        });
+				// scan for bluetooth devices on DUT, we retry a couple of times
+				let scan = '';
+				await this.context.get().utils.waitUntil(async () => {
+					test.comment('Scanning for bluetooth devices...');
+					scan = await this.context
+						.get()
+						.worker.executeCommandInHostOS(
+							'hcitool scan',
+							this.context.get().link,
+						);
+					return scan.includes(btNameParsed[2]);
+				});
 
-        test.is(
-          scan.includes(btNameParsed[2]),
-          true,
-          "DUT should be able to see testbot when scanning for bluetooth devices"
-        );
-      },
-    },
-  ],
+				test.is(
+					scan.includes(btNameParsed[2]),
+					true,
+					'DUT should be able to see testbot when scanning for bluetooth devices',
+				);
+			},
+		},
+	],
 };

--- a/tests/suites/os/tests/boot-splash/index.js
+++ b/tests/suites/os/tests/boot-splash/index.js
@@ -45,7 +45,7 @@ module.exports = {
 			run: async function(test) {
 				const { hammingDistance, blockhash } = this.require('/common/graphics');
 
-				test.comment(`Calculating reference hash`)
+				test.comment(`Calculating reference hash`);
 				// Pull in the reference image
 				const referenceHash = await new Promise((resolve, reject) => {
 					const stream = fs.createReadStream(BOOT_SPLASH);
@@ -59,39 +59,39 @@ module.exports = {
 						resolve(blockhash(decode(Buffer.concat(buffer))));
 					});
 				});
-				test.comment("Finished calculating reference hash")
+				test.comment('Finished calculating reference hash');
 
-				test.comment("Starting capture")
+				test.comment('Starting capture');
 				await this.context.get().worker.capture('start');
 
 				// Rebooting the DUT
-				await this.context.get().worker.rebootDut(this.context.get().link)
+				await this.context.get().worker.rebootDut(this.context.get().link);
 				test.comment(`Stopping capture...`);
 
 				let stopCapture = new Promise((resolve, reject) => {
 					const res = this.context.get().worker.capture('stop');
 					res.on('error', error => {
-						throw new Error(`Error stopping capture: ${error}`)
+						throw new Error(`Error stopping capture: ${error}`);
 					});
 
-					res.on('response', (response) => {
-						if(response.statusCode === 200){
-							test.comment(`Capture stopped...`)
-							resolve()
-						};
+					res.on('response', response => {
+						if (response.statusCode === 200) {
+							test.comment(`Capture stopped...`);
+							resolve();
+						}
 					});
 				});
 
 				await stopCapture;
 
 				// captured frames are stored in /data/capture - we probably want a way to remove the need for a hard coded reference here
-				const captured = fs.readdirSync(`/data/capture`)
+				const captured = fs.readdirSync(`/data/capture`);
 
-				let pass = false
-				test.comment(`Comparing captured images to reference image...`)
-				for(let image of captured.reverse()){
+				let pass = false;
+				test.comment(`Comparing captured images to reference image...`);
+				for (let image of captured.reverse()) {
 					const capturedHash = await new Promise((resolve, reject) => {
-						try{
+						try {
 							const stream = fs.createReadStream(`/data/capture/` + image);
 							const buffer = [];
 
@@ -102,22 +102,24 @@ module.exports = {
 							stream.on('end', () => {
 								resolve(blockhash(decode(Buffer.concat(buffer))));
 							});
-						} catch (e){
-							test.comment(`Error while comparing images: ${e}`)
+						} catch (e) {
+							test.comment(`Error while comparing images: ${e}`);
 						}
 					});
 
-					let testDistance = hammingDistance(referenceHash, capturedHash)
-					if(testDistance < 20){
-						test.comment(`Found match, image ${image}, hamming distance from reference: ${testDistance}`)
-						pass = true
-						break
+					let testDistance = hammingDistance(referenceHash, capturedHash);
+					if (testDistance < 20) {
+						test.comment(
+							`Found match, image ${image}, hamming distance from reference: ${testDistance}`,
+						);
+						pass = true;
+						break;
 					}
 				}
 
-				test.comment(`Storing captured frames...`)
+				test.comment(`Storing captured frames...`);
 				await this.archiver.add(`/data/capture`);
-				test.comment(`Frames stored`)
+				test.comment(`Frames stored`);
 
 				test.true(
 					pass,

--- a/tests/suites/os/tests/chrony/index.js
+++ b/tests/suites/os/tests/chrony/index.js
@@ -1,58 +1,58 @@
 module.exports = {
-  title: "chrony tests",
-  tests: [
-    {
-      title: "Chronyd service",
-      run: async function (test) {
-        let result = "";
-        result = await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            "systemctl status chronyd | grep running",
-            this.context.get().link
-          );
-        test.is(result !== "", true, "Chronyd service should be running");
-      },
-    },
-    {
-      title: "Sync test",
-      run: async function (test) {
-        let result = "";
-        await this.context.get().utils.waitUntil(async () => {
-          test.comment("checking system clock synchronized...");
-          result = await this.context
-            .get()
-            .worker.executeCommandInHostOS(
-              "timedatectl | grep System",
-              this.context.get().link
-            );
-          return result === "System clock synchronized: yes";
-        });
-        result = await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            "timedatectl | grep System",
-            this.context.get().link
-          );
-        test.is(
-          result,
-          "System clock synchronized: yes",
-          "System clock should be synchronized"
-        );
-      },
-    },
-    {
-      title: "Source test",
-      run: async function (test) {
-        let result = "";
-        result = await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            `chronyc sources -n | fgrep '^*'`,
-            this.context.get().link
-          );
-        test.is(result !== "", true, "Should see ^* next to chrony source");
-      },
-    },
-  ],
+	title: 'chrony tests',
+	tests: [
+		{
+			title: 'Chronyd service',
+			run: async function(test) {
+				let result = '';
+				result = await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						'systemctl status chronyd | grep running',
+						this.context.get().link,
+					);
+				test.is(result !== '', true, 'Chronyd service should be running');
+			},
+		},
+		{
+			title: 'Sync test',
+			run: async function(test) {
+				let result = '';
+				await this.context.get().utils.waitUntil(async () => {
+					test.comment('checking system clock synchronized...');
+					result = await this.context
+						.get()
+						.worker.executeCommandInHostOS(
+							'timedatectl | grep System',
+							this.context.get().link,
+						);
+					return result === 'System clock synchronized: yes';
+				});
+				result = await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						'timedatectl | grep System',
+						this.context.get().link,
+					);
+				test.is(
+					result,
+					'System clock synchronized: yes',
+					'System clock should be synchronized',
+				);
+			},
+		},
+		{
+			title: 'Source test',
+			run: async function(test) {
+				let result = '';
+				result = await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						`chronyc sources -n | fgrep '^*'`,
+						this.context.get().link,
+					);
+				test.is(result !== '', true, 'Should see ^* next to chrony source');
+			},
+		},
+	],
 };

--- a/tests/suites/os/tests/config-json/index.js
+++ b/tests/suites/os/tests/config-json/index.js
@@ -14,35 +14,6 @@
 
 "use strict";
 
-const rebootDevice = async (that, test) => {
-  await that.context
-    .get()
-    .worker.executeCommandInHostOS(
-      "touch /tmp/reboot-check",
-      that.context.get().link
-    );
-
-  test.comment("Starting reboot...");
-  await that.context
-    .get()
-    .worker.executeCommandInHostOS(
-      "systemd-run --on-active=2 /sbin/reboot",
-      that.context.get().link
-    );
-
-  await that.context.get().utils.waitUntil(async () => {
-    test.comment("Waiting for DUT to come back online...");
-    let res = await that.context
-      .get()
-      .worker.executeCommandInHostOS(
-        '[[ ! -f /tmp/reboot-check ]] && echo "pass"',
-        that.context.get().link
-      );
-
-    return res === "pass";
-  }, false);
-};
-
 module.exports = {
   title: "Config.json configuration tests",
   tests: [
@@ -73,6 +44,7 @@ module.exports = {
             "systemd-run --on-active=2 /sbin/reboot",
             this.context.get().link
           );
+        // Testbot looks for DUT with an updated hostname
         await this.context.get().utils.waitUntil(async () => {
           test.comment("Waiting to come back online...");
           return (
@@ -130,7 +102,6 @@ module.exports = {
         }, false);
       },
     },
-
     {
       title: "ntpServer test",
       run: async function (test) {
@@ -145,7 +116,8 @@ module.exports = {
             this.context.get().link
           );
 
-        await rebootDevice(this, test);
+        // Rebooting the DUT
+        await this.context.get().worker.rebootDut(this.context.get().link)
 
         await test.resolves(
           this.context
@@ -196,7 +168,8 @@ module.exports = {
             this.context.get().link
           );
 
-        await rebootDevice(this, test);
+        // Rebooting the DUT
+        await this.context.get().worker.rebootDut(this.context.get().link)
 
         test.is(
           (
@@ -246,7 +219,8 @@ module.exports = {
             this.context.get().link
           );
 
-        await rebootDevice(this, test);
+        // Rebooting the DUT
+        await this.context.get().worker.rebootDut(this.context.get().link)
 
         const config = await this.context
           .get()
@@ -279,7 +253,8 @@ module.exports = {
             this.context.get().link
           );
 
-        await rebootDevice(this, test);
+        // Rebooting the DUT
+        await this.context.get().worker.rebootDut(this.context.get().link)
 
         const config = await this.context
           .get()
@@ -318,7 +293,8 @@ module.exports = {
             this.context.get().link
           );
 
-        await rebootDevice(this, test);
+        // Rebooting the DUT
+        await this.context.get().worker.rebootDut(this.context.get().link)
 
         test.is(
           await this.context
@@ -371,10 +347,10 @@ module.exports = {
         );
 
         test.comment("Attempting first reboot");
-        await rebootDevice(this, test);
+        await this.context.get().worker.rebootDut(this.context.get().link)
 
         test.comment("Attempting second reboot");
-        await rebootDevice(this, test);
+        await this.context.get().worker.rebootDut(this.context.get().link)
 
         const testcount = parseInt(
           await this.context

--- a/tests/suites/os/tests/config-json/index.js
+++ b/tests/suites/os/tests/config-json/index.js
@@ -12,360 +12,362 @@
  * limitations under the License.
  */
 
-"use strict";
+'use strict';
 
 module.exports = {
-  title: "Config.json configuration tests",
-  tests: [
-    {
-      title: "hostname configuration test",
-      run: async function (test) {
-        const hostname = Math.random().toString(36).substring(2, 10);
+	title: 'Config.json configuration tests',
+	tests: [
+		{
+			title: 'hostname configuration test',
+			run: async function(test) {
+				const hostname = Math.random()
+					.toString(36)
+					.substring(2, 10);
 
-        // Add hostname
-        await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            `tmp=$(mktemp)&&cat /mnt/boot/config.json | jq '.hostname="${hostname}"' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
-            this.context.get().link
-          );
+				// Add hostname
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						`tmp=$(mktemp)&&cat /mnt/boot/config.json | jq '.hostname="${hostname}"' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
+						this.context.get().link,
+					);
 
-        // Start reboot check
-        await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            "touch /tmp/reboot-check",
-            this.context.get().link
-          );
-        test.comment("Starting reboot...");
-        await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            "systemd-run --on-active=2 /sbin/reboot",
-            this.context.get().link
-          );
-        // Testbot looks for DUT with an updated hostname
-        await this.context.get().utils.waitUntil(async () => {
-          test.comment("Waiting to come back online...");
-          return (
-            (await this.context
-              .get()
-              .worker.executeCommandInHostOS(
-                '[[ ! -f /tmp/reboot-check ]] && echo "pass"',
-                `${hostname}.local`
-              )) === "pass"
-          );
-        }, false);
+				// Start reboot check
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						'touch /tmp/reboot-check',
+						this.context.get().link,
+					);
+				test.comment('Starting reboot...');
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						'systemd-run --on-active=2 /sbin/reboot',
+						this.context.get().link,
+					);
+				// Testbot looks for DUT with an updated hostname
+				await this.context.get().utils.waitUntil(async () => {
+					test.comment('Waiting to come back online...');
+					return (
+						(await this.context
+							.get()
+							.worker.executeCommandInHostOS(
+								'[[ ! -f /tmp/reboot-check ]] && echo "pass"',
+								`${hostname}.local`,
+							)) === 'pass'
+					);
+				}, false);
 
-        test.equal(
-          await this.context
-            .get()
-            .worker.executeCommandInHostOS(
-              "cat /etc/hostname",
-              `${hostname}.local`
-            ),
-          hostname,
-          "Device should have new hostname"
-        );
+				test.equal(
+					await this.context
+						.get()
+						.worker.executeCommandInHostOS(
+							'cat /etc/hostname',
+							`${hostname}.local`,
+						),
+					hostname,
+					'Device should have new hostname',
+				);
 
-        // Remove hostname
-        await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            'tmp=$(mktemp)&&cat /mnt/boot/config.json | jq "del(.hostname)" > $tmp&&mv "$tmp" /mnt/boot/config.json',
-            `${hostname}.local`
-          );
+				// Remove hostname
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						'tmp=$(mktemp)&&cat /mnt/boot/config.json | jq "del(.hostname)" > $tmp&&mv "$tmp" /mnt/boot/config.json',
+						`${hostname}.local`,
+					);
 
-        // Start reboot check
-        await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            "touch /tmp/reboot-check",
-            `${hostname}.local`
-          );
+				// Start reboot check
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						'touch /tmp/reboot-check',
+						`${hostname}.local`,
+					);
 
-        await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            "systemd-run --on-active=2 /sbin/reboot",
-            `${hostname}.local`
-          );
-        await this.context.get().utils.waitUntil(async () => {
-          return (
-            (await this.context
-              .get()
-              .worker.executeCommandInHostOS(
-                '[[ ! -f /tmp/reboot-check ]] && echo "pass"',
-                this.context.get().link
-              )) === "pass"
-          );
-        }, false);
-      },
-    },
-    {
-      title: "ntpServer test",
-      run: async function (test) {
-        const ntpServer = (regex = "") => {
-          return `time${regex}.google.com`;
-        };
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						'systemd-run --on-active=2 /sbin/reboot',
+						`${hostname}.local`,
+					);
+				await this.context.get().utils.waitUntil(async () => {
+					return (
+						(await this.context
+							.get()
+							.worker.executeCommandInHostOS(
+								'[[ ! -f /tmp/reboot-check ]] && echo "pass"',
+								this.context.get().link,
+							)) === 'pass'
+					);
+				}, false);
+			},
+		},
+		{
+			title: 'ntpServer test',
+			run: async function(test) {
+				const ntpServer = (regex = '') => {
+					return `time${regex}.google.com`;
+				};
 
-        await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            `tmp=$(mktemp)&&cat /mnt/boot/config.json | jq '.ntpServers="${ntpServer()}"' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
-            this.context.get().link
-          );
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						`tmp=$(mktemp)&&cat /mnt/boot/config.json | jq '.ntpServers="${ntpServer()}"' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
+						this.context.get().link,
+					);
 
-        // Rebooting the DUT
-        await this.context.get().worker.rebootDut(this.context.get().link)
+				// Rebooting the DUT
+				await this.context.get().worker.rebootDut(this.context.get().link);
 
-        await test.resolves(
-          this.context
-            .get()
-            .worker.executeCommandInHostOS(
-              `chronyc sources | grep ${ntpServer(".*")}`,
-              this.context.get().link
-            ),
-          "Device should show one record with our ntp server"
-        );
+				await test.resolves(
+					this.context
+						.get()
+						.worker.executeCommandInHostOS(
+							`chronyc sources | grep ${ntpServer('.*')}`,
+							this.context.get().link,
+						),
+					'Device should show one record with our ntp server',
+				);
 
-        await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            'tmp=$(mktemp)&&cat /mnt/boot/config.json | jq "del(.ntpServers)" > $tmp&&mv "$tmp" /mnt/boot/config.json',
-            this.context.get().link
-          );
-      },
-    },
-    {
-      title: "dnsServer test",
-      run: async function (test) {
-        const dnsServer = "8.8.4.4";
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						'tmp=$(mktemp)&&cat /mnt/boot/config.json | jq "del(.ntpServers)" > $tmp&&mv "$tmp" /mnt/boot/config.json',
+						this.context.get().link,
+					);
+			},
+		},
+		{
+			title: 'dnsServer test',
+			run: async function(test) {
+				const dnsServer = '8.8.4.4';
 
-        const serverFile = await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            "systemctl show dnsmasq  | grep ExecStart= | sed -n 's/.*--servers-file=\\([^ ]*\\)\\s.*$/\\1/p'",
-            this.context.get().link
-          );
+				const serverFile = await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						"systemctl show dnsmasq  | grep ExecStart= | sed -n 's/.*--servers-file=\\([^ ]*\\)\\s.*$/\\1/p'",
+						this.context.get().link,
+					);
 
-        test.is(
-          (
-            await this.context
-              .get()
-              .worker.executeCommandInHostOS(
-                `cat ${serverFile}`,
-                this.context.get().link
-              )
-          ).trim(),
-          "server=8.8.8.8"
-        );
+				test.is(
+					(
+						await this.context
+							.get()
+							.worker.executeCommandInHostOS(
+								`cat ${serverFile}`,
+								this.context.get().link,
+							)
+					).trim(),
+					'server=8.8.8.8',
+				);
 
-        await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            `tmp=$(mktemp)&&cat /mnt/boot/config.json | jq '.dnsServers="${dnsServer}"' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
-            this.context.get().link
-          );
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						`tmp=$(mktemp)&&cat /mnt/boot/config.json | jq '.dnsServers="${dnsServer}"' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
+						this.context.get().link,
+					);
 
-        // Rebooting the DUT
-        await this.context.get().worker.rebootDut(this.context.get().link)
+				// Rebooting the DUT
+				await this.context.get().worker.rebootDut(this.context.get().link);
 
-        test.is(
-          (
-            await this.context
-              .get()
-              .worker.executeCommandInHostOS(
-                `cat ${serverFile}`,
-                this.context.get().link
-              )
-          ).trim(),
-          `server=${dnsServer}`
-        );
+				test.is(
+					(
+						await this.context
+							.get()
+							.worker.executeCommandInHostOS(
+								`cat ${serverFile}`,
+								this.context.get().link,
+							)
+					).trim(),
+					`server=${dnsServer}`,
+				);
 
-        await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            'tmp=$(mktemp)&&cat /mnt/boot/config.json | jq "del(.dnsServers)" > $tmp&&mv "$tmp" /mnt/boot/config.json',
-            this.context.get().link
-          );
-      },
-    },
-    {
-      title: "os.network.connectivity test",
-      os: {
-        type: "object",
-        required: ["version"],
-        properties: {
-          version: {
-            type: "string",
-            semver: {
-              gt: "2.34.0",
-            },
-          },
-        },
-      },
-      run: async function (test) {
-        const connectivity = {
-          uri: "http://www.archlinux.org/check_network_status.txt",
-        };
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						'tmp=$(mktemp)&&cat /mnt/boot/config.json | jq "del(.dnsServers)" > $tmp&&mv "$tmp" /mnt/boot/config.json',
+						this.context.get().link,
+					);
+			},
+		},
+		{
+			title: 'os.network.connectivity test',
+			os: {
+				type: 'object',
+				required: ['version'],
+				properties: {
+					version: {
+						type: 'string',
+						semver: {
+							gt: '2.34.0',
+						},
+					},
+				},
+			},
+			run: async function(test) {
+				const connectivity = {
+					uri: 'http://www.archlinux.org/check_network_status.txt',
+				};
 
-        await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            `tmp=$(mktemp)&&cat /mnt/boot/config.json | jq '.os.network.connectivity=${JSON.stringify(
-              connectivity
-            )}' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
-            this.context.get().link
-          );
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						`tmp=$(mktemp)&&cat /mnt/boot/config.json | jq '.os.network.connectivity=${JSON.stringify(
+							connectivity,
+						)}' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
+						this.context.get().link,
+					);
 
-        // Rebooting the DUT
-        await this.context.get().worker.rebootDut(this.context.get().link)
+				// Rebooting the DUT
+				await this.context.get().worker.rebootDut(this.context.get().link);
 
-        const config = await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            'NetworkManager --print-config | awk "/\\[connectivity\\]/{flag=1;next}/\\[/{flag=0}flag"',
-            this.context.get().link
-          );
+				const config = await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						'NetworkManager --print-config | awk "/\\[connectivity\\]/{flag=1;next}/\\[/{flag=0}flag"',
+						this.context.get().link,
+					);
 
-        test.is(
-          /uri=(.*)\n/.exec(config)[1],
-          connectivity.uri,
-          `NetworkManager should be configured with uri: ${connectivity.uri}`
-        );
+				test.is(
+					/uri=(.*)\n/.exec(config)[1],
+					connectivity.uri,
+					`NetworkManager should be configured with uri: ${connectivity.uri}`,
+				);
 
-        await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            'tmp=$(mktemp)&&cat /mnt/boot/config.json | jq "del(.os.network.connectivity)" > $tmp&&mv "$tmp" /mnt/boot/config.json',
-            this.context.get().link
-          );
-      },
-    },
-    {
-      title: "os.network.wifi.randomMacAddressScan test",
-      run: async function (test) {
-        await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            `tmp=$(mktemp)&&cat /mnt/boot/config.json | jq '.os.network.wifi.randomMacAddressScan=true' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
-            this.context.get().link
-          );
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						'tmp=$(mktemp)&&cat /mnt/boot/config.json | jq "del(.os.network.connectivity)" > $tmp&&mv "$tmp" /mnt/boot/config.json',
+						this.context.get().link,
+					);
+			},
+		},
+		{
+			title: 'os.network.wifi.randomMacAddressScan test',
+			run: async function(test) {
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						`tmp=$(mktemp)&&cat /mnt/boot/config.json | jq '.os.network.wifi.randomMacAddressScan=true' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
+						this.context.get().link,
+					);
 
-        // Rebooting the DUT
-        await this.context.get().worker.rebootDut(this.context.get().link)
+				// Rebooting the DUT
+				await this.context.get().worker.rebootDut(this.context.get().link);
 
-        const config = await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            'NetworkManager --print-config | awk "/\\[device\\]/{flag=1;next}/\\[/{flag=0}flag"',
-            this.context.get().link
-          );
+				const config = await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						'NetworkManager --print-config | awk "/\\[device\\]/{flag=1;next}/\\[/{flag=0}flag"',
+						this.context.get().link,
+					);
 
-        test.match(
-          config,
-          /wifi.scan-rand-mac-address=yes/,
-          "NetworkManager should be configured to randomize wifi MAC"
-        );
+				test.match(
+					config,
+					/wifi.scan-rand-mac-address=yes/,
+					'NetworkManager should be configured to randomize wifi MAC',
+				);
 
-        await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            `tmp=$(mktemp)&&cat /mnt/boot/config.json | jq 'del(.os.network.wifi)' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
-            this.context.get().link
-          );
-      },
-    },
-    {
-      title: "udevRules test",
-      run: async function (test) {
-        const rule = {
-          99: 'ENV{ID_FS_LABEL_ENC}=="resin-boot", SYMLINK+="disk/test"',
-        };
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						`tmp=$(mktemp)&&cat /mnt/boot/config.json | jq 'del(.os.network.wifi)' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
+						this.context.get().link,
+					);
+			},
+		},
+		{
+			title: 'udevRules test',
+			run: async function(test) {
+				const rule = {
+					99: 'ENV{ID_FS_LABEL_ENC}=="resin-boot", SYMLINK+="disk/test"',
+				};
 
-        await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            `tmp=$(mktemp)&&cat /mnt/boot/config.json | jq '.os.udevRules=${JSON.stringify(
-              rule
-            )}' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
-            this.context.get().link
-          );
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						`tmp=$(mktemp)&&cat /mnt/boot/config.json | jq '.os.udevRules=${JSON.stringify(
+							rule,
+						)}' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
+						this.context.get().link,
+					);
 
-        // Rebooting the DUT
-        await this.context.get().worker.rebootDut(this.context.get().link)
+				// Rebooting the DUT
+				await this.context.get().worker.rebootDut(this.context.get().link);
 
-        test.is(
-          await this.context
-            .get()
-            .worker.executeCommandInHostOS(
-              "readlink -e /dev/disk/test",
-              this.context.get().link
-            ),
-          await this.context
-            .get()
-            .worker.executeCommandInHostOS(
-              "readlink -e /dev/disk/by-label/resin-boot",
-              this.context.get().link
-            ),
-          "Dev link should point to the correct device"
-        );
+				test.is(
+					await this.context
+						.get()
+						.worker.executeCommandInHostOS(
+							'readlink -e /dev/disk/test',
+							this.context.get().link,
+						),
+					await this.context
+						.get()
+						.worker.executeCommandInHostOS(
+							'readlink -e /dev/disk/by-label/resin-boot',
+							this.context.get().link,
+						),
+					'Dev link should point to the correct device',
+				);
 
-        await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            `tmp=$(mktemp)&&cat /mnt/boot/config.json | jq 'del(.os.udevRules)' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
-            this.context.get().link
-          );
-      },
-    },
-    {
-      title: "sshKeys test",
-      run: async function (test) {
-        await test.resolves(
-          this.context
-            .get()
-            .worker.executeCommandInHostOS(
-              "echo true",
-              this.context.get().link
-            ),
-          "Should be able to establish ssh connection to the device"
-        );
-      },
-    },
-    {
-      title: "persistentLogging configuration test",
-      run: async function (test) {
-        const bootCount = parseInt(
-          await this.context
-            .get()
-            .worker.executeCommandInHostOS(
-              "journalctl --list-boots | wc -l",
-              this.context.get().link
-            )
-        );
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						`tmp=$(mktemp)&&cat /mnt/boot/config.json | jq 'del(.os.udevRules)' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
+						this.context.get().link,
+					);
+			},
+		},
+		{
+			title: 'sshKeys test',
+			run: async function(test) {
+				await test.resolves(
+					this.context
+						.get()
+						.worker.executeCommandInHostOS(
+							'echo true',
+							this.context.get().link,
+						),
+					'Should be able to establish ssh connection to the device',
+				);
+			},
+		},
+		{
+			title: 'persistentLogging configuration test',
+			run: async function(test) {
+				const bootCount = parseInt(
+					await this.context
+						.get()
+						.worker.executeCommandInHostOS(
+							'journalctl --list-boots | wc -l',
+							this.context.get().link,
+						),
+				);
 
-        test.comment("Attempting first reboot");
-        await this.context.get().worker.rebootDut(this.context.get().link)
+				test.comment('Attempting first reboot');
+				await this.context.get().worker.rebootDut(this.context.get().link);
 
-        test.comment("Attempting second reboot");
-        await this.context.get().worker.rebootDut(this.context.get().link)
+				test.comment('Attempting second reboot');
+				await this.context.get().worker.rebootDut(this.context.get().link);
 
-        const testcount = parseInt(
-          await this.context
-            .get()
-            .worker.executeCommandInHostOS(
-              "journalctl --list-boots | wc -l",
-              this.context.get().link
-            )
-        );
-        test.is(
-          testcount === bootCount+2,
-          true,
-          `Device should show previous boot records, showed ${testcount} boots`
-        );
-      },
-    },
-  ],
+				const testcount = parseInt(
+					await this.context
+						.get()
+						.worker.executeCommandInHostOS(
+							'journalctl --list-boots | wc -l',
+							this.context.get().link,
+						),
+				);
+				test.is(
+					testcount === bootCount + 2,
+					true,
+					`Device should show previous boot records, showed ${testcount} boots`,
+				);
+			},
+		},
+	],
 };

--- a/tests/suites/os/tests/connectivity/index.js
+++ b/tests/suites/os/tests/connectivity/index.js
@@ -105,31 +105,8 @@ module.exports = {
                 this.context.get().link
               );
 
-            // Start reboot check
-            await this.context
-              .get()
-              .worker.executeCommandInHostOS(
-                "touch /tmp/reboot-check",
-                this.context.get().link
-              );
-            test.comment("Starting reboot...");
-            await this.context
-              .get()
-              .worker.executeCommandInHostOS(
-                "systemd-run --on-active=2 /sbin/reboot",
-                this.context.get().link
-              );
-            await this.context.get().utils.waitUntil(async () => {
-              test.comment("Waiting for DUT to come back online...");
-              return (
-                (await this.context
-                  .get()
-                  .worker.executeCommandInHostOS(
-                    '[[ ! -f /tmp/reboot-check ]] && echo "pass"',
-                    this.context.get().link
-                  )) === "pass"
-              );
-            }, false);
+            // Rebooting the DUT
+            await this.context.get().worker.rebootDut(this.context.get().link)
 
             await this.context
               .get()
@@ -146,31 +123,8 @@ module.exports = {
                 this.context.get().link
               );
 
-            // Start reboot check
-            await this.context
-              .get()
-              .worker.executeCommandInHostOS(
-                "touch /tmp/reboot-check",
-                this.context.get().link
-              );
-            test.comment("Starting reboot...");
-            await this.context
-              .get()
-              .worker.executeCommandInHostOS(
-                "systemd-run --on-active=2 /sbin/reboot",
-                this.context.get().link
-              );
-            await this.context.get().utils.waitUntil(async () => {
-              test.comment("Waiting for DUT to come back online...");
-              return (
-                (await this.context
-                  .get()
-                  .worker.executeCommandInHostOS(
-                    '[[ ! -f /tmp/reboot-check ]] && echo "pass"',
-                    this.context.get().link
-                  )) === "pass"
-              );
-            }, false);
+            // Rebooting the DUT
+            await this.context.get().worker.rebootDut(this.context.get().link)
           },
         };
       }),

--- a/tests/suites/os/tests/connectivity/index.js
+++ b/tests/suites/os/tests/connectivity/index.js
@@ -12,122 +12,125 @@
  * limitations under the License.
  */
 
-"use strict";
+'use strict';
 
-const URL_TEST = "www.google.com";
+const URL_TEST = 'www.google.com';
 
 module.exports = {
-  title: "Connectivity tests",
-  tests: [
-    {
-      title: "Interface tests",
-      tests: ["wired", "wireless"].map((adaptor) => {
-        return {
-          title: `${adaptor.charAt(0).toUpperCase()}${adaptor.slice(1)} test`,
-          os: {
-            type: "object",
-            required: ["network"],
-            properties: {
-              network: {
-                type: "object",
-                required: [adaptor],
-                properties: {
-                  [adaptor]: {
-                    type: "boolean",
-                    const: true,
-                  },
-                },
-              },
-            },
-          },
-          run: async function (test) {
-            let testIface = (adaptor === "wireless") ? "wifi" : "ethernet";
-            const iface = await this.context
-              .get()
-              .worker.executeCommandInHostOS(
-                `nmcli d  | grep ' ${testIface} ' | grep connected | awk '{print $1}'`,
-                this.context.get().link
-              );
+	title: 'Connectivity tests',
+	tests: [
+		{
+			title: 'Interface tests',
+			tests: ['wired', 'wireless'].map(adaptor => {
+				return {
+					title: `${adaptor.charAt(0).toUpperCase()}${adaptor.slice(1)} test`,
+					os: {
+						type: 'object',
+						required: ['network'],
+						properties: {
+							network: {
+								type: 'object',
+								required: [adaptor],
+								properties: {
+									[adaptor]: {
+										type: 'boolean',
+										const: true,
+									},
+								},
+							},
+						},
+					},
+					run: async function(test) {
+						let testIface = adaptor === 'wireless' ? 'wifi' : 'ethernet';
+						const iface = await this.context
+							.get()
+							.worker.executeCommandInHostOS(
+								`nmcli d  | grep ' ${testIface} ' | grep connected | awk '{print $1}'`,
+								this.context.get().link,
+							);
 
-            if (iface === "") {
-              throw new Error(`No ${testIface} interface found.`);
-            }
+						if (iface === '') {
+							throw new Error(`No ${testIface} interface found.`);
+						}
 
-            let ping = await this.context
-              .get()
-              .worker.executeCommandInHostOS(
-                `ping -c 10 -I ${iface} ${URL_TEST}`,
-                this.context.get().link
-              );
+						let ping = await this.context
+							.get()
+							.worker.executeCommandInHostOS(
+								`ping -c 10 -I ${iface} ${URL_TEST}`,
+								this.context.get().link,
+							);
 
-            test.ok(ping.includes("10 packets transmitted, 10 packets received"), `${URL_TEST} responded over ${testIface}`);
-          },
-        };
-      }),
-    },
-    {
-      title: "Proxy tests",
-      tests: ["redsocks", "http-connect"].map((proxy) => {
-        return {
-          title: `${proxy.charAt(0).toUpperCase()}${proxy.slice(1)} test`,
-          run: async function (test) {
-            const PROXY_PORT = 8123;
+						test.ok(
+							ping.includes('10 packets transmitted, 10 packets received'),
+							`${URL_TEST} responded over ${testIface}`,
+						);
+					},
+				};
+			}),
+		},
+		{
+			title: 'Proxy tests',
+			tests: ['redsocks', 'http-connect'].map(proxy => {
+				return {
+					title: `${proxy.charAt(0).toUpperCase()}${proxy.slice(1)} test`,
+					run: async function(test) {
+						const PROXY_PORT = 8123;
 
-            await this.context
-              .get()
-              .worker.executeCommandInHostOS(
-                "mkdir -p /mnt/boot/system-proxy",
-                this.context.get().link
-              );
+						await this.context
+							.get()
+							.worker.executeCommandInHostOS(
+								'mkdir -p /mnt/boot/system-proxy',
+								this.context.get().link,
+							);
 
-            const proxyState = await this.context.get().worker.proxy({
-              port: PROXY_PORT,
-            });
+						const proxyState = await this.context.get().worker.proxy({
+							port: PROXY_PORT,
+						});
 
-            await this.context
-              .get()
-              .worker.executeCommandInHostOS(
-                'printf "' +
-                  "base { \n" +
-                  "log_debug = off; \n" +
-                  "log_info = on; \n" +
-                  "log = stderr; \n" +
-                  "daemon = off; \n" +
-                  "redirector = iptables; \n" +
-                  "} \n" +
-                  "redsocks { \n" +
-                  `type = ${proxy}; \n` +
-                  `ip = ${proxyState.ip}; \n` +
-                  `port = ${PROXY_PORT}; \n` +
-                  "local_ip = 127.0.0.1; \n" +
-                  "local_port = 12345; \n" +
-                  '} \n" > /mnt/boot/system-proxy/redsocks.conf',
-                this.context.get().link
-              );
+						await this.context
+							.get()
+							.worker.executeCommandInHostOS(
+								'printf "' +
+									'base { \n' +
+									'log_debug = off; \n' +
+									'log_info = on; \n' +
+									'log = stderr; \n' +
+									'daemon = off; \n' +
+									'redirector = iptables; \n' +
+									'} \n' +
+									'redsocks { \n' +
+									`type = ${proxy}; \n` +
+									`ip = ${proxyState.ip}; \n` +
+									`port = ${PROXY_PORT}; \n` +
+									'local_ip = 127.0.0.1; \n' +
+									'local_port = 12345; \n' +
+									'} \n" > /mnt/boot/system-proxy/redsocks.conf',
+								this.context.get().link,
+							);
 
-            // Rebooting the DUT
-            await this.context.get().worker.rebootDut(this.context.get().link)
+						// Rebooting the DUT
+						await this.context.get().worker.rebootDut(this.context.get().link);
 
-            await this.context
-              .get()
-              .worker.executeCommandInHostOS(
-                `ping -c 10 ${URL_TEST}`,
-                this.context.get().link
-              );
-            test.true(`${URL_TEST} responded over ${proxy} proxy`);
+						await this.context
+							.get()
+							.worker.executeCommandInHostOS(
+								`ping -c 10 ${URL_TEST}`,
+								this.context.get().link,
+							);
+						test.true(`${URL_TEST} responded over ${proxy} proxy`);
 
-            await this.context
-              .get()
-              .worker.executeCommandInHostOS(
-                "rm -rf /mnt/boot/system-proxy",
-                this.context.get().link
-              );
+						await this.context
+							.get()
+							.worker.executeCommandInHostOS(
+								'rm -rf /mnt/boot/system-proxy',
+								this.context.get().link,
+							);
 
-            // Rebooting the DUT
-            await this.context.get().worker.rebootDut(this.context.get().link)
-          },
-        };
-      }),
-    },
-  ],
+						// Rebooting the DUT
+						await this.context.get().worker.rebootDut(this.context.get().link);
+					},
+				};
+			}),
+		},
+	],
 };

--- a/tests/suites/os/tests/device-tree/index.js
+++ b/tests/suites/os/tests/device-tree/index.js
@@ -60,7 +60,8 @@ module.exports = {
 						this.context.get().link,
 					);
 
-				// Setting the device tree variables using Supervisor API 
+				// Setting the device tree variables using Supervisor API
+				// This request reboots the DUT
 				const setTargetState = await request({
 					method: "POST",
 					headers: {

--- a/tests/suites/os/tests/device-tree/index.js
+++ b/tests/suites/os/tests/device-tree/index.js
@@ -12,46 +12,47 @@
  * limitations under the License.
  */
 
-"use strict";
+'use strict';
 
-const request = require("request-promise");
+const request = require('request-promise');
 const SUPERVISOR_PORT = 48484;
 const fs = require('fs');
 
 module.exports = {
-	title: "Device Tree tests",
+	title: 'Device Tree tests',
 	tests: [
 		{
-			title: "DToverlay & DTparam tests",
-			run: async function (test) {
+			title: 'DToverlay & DTparam tests',
+			run: async function(test) {
 				let ip = await this.context.get().worker.ip(this.context.get().link);
 
 				// Wait for supervisor API to start
 				await this.context.get().utils.waitUntil(async () => {
 					return (
 						(await request({
-							method: "GET",
+							method: 'GET',
 							uri: `http://${ip}:${SUPERVISOR_PORT}/ping`,
-						})) === "OK"
+						})) === 'OK'
 					);
 				}, false);
 
 				const targetState = {
-					"local": {
-						"name": "local",
-						"config": {
-							"HOST_CONFIG_dtoverlay": "\"vc4-fkms-v3d\",\"i2c0\",\"i2c1\",\"i2c3\"",
-							"HOST_CONFIG_dtparam": "\"i2c_arm=on\",\"spi=on\",\"audio=on\",\"foo=bar\",\"level=42\"",
-							"SUPERVISOR_PERSISTENT_LOGGING": "true",
-							"SUPERVISOR_LOCAL_MODE": "true"
+					local: {
+						name: 'local',
+						config: {
+							HOST_CONFIG_dtoverlay: '"vc4-fkms-v3d","i2c0","i2c1","i2c3"',
+							HOST_CONFIG_dtparam:
+								'"i2c_arm=on","spi=on","audio=on","foo=bar","level=42"',
+							SUPERVISOR_PERSISTENT_LOGGING: 'true',
+							SUPERVISOR_LOCAL_MODE: 'true',
 						},
-						"apps": {}
+						apps: {},
 					},
-					"dependent": {
-						"apps": [],
-						"devices": []
-					}
-				}
+					dependent: {
+						apps: [],
+						devices: [],
+					},
+				};
 
 				await this.context
 					.get()
@@ -63,7 +64,7 @@ module.exports = {
 				// Setting the device tree variables using Supervisor API
 				// This request reboots the DUT
 				const setTargetState = await request({
-					method: "POST",
+					method: 'POST',
 					headers: {
 						'Content-Type': 'application/json',
 					},
@@ -72,17 +73,21 @@ module.exports = {
 					uri: `http://${ip}:${SUPERVISOR_PORT}/v2/local/target-state`,
 				});
 
-				test.same(setTargetState, { status: "success", message: "OK" }, "DToverlay & DTparam configured successfully through Supervisor API");
+				test.same(
+					setTargetState,
+					{ status: 'success', message: 'OK' },
+					'DToverlay & DTparam configured successfully through Supervisor API',
+				);
 
 				await this.context.get().utils.waitUntil(async () => {
-					test.comment("Waiting for DUT to come back online after reboot...");
+					test.comment('Waiting for DUT to come back online after reboot...');
 					return (
 						(await this.context
 							.get()
 							.worker.executeCommandInHostOS(
 								'[[ ! -f /tmp/reboot-check ]] && echo "pass"',
-								this.context.get().link
-							)) === "pass"
+								this.context.get().link,
+							)) === 'pass'
 					);
 				}, false);
 
@@ -90,43 +95,61 @@ module.exports = {
 				ip = await this.context.get().worker.ip(this.context.get().link);
 
 				await this.context.get().utils.waitUntil(async () => {
-					test.comment("Waiting for supervisor to be ready after reboot...");
+					test.comment('Waiting for supervisor to be ready after reboot...');
 					return (
 						(await request({
-							method: "GET",
+							method: 'GET',
 							uri: `http://${ip}:${SUPERVISOR_PORT}/ping`,
-						})) === "OK"
+						})) === 'OK'
 					);
 				}, false);
 
 				// Get the current target state of device
 				const currentState = await request({
-					method: "GET",
+					method: 'GET',
 					uri: `http://${ip}:${SUPERVISOR_PORT}/v2/local/target-state`,
-					json: true
+					json: true,
 				});
 
-				test.equal(currentState.state.local.config.HOST_CONFIG_dtoverlay, targetState.local.config.HOST_CONFIG_dtoverlay, "DToverlay successfully set in target state")
-				test.equal(currentState.state.local.config.HOST_CONFIG_dtparam, targetState.local.config.HOST_CONFIG_dtparam, "DTparam successfully set in target state")
+				test.equal(
+					currentState.state.local.config.HOST_CONFIG_dtoverlay,
+					targetState.local.config.HOST_CONFIG_dtoverlay,
+					'DToverlay successfully set in target state',
+				);
+				test.equal(
+					currentState.state.local.config.HOST_CONFIG_dtparam,
+					targetState.local.config.HOST_CONFIG_dtparam,
+					'DTparam successfully set in target state',
+				);
 
-				const dtoverlay = fs.readFileSync(`${__dirname}/dtoverlay.sh`).toString();
+				const dtoverlay = fs
+					.readFileSync(`${__dirname}/dtoverlay.sh`)
+					.toString();
 				const dtparam = fs.readFileSync(`${__dirname}/dtparam.sh`).toString();
 
 				const overlayConfigTxt = await this.context
 					.get()
 					.worker.executeCommandInHostOS(
 						`cd /tmp && ${dtoverlay}`,
-						this.context.get().link
+						this.context.get().link,
 					);
 
-				test.equal(overlayConfigTxt, targetState.local.config.HOST_CONFIG_dtoverlay, "DToverlay successfully configured in the config.txt")
+				test.equal(
+					overlayConfigTxt,
+					targetState.local.config.HOST_CONFIG_dtoverlay,
+					'DToverlay successfully configured in the config.txt',
+				);
 				const paramConfigTxt = await this.context
 					.get()
 					.worker.executeCommandInHostOS(
 						`cd /tmp && ${dtparam}`,
-						this.context.get().link
+						this.context.get().link,
 					);
-				test.equal(paramConfigTxt, targetState.local.config.HOST_CONFIG_dtparam, "DTparam successfully configured in the config.txt")
+				test.equal(
+					paramConfigTxt,
+					targetState.local.config.HOST_CONFIG_dtparam,
+					'DTparam successfully configured in the config.txt',
+				);
 			},
 		},
 	],

--- a/tests/suites/os/tests/engine-healthcheck/index.js
+++ b/tests/suites/os/tests/engine-healthcheck/index.js
@@ -38,8 +38,8 @@ module.exports = {
 							`/usr/lib/balena/balena-healthcheck >/dev/null 2>&1 && echo "pass"`,
 							this.context.get().link,
 						),
-					"pass",
-					"balena-healthcheck should pass."
+					'pass',
+					'balena-healthcheck should pass.',
 				);
 			},
 		},
@@ -56,7 +56,7 @@ module.exports = {
 							)) === 'pass'
 					);
 				});
-			
+
 				await this.context
 					.get()
 					.worker.executeCommandInHostOS(
@@ -71,8 +71,8 @@ module.exports = {
 							`/usr/lib/balena/balena-healthcheck >/dev/null 2>&1 && echo "pass"`,
 							this.context.get().link,
 						),
-					"pass",
-					"balena-healthcheck should pass."
+					'pass',
+					'balena-healthcheck should pass.',
 				);
 			},
 		},

--- a/tests/suites/os/tests/fingerprint/index.js
+++ b/tests/suites/os/tests/fingerprint/index.js
@@ -12,41 +12,41 @@
  * limitations under the License.
  */
 
-"use strict";
+'use strict';
 
 module.exports = {
-  title: "OS corruption tests",
-  tests: [
-    {
-      title: "resinos.fingerprint file test",
-      run: async function (test) {
-        let error = null;
-        try {
-          await this.context
-            .get()
-            .worker.executeCommandInHostOS(
-              "md5sum --quiet -c /resinos.fingerprint",
-              this.context.get().link
-            );
-        } catch (e) {
-          try {
-            await this.context
-              .get()
-              .worker.executeCommandInHostOS(
-                "md5sum --quiet -c /balenaos.fingerprint",
-                this.context.get().link
-              );
-          } catch (e) {
-            error = e;
-          }
-        }
+	title: 'OS corruption tests',
+	tests: [
+		{
+			title: 'resinos.fingerprint file test',
+			run: async function(test) {
+				let error = null;
+				try {
+					await this.context
+						.get()
+						.worker.executeCommandInHostOS(
+							'md5sum --quiet -c /resinos.fingerprint',
+							this.context.get().link,
+						);
+				} catch (e) {
+					try {
+						await this.context
+							.get()
+							.worker.executeCommandInHostOS(
+								'md5sum --quiet -c /balenaos.fingerprint',
+								this.context.get().link,
+							);
+					} catch (e) {
+						error = e;
+					}
+				}
 
-        test.is(
-          error,
-          null,
-          "resinos.fingerprint/balenaos.fingerprint file passed md5sum, no OS corruption detected."
-        );
-      },
-    },
-  ],
+				test.is(
+					error,
+					null,
+					'resinos.fingerprint/balenaos.fingerprint file passed md5sum, no OS corruption detected.',
+				);
+			},
+		},
+	],
 };

--- a/tests/suites/os/tests/kernel-overlap/index.js
+++ b/tests/suites/os/tests/kernel-overlap/index.js
@@ -1,21 +1,21 @@
-const fs = require("fs");
+const fs = require('fs');
 
 module.exports = {
-  title: "kernel-overlap test",
-  run: async function (test) {
-    const fileContents = fs.readFileSync(`${__dirname}/script.sh`).toString();
+	title: 'kernel-overlap test',
+	run: async function(test) {
+		const fileContents = fs.readFileSync(`${__dirname}/script.sh`).toString();
 
-    const script = await this.context
-      .get()
-      .worker.executeCommandInHostOS(
-        `cd /tmp && ${fileContents}`,
-        this.context.get().link
-      );
+		const script = await this.context
+			.get()
+			.worker.executeCommandInHostOS(
+				`cd /tmp && ${fileContents}`,
+				this.context.get().link,
+			);
 
-    test.is(
-      script.includes("ok"),
-      true,
-      "kernel-overlap script should return ok"
-    );
-  },
+		test.is(
+			script.includes('ok'),
+			true,
+			'kernel-overlap script should return ok',
+		);
+	},
 };

--- a/tests/suites/os/tests/led/index.js
+++ b/tests/suites/os/tests/led/index.js
@@ -12,100 +12,100 @@
  * limitations under the License.
  */
 
-"use strict";
+'use strict';
 
-const { delay } = require("bluebird");
-const request = require("request-promise");
+const { delay } = require('bluebird');
+const request = require('request-promise');
 
 const SUPERVISOR_PORT = 48484;
 const BLINK_DURATION = 20000;
 
 module.exports = {
-  title: "Identification test",
-  os: {
-    type: "object",
-    required: ["variant"],
-    properties: {
-      variant: {
-        type: "string",
-        const: "Development",
-      },
-    },
-  },
-  run: async function (test) {
-    const serviceName = "collector";
-    const ip = await this.context.get().worker.ip(this.context.get().link);
+	title: 'Identification test',
+	os: {
+		type: 'object',
+		required: ['variant'],
+		properties: {
+			variant: {
+				type: 'string',
+				const: 'Development',
+			},
+		},
+	},
+	run: async function(test) {
+		const serviceName = 'collector';
+		const ip = await this.context.get().worker.ip(this.context.get().link);
 
-    // Wait for the supervisor API to be up
-    await this.context.get().utils.waitUntil(async () => {
-      return (
-        (await request({
-          method: "GET",
-          uri: `http://${ip}:${SUPERVISOR_PORT}/ping`,
-        })) === "OK"
-      );
-    }, false);
+		// Wait for the supervisor API to be up
+		await this.context.get().utils.waitUntil(async () => {
+			return (
+				(await request({
+					method: 'GET',
+					uri: `http://${ip}:${SUPERVISOR_PORT}/ping`,
+				})) === 'OK'
+			);
+		}, false);
 
-    await this.context
-      .get()
-      .worker.executeCommandInHostOS(
-        `source /etc/balena-supervisor/supervisor.conf ; systemd-run --unit=${serviceName} bash -c "while true ; do cat $LED_FILE ; done"`,
-        this.context.get().link
-      );
+		await this.context
+			.get()
+			.worker.executeCommandInHostOS(
+				`source /etc/balena-supervisor/supervisor.conf ; systemd-run --unit=${serviceName} bash -c "while true ; do cat $LED_FILE ; done"`,
+				this.context.get().link,
+			);
 
-    const body = await request({
-      method: "POST",
-      uri: `http://${ip}:${SUPERVISOR_PORT}/v1/blink`,
-    });
+		const body = await request({
+			method: 'POST',
+			uri: `http://${ip}:${SUPERVISOR_PORT}/v1/blink`,
+		});
 
-    test.is(body, "OK", "Response should be expected");
+		test.is(body, 'OK', 'Response should be expected');
 
-    // Wait for the blink action to complete
-    await delay(BLINK_DURATION);
+		// Wait for the blink action to complete
+		await delay(BLINK_DURATION);
 
-    await this.context
-      .get()
-      .worker.executeCommandInHostOS(
-        `systemctl stop ${serviceName}`,
-        this.context.get().link
-      );
+		await this.context
+			.get()
+			.worker.executeCommandInHostOS(
+				`systemctl stop ${serviceName}`,
+				this.context.get().link,
+			);
 
-    const lines = (
-      await this.context
-        .get()
-        .worker.executeCommandInHostOS(
-          `journalctl -o cat --unit=${serviceName}`,
-          this.context.get().link
-        )
-    ).split("\n");
+		const lines = (
+			await this.context
+				.get()
+				.worker.executeCommandInHostOS(
+					`journalctl -o cat --unit=${serviceName}`,
+					this.context.get().link,
+				)
+		).split('\n');
 
-    const extractedLines = lines.slice(
-      lines.findIndex((line) => {
-        return /^Started.*/.test(line);
-      }) + 1,
-      lines.findIndex((line) => {
-        return /^Stopping.*/.test(line);
-      })
-    );
+		const extractedLines = lines.slice(
+			lines.findIndex(line => {
+				return /^Started.*/.test(line);
+			}) + 1,
+			lines.findIndex(line => {
+				return /^Stopping.*/.test(line);
+			}),
+		);
 
-    // we want to collapse only duplciated values from our read
-    const result = extractedLines.reduce((acc, line) => {
-      return acc.slice(-1)[0] !== parseInt(line)
-        ? acc.concat([parseInt(line)])
-        : acc;
-    }, []);
+		// we want to collapse only duplciated values from our read
+		const result = extractedLines.reduce((acc, line) => {
+			return acc.slice(-1)[0] !== parseInt(line)
+				? acc.concat([parseInt(line)])
+				: acc;
+		}, []);
 
-    /*test.true(
+		/*test.true(
 			result.length > 0 && result.length % 2 === 0,
 			'Blink pattern should have been detected',
 		);*/
 
-    let count = 0;
-    for (let i = 0; i < result.length; i += 2) {
-      if (Math.abs(result[i] - result[i + 1]) === 255) {
-        ++count;
-      }
-    }
-    test.is(count > 10, true, `Led should have blinked multiple times`);
-  },
+		let count = 0;
+		for (let i = 0; i < result.length; i += 2) {
+			if (Math.abs(result[i] - result[i + 1]) === 255) {
+				++count;
+			}
+		}
+		test.is(count > 10, true, `Led should have blinked multiple times`);
+	},
 };

--- a/tests/suites/os/tests/os-release/index.js
+++ b/tests/suites/os/tests/os-release/index.js
@@ -12,57 +12,57 @@
  * limitations under the License.
  */
 
-"use strict";
+'use strict';
 
 module.exports = {
-  title: "OS-release tests",
-  tests: [
-    {
-      title: "OS-release file check",
-      run: async function (test) {
-        const file = await this.context
-          .get()
-          .worker.executeCommandInHostOS(
-            "cat /etc/os-release",
-            this.context.get().link
-          );
+	title: 'OS-release tests',
+	tests: [
+		{
+			title: 'OS-release file check',
+			run: async function(test) {
+				const file = await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						'cat /etc/os-release',
+						this.context.get().link,
+					);
 
-        const result = {};
-        file.split("\n").forEach((element) => {
-          const parse = /(.*)=(.*)/.exec(element);
-          result[parse[1]] = parse[2];
-        });
+				const result = {};
+				file.split('\n').forEach(element => {
+					const parse = /(.*)=(.*)/.exec(element);
+					result[parse[1]] = parse[2];
+				});
 
-        [
-          "ID",
-          "NAME",
-          "VERSION",
-          "VERSION_ID",
-          "PRETTY_NAME",
-          "MACHINE",
-          "VARIANT",
-          "VARIANT_ID",
-          "META_BALENA_VERSION",
-          //"RESIN_BOARD_REV",
-          //"META_RESIN_REV",
-          "SLUG",
-        ].forEach((field) => {
-          test.includes(
-            result,
-            {
-              [field]: /.*/,
-            },
-            `OS-release file should contain field ${field}`
-          );
-        });
+				[
+					'ID',
+					'NAME',
+					'VERSION',
+					'VERSION_ID',
+					'PRETTY_NAME',
+					'MACHINE',
+					'VARIANT',
+					'VARIANT_ID',
+					'META_BALENA_VERSION',
+					//"RESIN_BOARD_REV",
+					//"META_RESIN_REV",
+					'SLUG',
+				].forEach(field => {
+					test.includes(
+						result,
+						{
+							[field]: /.*/,
+						},
+						`OS-release file should contain field ${field}`,
+					);
+				});
 
-        // check slug
-        test.is(
-          result["SLUG"],
-          `"${this.context.get().os.deviceType}"`,
-          `SLUG field should contain ${this.context.get().os.deviceType}`
-        );
-      },
-    },
-  ],
+				// check slug
+				test.is(
+					result['SLUG'],
+					`"${this.context.get().os.deviceType}"`,
+					`SLUG field should contain ${this.context.get().os.deviceType}`,
+				);
+			},
+		},
+	],
 };

--- a/tests/suites/os/tests/udev/index.js
+++ b/tests/suites/os/tests/udev/index.js
@@ -12,39 +12,39 @@
  * limitations under the License.
  */
 
-"use strict";
+'use strict';
 
 module.exports = {
-  title: "udev tests",
-  tests: [
-    {
-      title: "Ramdisks, zram and loop devices are not scanned for rootfs",
-      run: async function (test) {
-        // This is an artificial condition - it is difficult to say at any moment whether
-        // all the devices have been brought up as some of them may take longer than others.
-        // This waits for the engine to start which should mean the system is up and running.
-        await this.context.get().utils.waitUntil(async () => {
-          return (
-            (await this.context
-              .get()
-              .worker.executeCommandInHostOS(
-                `systemctl is-active --quiet balena.service && echo "pass"`,
-                this.context.get().link
-              )) === "pass"
-          );
-        });
+	title: 'udev tests',
+	tests: [
+		{
+			title: 'Ramdisks, zram and loop devices are not scanned for rootfs',
+			run: async function(test) {
+				// This is an artificial condition - it is difficult to say at any moment whether
+				// all the devices have been brought up as some of them may take longer than others.
+				// This waits for the engine to start which should mean the system is up and running.
+				await this.context.get().utils.waitUntil(async () => {
+					return (
+						(await this.context
+							.get()
+							.worker.executeCommandInHostOS(
+								`systemctl is-active --quiet balena.service && echo "pass"`,
+								this.context.get().link,
+							)) === 'pass'
+					);
+				});
 
-        test.is(
-          await this.context
-            .get()
-            .worker.executeCommandInHostOS(
-              `journalctl -u systemd-udevd.service | grep "Failed to substitute variable" >/dev/null 2>&1 || echo "pass"`,
-              this.context.get().link
-            ),
-          "pass",
-          "Udev logs have no warnings from scanning ramdisks, zram or loop devices for rootfs."
-        );
-      },
-    },
-  ],
+				test.is(
+					await this.context
+						.get()
+						.worker.executeCommandInHostOS(
+							`journalctl -u systemd-udevd.service | grep "Failed to substitute variable" >/dev/null 2>&1 || echo "pass"`,
+							this.context.get().link,
+						),
+					'pass',
+					'Udev logs have no warnings from scanning ramdisks, zram or loop devices for rootfs.',
+				);
+			},
+		},
+	],
 };

--- a/tests/suites/os/tests/variables/index.js
+++ b/tests/suites/os/tests/variables/index.js
@@ -13,68 +13,65 @@
  * limitations under the License.
  */
 
-"use strict";
-
-const retry = require("bluebird-retry");
-const request = require("request-promise");
+'use strict';
 
 module.exports = {
-  title: "Container exposed variables test",
-  os: {
-    type: "object",
-    required: ["variant"],
-    properties: {
-      variant: {
-        type: "string",
-        const: "Development",
-      },
-    },
-  },
-  run: async function (test) {
-    const ip = await this.context.get().worker.ip(this.context.get().link);
+	title: 'Container exposed variables test',
+	os: {
+		type: 'object',
+		required: ['variant'],
+		properties: {
+			variant: {
+				type: 'string',
+				const: 'Development',
+			},
+		},
+	},
+	run: async function(test) {
+		const ip = await this.context.get().worker.ip(this.context.get().link);
 
-    const state = await this.context
-      .get()
-      .worker.pushContainerToDUT(ip, __dirname, "variables");
-    const env = await this.context
-      .get()
-      .worker.executeCommandInContainer("env", "variables", ip);
+		await this.context
+			.get()
+			.worker.pushContainerToDUT(ip, __dirname, 'variables');
+		const env = await this.context
+			.get()
+			.worker.executeCommandInContainer('env', 'variables', ip);
 
-    const result = {};
-    env.split("\n").forEach((element) => {
-      const parse = /(.*)=(.*)/.exec(element);
-      result[parse[1]] = parse[2];
-    });
+		const result = {};
+		env.split('\n').forEach(element => {
+			const parse = /(.*)=(.*)/.exec(element);
+			result[parse[1]] = parse[2];
+		});
 
-    ["BALENA", "RESIN"].forEach((prefix) => {
-      [
-        "DEVICE_NAME_AT_INIT",
-        "APP_ID",
-        "APP_NAME",
-        "SERVICE_NAME",
-        "DEVICE_UUID",
-        "DEVICE_TYPE",
-        "HOST_OS_VERSION",
-        "APP_LOCK_PATH",
-        "",
-      ].forEach((variable) => {
-        const fullVariable = `${prefix}${variable ? "_" + variable : ""}`;
+		['BALENA', 'RESIN'].forEach(prefix => {
+			[
+				'DEVICE_NAME_AT_INIT',
+				'APP_ID',
+				'APP_NAME',
+				'SERVICE_NAME',
+				'DEVICE_UUID',
+				'DEVICE_TYPE',
+				'HOST_OS_VERSION',
+				'APP_LOCK_PATH',
+				'',
+			].forEach(variable => {
+				const fullVariable = `${prefix}${variable ? '_' + variable : ''}`;
 
-        test.includes(
-          result,
-          {
-            [fullVariable]: /.*/,
-          },
-          `Should find ${fullVariable} in env`
-        );
-      });
-    });
+				test.includes(
+					result,
+					{
+						[fullVariable]: /.*/,
+					},
+					`Should find ${fullVariable} in env`,
+				);
+			});
+		});
 
-    // This variable does not have a RESIN_ equivalent, so we will single it out
-    test.includes(
-      result,
-      { BALENA_SERVICE_HANDOVER_COMPLETE_PATH: /.*/ },
-      "Should find expected variable in env"
-    );
-  },
+		// This variable does not have a RESIN_ equivalent, so we will single it out
+		test.includes(
+			result,
+			{ BALENA_SERVICE_HANDOVER_COMPLETE_PATH: /.*/ },
+			'Should find expected variable in env',
+		);
+	},
 };

--- a/tests/suites/package.json
+++ b/tests/suites/package.json
@@ -1,7 +1,7 @@
 {
 	"scripts": {
 		"prettify": "prettier --config ./.prettierrc --write \"{os,hup}/**/*.js\"",
-		"lint": "eslint -c ./.eslintrc.* os hup"
+		"lint": "eslint --fix -c ./.eslintrc.* os hup"
 	},
 	"devDependencies": {
 		"eslint": "^4.19.1",


### PR DESCRIPTION
- As the image being unzipped into a temporary directory which is automatically cleaned up in the test. There is no need to delete the image inside the suite teardown https://github.com/balena-os/leviathan/pull/433/
- The fetch() function has had its arguments removed as they were redundant, so we can remove those arguments in suite.js including the downloadType property from config.js  https://github.com/balena-os/leviathan/pull/433/
- With the introduction of new helpers, we can replace old code with helpful new helpers https://github.com/balena-os/leviathan/pull/439

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
