### PR TITLE
classes/resin-u-boot: Increase OS_BOOTCOUNT_LIMIT to 3

### DIFF
--- a/meta-balena-common/classes/resin-u-boot.bbclass
+++ b/meta-balena-common/classes/resin-u-boot.bbclass
@@ -46,7 +46,7 @@ BALENA_UBOOT_DEVICE_TYPES ?= "mmc"
 BASE_OS_CMDLINE ?= "${OS_KERNEL_CMDLINE}"
 OS_BOOTCOUNT_FILE ?= "bootcount.env"
 OS_BOOTCOUNT_SKIP ?= "0"
-OS_BOOTCOUNT_LIMIT ?= "1"
+OS_BOOTCOUNT_LIMIT ?= "3"
 
 # These options go into the device headerfile via config_resin.h
 CONFIG_RESET_TO_RETRY ?= "1"


### PR DESCRIPTION
Let's increase the current value for the rollback-altboot
bootcount to 5, to account for accidental poweroffs triggered
by users or by power supplys when booting into the new OS,
during HUP.

When the limit is reached, u-boot will proceed to try
to boot into the old OS.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Connects-to: https://github.com/balena-os/meta-balena/issues/2301
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
