### PR TITLE
kernel-modules-headers: Copy module.lds

### DIFF
--- a/meta-balena-common/recipes-devtools/kernel-modules-headers/files/gen_mod_headers
+++ b/meta-balena-common/recipes-devtools/kernel-modules-headers/files/gen_mod_headers
@@ -248,6 +248,11 @@ if [[ -n "$prefix" ]]; then
 	make HOSTCC="$hostcc" HOSTLD="$LD" $build_opts prepare0
 	mv include/generated/utsrelease.h.bkp include/generated/utsrelease.h
 
+	# From v5.10 - see https://github.com/torvalds/linux/commit/596b0474d3d9
+	if [[ -f "xscripts/module.lds" ]]; then
+		cp xscripts/module.lds scripts/module.lds
+	fi
+
 	if [[ -e xtools/objtool/fixdep ]]; then
 	    if [[ -e tools/build/Makefile ]]; then
 		# let's use the native fixdep for the target objtool compilation


### PR DESCRIPTION
Since kernel v5.10 this file is generated when using modules-prepare. As
the kernel-modules-headers container pre-built target binaries, we also
need to include this file in the package.

This is not a problem when using kernel-source as a modules-prepare is
always required.

Fixes: #2289
Relates-to: #1822
Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [x] Manual test case recorded (see https://github.com/balena-os/meta-balena/issues/2289#issuecomment-901843022)
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
