### PR TITLE
linux-firmware: Package iwlwifi-QuZ-a0-hr-b0 firmware

### DIFF
--- a/meta-balena-common/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/meta-balena-common/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -160,3 +160,8 @@ PACKAGES =+ "${PN}-i915-dg1"
 FILES:${PN}-i915-dg1 = " \
     ${nonarch_base_libdir}/firmware/i915/dg1* \
     "
+PACKAGES =+ "${PN}-iwlwifi-quz-a0-hr-b0"
+
+FILES:${PN}-iwlwifi-quz-a0-hr-b0 = " \
+    ${nonarch_base_libdir}/firmware/iwlwifi-QuZ-a0-hr-b0-48.ucode \
+"


### PR DESCRIPTION
We add this fw on its own package so that boards can add it to
rootfs (for Intel NUC 11th generation more specifically)

Changelog-entry: Package iwlwifi-QuZ-a0-hr-b0 firmware separately
Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
