### PR TITLE
grub: don't package or install bindir utils

### DIFF
--- a/meta-balena-common/recipes-bsp/grub/grub_%.bbappend
+++ b/meta-balena-common/recipes-bsp/grub/grub_%.bbappend
@@ -6,8 +6,9 @@ DEPENDS_append_class-target = " grub-conf"
 # this removes them for aarch64
 FILES_${PN}-common_remove = "${libdir}/${BPN}"
 
-# remove sbin utilities, such as grub-install
+# remove utilities, such as grub-install, grub-mkrescue, etc.
 FILES_${PN}-common_remove = "${sbindir}"
+FILES_${PN}-common_remove = "${bindir}"
 
 # Modules are built into the grub image for speed and simplicity, but DTs still
 # expect the modules directory to exist in ${DEPLOYDIR}, so create it.


### PR DESCRIPTION
Remove ${bindir} from FILES_grub-common, ensuring grub utilities aren't
installed to /usr/bin, in addition to a previous similar commit that
removed sbin utils. This frees approximately 5.5M.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [x] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
