### PR TITLE
resindataexpander: expand fs independent of partition

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/resindataexpander
+++ b/meta-balena-common/recipes-core/initrdscripts/files/resindataexpander
@@ -75,12 +75,12 @@ resindataexpander_run() {
 
                 # We return when we've done the expansion
 		info "Data partition at $datapart expanded."
-		# Expand filesystem
-		info "resindataexpander: Expand ext4 filesystem on ${datapart}"
-		resize2fs -f "${datapart}"
-		sync
                 return
         fi
     done
-    info "No data partition expanding needed."
+
+    # Expand filesystem
+    info "resindataexpander: Expand ext4 filesystem on ${datapart}"
+    resize2fs -f ${datapart}
+    sync
 }


### PR DESCRIPTION
When resizing the filesystem fails, such as when resize2fs won't touch
it because it's dirty, the partition gets resized, but not the
filesystem. The script will not attempt to resize the filesystem again,
as it detects the partition has already been resized.

Split these actions apart, so that the filesystem resize is always
attempted. If resize2fs detects that the filesystem is already filling
available space, it will exit with no action taken.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
