### PR TITLE
kernel-headers-test: Update base image to buster

### DIFF
--- a/meta-balena-common/recipes-kernel/linux/files/Dockerfile
+++ b/meta-balena-common/recipes-kernel/linux/files/Dockerfile
@@ -1,5 +1,4 @@
-# Use stretch as we have devices with old 3.10 kernel that won't build with gcc8 in buster
-FROM balenalib/intel-nuc-debian:stretch-20190717
+FROM balenalib/intel-nuc-debian:buster-20210705
 
 # Install dependencies
 RUN apt-get update && apt-get install -y curl wget build-essential libelf-dev bc flex libssl-dev bison gcc-arm-linux-gnueabi gcc-aarch64-linux-gnu python-minimal


### PR DESCRIPTION
Since we don't have devices using older 3.x kernels we update to a newer
base image so that we don't have problems compiling this test kernel
module on newer kernels. This avoids the following error on kernel
5.10.31 on arm64 raspberrypicm4-ioboard for example:

ERROR: modpost: "_mcount"
[/usr/src/app/example_module_headers_src/hello.ko] undefined!

Change-type: patch
Changelog-entry:
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
