### PR TITLE
balena-engine: Update to 19.03.29

### DIFF
--- a/meta-balena-common/recipes-containers/balena/balena_git.bb
+++ b/meta-balena-common/recipes-containers/balena/balena_git.bb
@@ -11,10 +11,10 @@ LIC_FILES_CHKSUM = "file://src/import/LICENSE;md5=4859e97a9c7780e77972d989f0823f
 
 inherit systemd go pkgconfig useradd
 
-BALENA_VERSION = "19.03.26"
+BALENA_VERSION = "19.03.29"
 BALENA_BRANCH= "master"
 
-SRCREV = "daea8e24284bfb3b81da884e32ae286dc2f0741b"
+SRCREV = "6e4ae37185d26c54514e916ac413b3d7dc36482c"
 SRC_URI = "\
 	git://github.com/balena-os/balena-engine.git;branch=${BALENA_BRANCH};destsuffix=git/src/import \
 	file://balena.service \


### PR DESCRIPTION
Update balena-engine from 19.03.26 to 19.03.29

Change-type: patch
Changelog-entry: Update balena-engine to v19.03.29
Signed-off-by: Robert Günzler <robertg@balena.io>
