### PR TITLE
hostapp-update-hooks: Fix blacklisted extlinux.conf file path

### DIFF
--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-bootfiles
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-bootfiles
@@ -14,7 +14,7 @@ bootfiles_blacklist="\
 	/config.json \
 	/config.txt \
 	/splash/balena-logo.png \
-	/extlinux.conf \
+	/extlinux/extlinux.conf \
 	/extra_uEnv.txt \
 	/grub_extraenv \
 	/configfs.json \


### PR DESCRIPTION
The extlinux.conf file path in meta-balena is currently
incorrect, let's update it's boot partition path so that
BalenaHUP won't need to transfer the isolcpus setting to
the new OS anymore. This is necessary only when updating from older
OS versions in which the supervisor adds the isolcpus
setting to the boot partition extlinux.conf file.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
