### PR TITLE
resin-u-boot.bbclass: Make console silencing change more resilient

### DIFF
--- a/meta-balena-common/classes/resin-u-boot.bbclass
+++ b/meta-balena-common/classes/resin-u-boot.bbclass
@@ -22,10 +22,14 @@ do_configure_append() {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'development-image', 'false', 'true', d)}; then
         if grep -qP "void puts\(const char \*s\)" ${S}/common/console.c ; then
             line=$(grep -nP "void puts\(const char \*s\)" ${S}/common/console.c | cut -f1 -d:)
-            sed -i "$(expr ${line} \+ 2) i return;" ${S}/common/console.c
+            increment=0
+            for iter in ${line}; do
+                sed -i "$(expr ${iter} \+ 2 \+ ${increment}) i return;" ${S}/common/console.c
+                increment=`expr $increment + 1`
+            done
         else
             bbfatal "Failed to patch u-boot for silencing console in production!"
-	fi;
+        fi;
     fi;
 }
 


### PR DESCRIPTION
There is at least a case in a board where the puts function in u-boot's
common/console.c is #ifdef'ed and defined twice. Let's accomodate for
such cases by correctly looping through more than one function
definition if present.

Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
