### PR TITLE
Assign a fixed name to the balena-healthcheck container

### DIFF
--- a/meta-balena-common/recipes-containers/balena/balena/balena-healthcheck
+++ b/meta-balena-common/recipes-containers/balena/balena/balena-healthcheck
@@ -17,4 +17,5 @@ if ! balena image inspect balena-healthcheck-image > /dev/null 2>&1; then
 fi
 
 # Check that we can start a new container
-balena run --rm --log-driver none --network none balena-healthcheck-image > /dev/null
+balena rm --force balena_healthcheck 2>/dev/null || true
+balena run --rm --log-driver none --network none --name balena_healthcheck balena-healthcheck-image > /dev/null


### PR DESCRIPTION
This avoids confusion when new containers with random names
appear in the runtime history of the engine.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/balena-os/meta-balena/issues/2256

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
