### PR TITLE
tests: Symlink /dev/null instead of copying bash to break services

### DIFF
--- a/tests/suites/hup/tests/rollback-health.js
+++ b/tests/suites/hup/tests/rollback-health.js
@@ -46,7 +46,7 @@ module.exports = {
 				await this.context
 					.get()
 					.worker.executeCommandInHostOS(
-						`cp /bin/bash $(find /mnt/sysroot/inactive/ | grep "usr/bin/balena-engine$")`,
+						`ln -sf /dev/null $(find /mnt/sysroot/inactive/ | grep "usr/bin/balena-engine$")`,
 						this.context.get().link,
 					);
 
@@ -151,7 +151,7 @@ module.exports = {
 				await this.context
 					.get()
 					.worker.executeCommandInHostOS(
-						`cp /bin/bash $(find /mnt/sysroot/inactive/ | grep "bin/openvpn$")`,
+						`ln -sf /dev/null $(find /mnt/sysroot/inactive/ | grep "bin/openvpn$")`,
 						this.context.get().link,
 					);
 


### PR DESCRIPTION
Triggered by a failue in the VPN test - the bash binary is bigger than the openvpn binary and on devices with limitted rootfs space the copying is not possible. Symlinking /dev/null will break the services as well.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
