### PR TITLE
Restart services when config.json changes

### DIFF
--- a/meta-balena-common/recipes-connectivity/balena-net-config/balena-net-config/balena-net-config.service
+++ b/meta-balena-common/recipes-connectivity/balena-net-config/balena-net-config/balena-net-config.service
@@ -2,6 +2,7 @@
 Description=Resin network configure service
 Requires=resin-boot.service bind-etc-NetworkManager-system-connections.service
 After=resin-boot.service bind-etc-NetworkManager-system-connections.service
+PartOf=config-json.target
 
 [Service]
 ExecStart=@BASE_BINDIR@/bash @BINDIR@/balena-net-config

--- a/meta-balena-common/recipes-connectivity/balena-ntp-config/balena-ntp-config/balena-ntp-config.service
+++ b/meta-balena-common/recipes-connectivity/balena-ntp-config/balena-ntp-config/balena-ntp-config.service
@@ -2,6 +2,7 @@
 Description=Resin NTP server configure service
 Requires=balena-net-config.service
 After=balena-net-config.service
+PartOf=config-json.target
 
 [Service]
 ExecStart=@BINDIR@/balena-ntp-config

--- a/meta-balena-common/recipes-connectivity/dnsmasq/balena-files/dnsmasq.conf.systemd
+++ b/meta-balena-common/recipes-connectivity/dnsmasq/balena-files/dnsmasq.conf.systemd
@@ -1,6 +1,7 @@
 [Unit]
 Wants=balena-net-config.service
 After=balena-net-config.service
+PartOf=config-json.target
 
 [Service]
 Type=simple

--- a/meta-balena-common/recipes-connectivity/openvpn/files/prepare-openvpn.service
+++ b/meta-balena-common/recipes-connectivity/openvpn/files/prepare-openvpn.service
@@ -3,6 +3,7 @@ Description=Prepare OpenVPN
 Requires=resin-boot.service balena-device-uuid.service os-config-devicekey.service var-volatile.mount
 After=resin-boot.service balena-device-uuid.service os-config-devicekey.service var-volatile.mount
 ConditionFileNotEmpty=/etc/openvpn/openvpn.conf
+PartOf=config-json.target
 
 [Service]
 Type=oneshot

--- a/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars.bb
+++ b/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars.bb
@@ -6,6 +6,7 @@ SRC_URI = " \
     file://balena-config-vars \
     file://config-json.path \
     file://config-json.service \
+    file://config-json.target \
     file://os-networkmanager \
     file://os-networkmanager.service \
     file://os-udevrules \
@@ -30,6 +31,7 @@ do_build[noexec] = "1"
 SYSTEMD_SERVICE_${PN} = " \
     config-json.path \
     config-json.service \
+    config-json.target \
     os-networkmanager.service \
     os-udevrules.service \
     os-sshkeys.service \
@@ -46,6 +48,7 @@ do_install() {
         install -d ${D}${systemd_unitdir}/system
         install -c -m 0644 ${WORKDIR}/config-json.path ${D}${systemd_unitdir}/system
         install -c -m 0644 ${WORKDIR}/config-json.service ${D}${systemd_unitdir}/system
+        install -c -m 0644 ${WORKDIR}/config-json.target ${D}${systemd_unitdir}/system
         install -c -m 0644 ${WORKDIR}/os-networkmanager.service ${D}${systemd_unitdir}/system
         install -c -m 0644 ${WORKDIR}/os-udevrules.service ${D}${systemd_unitdir}/system
         install -c -m 0644 ${WORKDIR}/os-sshkeys.service ${D}${systemd_unitdir}/system

--- a/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/balena-config-vars
+++ b/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/balena-config-vars
@@ -85,6 +85,12 @@ if [ -f $CONFIG_PATH ]; then
         eval "$CONFIG_PARAMS"
     fi
 
+    # "null" is a valid setting in config.json that should write
+    # an empty string for dns servers rather than the defaults
+    if [ "$DNS_SERVERS" = "null" ]; then
+        DNS_SERVERS=""
+    fi
+
     # Set additional default values.
     if [ -z "$OS_NET_CONN_URI" ]; then
         if [ -n "$API_ENDPOINT" ]; then

--- a/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/config-json.service
+++ b/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/config-json.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Config.json watcher service
-Wants=prepare-openvpn.service balena-ntp-config.service
 
 [Service]
 Type=oneshot
 ExecStart=/bin/echo 'config.json changed'
+ExecStart=/bin/systemctl restart config-json.target

--- a/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/config-json.target
+++ b/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/config-json.target
@@ -1,0 +1,2 @@
+[Unit]
+Description=Config.json watcher target


### PR DESCRIPTION
Create a target that different services can be `PartOf` that will get restarted on `config.json` change.

Add `dnsmasq` to this list of services to resolve https://github.com/balena-os/meta-balena/issues/2235.

This PR also avoids a dnsmasq error when `dnsServers="null"` in config.json
that was accidentally removed in https://github.com/balena-os/meta-balena/pull/2168.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>

---
### Manual test cases

1. Apply custom servers via `config.json` https://www.balena.io/docs/reference/OS/configuration/#dnsservers
2. Confirm `dnsmasq` has restarted and is active with new servers

```bash
jq '.dnsServers = "1.2.3.4"' /mnt/boot/config.json > /mnt/data/config.json && mv /mnt/data/config.json /mnt/boot/config.json
systemctl status dnsmasq.service config-json.*

jq '.dnsServers = "null"' /mnt/boot/config.json > /mnt/data/config.json && mv /mnt/data/config.json /mnt/boot/config.json
systemctl status dnsmasq.service config-json.*
```

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [x] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
