### PR TITLE
linux-firmware: package i915 generations separately

### DIFF
--- a/meta-balena-common/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/meta-balena-common/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -65,3 +65,98 @@ PACKAGES =+ "${PN}-iwlwifi-cc-a0"
 FILES_${PN}-iwlwifi-cc-a0 = " \
     ${nonarch_base_libdir}/firmware/iwlwifi-cc-a0-48.ucode \
 "
+
+# Skylake/6th Gen Core processors
+# https://en.wikipedia.org/wiki/Skylake_(microarchitecture)#List_of_Skylake_processor_models
+PACKAGES =+ "${PN}-i915-skl"
+
+FILES_${PN}-i915-skl = " \
+    ${nonarch_base_libdir}/firmware/i915/skl* \
+    "
+
+# Kaby Lake/14nm Skylake successor, Gen 7 desktop/mobile
+# https://en.wikipedia.org/wiki/Kaby_Lake#List_of_7th_generation_Kaby_Lake_processors
+PACKAGES =+ "${PN}-i915-kbl"
+
+FILES_${PN}-i915-kbl = " \
+    ${nonarch_base_libdir}/firmware/i915/kbl* \
+    "
+
+# Gemini Lake/Goldmont Plus, low-power 14nm Pentium/Celeron desktop and mobile
+# https://en.wikipedia.org/wiki/Goldmont_Plus#List_of_Goldmont_Plus_processors
+PACKAGES =+ "${PN}-i915-glk"
+
+FILES_${PN}-i915-glk = " \
+    ${nonarch_base_libdir}/firmware/i915/glk* \
+    "
+
+# Cannon Lake/10nm shrink of Kaby Lake, only the i3-8121U
+# https://en.wikipedia.org/wiki/Cannon_Lake_(microprocessor)#List_of_Cannon_Lake_CPUs
+PACKAGES =+ "${PN}-i915-cnl"
+
+FILES_${PN}-i915-cnl = " \
+    ${nonarch_base_libdir}/firmware/i915/cnl* \
+    "
+
+# Ice Lake/10nm 10th gen mobile and certain Xeons
+# https://en.wikipedia.org/wiki/Ice_Lake_(microprocessor)#List_of_Ice_Lake_CPUs
+PACKAGES =+ "${PN}-i915-icl"
+
+FILES_${PN}-i915-icl = " \
+    ${nonarch_base_libdir}/firmware/i915/icl* \
+    "
+
+# Comet Lake/14nm 10th Gen Core processors
+# https://en.wikipedia.org/wiki/Comet_Lake_(microprocessor)#List_of_10th_generation_Comet_Lake_processors
+PACKAGES =+ "${PN}-i915-cml"
+
+FILES_${PN}-i915-cml = " \
+    ${nonarch_base_libdir}/firmware/i915/cml* \
+    "
+
+# Broxton/cancelled Cherry Trail successor
+# https://en.wikichip.org/wiki/intel/cores/broxton
+PACKAGES =+ "${PN}-i915-bxt"
+
+FILES_${PN}-i915-bxt = " \
+    ${nonarch_base_libdir}/firmware/i915/bxt* \
+    "
+
+# Rocket Lake/14nm backport of Ice Lake, 11th Gen Core desktop processors w/ Xe graphics
+# https://en.wikipedia.org/wiki/Rocket_Lake#List_of_11th_generation_Rocket_Lake_processors
+PACKAGES =+ "${PN}-i915-rkl"
+
+FILES_${PN}-i915-rkl = " \
+    ${nonarch_base_libdir}/firmware/i915/rkl* \
+    "
+
+# Tiger Lake/10nm 11th gen mobile w/ Xe graphics
+# https://en.wikipedia.org/wiki/Tiger_Lake#List_of_Tiger_Lake_CPUs
+PACKAGES =+ "${PN}-i915-tgl"
+
+FILES_${PN}-i915-tgl = " \
+    ${nonarch_base_libdir}/firmware/i915/tgl* \
+    "
+
+# Elkhart Lake/10nm Atom server CPUs
+# https://ark.intel.com/content/www/us/en/ark/products/codename/128825/products-formerly-elkhart-lake.html
+PACKAGES =+ "${PN}-i915-ehl"
+
+FILES_${PN}-i915-ehl = " \
+    ${nonarch_base_libdir}/firmware/i915/ehl* \
+    "
+
+# Alder Lake/10nm successor to Tiger Lake, unreleased as of this commit
+# https://en.wikichip.org/wiki/intel/microarchitectures/alder_lake
+PACKAGES =+ "${PN}-i915-adl"
+
+FILES_${PN}-i915-adl = " \
+    ${nonarch_base_libdir}/firmware/i915/adl* \
+    "
+
+# First gen discrete graphics, unreleased as of this commit
+PACKAGES =+ "${PN}-i915-dg1"
+
+FILES_${PN}-i915-dg1 = " \
+    ${nonarch_base_libdir}/firmware/i915/dg1* \
+    "


### PR DESCRIPTION
Package Intel graphics firmware generations separately, allowing GPU
firmware to be installed for specific SoCs.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
