### PR TITLE
tests: remove healthcheck test race condition

### DIFF
--- a/tests/suites/os/tests/healthcheck/index.js
+++ b/tests/suites/os/tests/healthcheck/index.js
@@ -35,11 +35,37 @@ module.exports = {
 		const state = await this.context
 			.get()
 			.worker.pushContainerToDUT(ip, __dirname, 'healthcheck');
+
+
+		// wait until status of container is "healthy"
+		await this.context.get().utils.waitUntil(async () => {
+			test.comment("Waiting to container to report as healthy...");
+			// retrieve healthcheck events
+			let health = JSON.parse(await this.context
+			  .get()
+			  .worker.executeCommandInHostOS(
+				`printf '["null"'; balena events --filter container=${state.services.healthcheck} --filter event=health_status --since 1 --until "$(date +%Y-%m-%dT%H:%M:%S.%NZ)" --format '{{json .}}' | while read LINE; do printf ",$LINE"; done; printf ']'`,
+				ip
+			  )
+			)
+			let status = health.reduce(function (result, element) {
+			  if (element.status != null) {
+				result.push(element.status);
+			  }
+			  return result;
+			}, [])
+	  
+			return status.includes("health_status: healthy")
+	  
+		  }, false);
+
+
+		// cause the container healthcheck to fail
 		await this.context
 			.get()
 			.worker.executeCommandInContainer('rm /tmp/health', 'healthcheck', ip);
 
-		// wait for 10s before checking for health status to give
+		// wait for 5s before checking for health status to give
 		await delay(1000 * 5);
 
 		let status = [];
@@ -66,12 +92,11 @@ module.exports = {
 			test.comment(`Container is currently: "${status[status.length - 1]}"`);
 
 			return status.includes('health_status: unhealthy'); // Exit this block when container goes to "unhealthy"
-		});
+		}, false);
 
 		// check that the container went from healthy to unhealthy
 		test.ok(
-			status.includes('health_status: unhealthy') &&
-				status.includes('health_status: healthy'),
+			status.includes('health_status: unhealthy'),
 			'Container should go from healthy to unhealthy',
 		);
 	},


### PR DESCRIPTION
Sometimes in the container healthcheck test there is a race condition - -the test causes a containers docker healthcheck to fail, and expects the container to go from healthy to unhealthy - however depending on when this happens, the test may never detect the healthy state first - causing the test to fail. 

This PR alters the test so that it waits to confirm a healthy state, before making the container unhealthy 

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
