### PR TITLE
recipes-connectivity: improve NTP dispatcher script

### DIFF
--- a/meta-balena-common/recipes-connectivity/networkmanager/balena-files/99onoffline_ntp
+++ b/meta-balena-common/recipes-connectivity/networkmanager/balena-files/99onoffline_ntp
@@ -8,8 +8,8 @@ INTERFACE=$1
 ACTION=$2
 
 case "$ACTION" in
-	up|down)
-	echo "Setting NTP source on/offline status ($INTERFACE $ACTION)."
+	connectivity-change)
+	echo "Setting NTP source on/offline status ($ACTION $CONNECTIVITY_STATE)."
 	/usr/bin/chronyc onoffline > /dev/null 2>&1 || true
 	;;
 	*)


### PR DESCRIPTION
Change the NetworkManager NTP dispatcher script to update the on/offline status of the NTP sources on `connectivity-change` events instead of up/down events.

Currently `chronyc onoffline` is run for 'up/down' events on any network interface. It makes more sense to run it for
`connectivity-change` events as we are really interested in whether the internet is there or not rather than whether an interface is up or down.

Change-type: patch
Changelog-entry: recipes-connectivity: improve NTP dispatcher script
Signed-off-by: Mark Corbin <mark@balena.io>

--

Tested on a RPi3 under balenaOS v2.82.10+rev2 by manually connecting and disconnecting both WiFi and Ethernet connections.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [x] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
