### PR TITLE
dosfstools: selectively apply upstreamed patch

### DIFF
--- a/meta-balena-common/recipes-devtools/dosfstools/dosfstools_%.bbappend
+++ b/meta-balena-common/recipes-devtools/dosfstools/dosfstools_%.bbappend
@@ -1,5 +1,4 @@
 FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
-SRC_URI_append = " file://0001-src-check.c-Fix-up-mtools-created-bad-dir-entries.patch"
 
 PACKAGES =+ "${PN}-fsck"
 FILES_${PN}-fsck = "${sbindir}/*fsck* ${base_sbindir}/*fsck*"

--- a/meta-balena-common/recipes-devtools/dosfstools/dosfstools_4.1.bbappend
+++ b/meta-balena-common/recipes-devtools/dosfstools/dosfstools_4.1.bbappend
@@ -1,0 +1,1 @@
+SRC_URI_append = " file://0001-src-check.c-Fix-up-mtools-created-bad-dir-entries.patch"


### PR DESCRIPTION
This patch was submitted and accepted upstream, and is present since
v4.2.

https://github.com/dosfstools/dosfstools/commit/87a8f29785bb605350821f1638a42e6cf3e49ce3

This fixes a build error applying a patch that's already been applied
when building newer versions of dosfstools.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
