### PR TITLE
linux-firmware: Package iwlwifi-QuZ-a0-hr-b0 firmware separately

### DIFF
--- a/meta-balena-common/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/meta-balena-common/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -16,6 +16,12 @@ FILES_${PN}-iwlwifi-qu-b0-hr-b0 = " \
     ${nonarch_base_libdir}/firmware/iwlwifi-Qu-b0-hr-b0-* \
     "
 
+PACKAGES =+ "${PN}-iwlwifi-quz-a0-hr-b0"
+
+FILES_${PN}-iwlwifi-quz-a0-hr-b0 = " \
+    ${nonarch_base_libdir}/firmware/iwlwifi-QuZ-a0-hr-b0-* \
+    "
+
 PACKAGES =+ "${PN}-ibt-19-0-4"
 
 FILES_${PN}-ibt-19-0-4  = " \


### PR DESCRIPTION
This is used for the AX201NGW WiFi 6 card, shipped in 10th gen NUCs and recent laptops. Device types should pull the package if necessary.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
