### PR TITLE
tests: s/BALENA_MACHINE_NAME/BALENA_ARCH

### DIFF
--- a/tests/suites/os/tests/healthcheck/Dockerfile.template
+++ b/tests/suites/os/tests/healthcheck/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine
+FROM balenalib/%%BALENA_ARCH%%-alpine
 
 HEALTHCHECK --interval=1s --retries=1 \
     CMD [ -f /tmp/health ] 

--- a/tests/suites/os/tests/variables/Dockerfile.template
+++ b/tests/suites/os/tests/variables/Dockerfile.template
@@ -1,3 +1,3 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine
+FROM balenalib/%%BALENA_ARCH%%-alpine
 
 CMD ["bash"]


### PR DESCRIPTION
Replace Dockerfile image %%BALENA_MACHINE_NAME%% var with
%%BALENA_ARCH%% for better compatibility

Device types lacking matching tags in the balenalib Docker Hub account
will fail tests when a matching image is not found. Switch to
BALENA_ARCH instead, to maintain compatibility.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
