### PR TITLE
common: conf: don't disable user-ns by default

### DIFF
--- a/meta-balena-common/conf/distro/include/balena-os.inc
+++ b/meta-balena-common/conf/distro/include/balena-os.inc
@@ -36,9 +36,6 @@ DISTRO_FEATURES_DEFAULT_remove = "x11"
 OS_DEVELOPMENT ?= "0"
 DISTRO_FEATURES_append = " ${@bb.utils.contains('OS_DEVELOPMENT','1','osdev-image','',d)}"
 
-# Disable user namespacing with a sysctl by default, but allow DTs to leave it enabled
-DISTRO_FEATURES_append = " disable-user-ns"
-
 # Providers
 PREFERRED_PROVIDER_docker ?= "docker"
 PREFERRED_PROVIDER_jpeg ?= "jpeg"


### PR DESCRIPTION
Upon reviewing the kernel configs for existing devices, we found at
least 64 DTs that previously enabled user namespacing, and only eight
that do not enable user namespacing.

In order to safely enable this config in the kernel while avoiding
enabling it for devices which previously did not have it, remove the
runtime configuration that disables it by default in meta-balena. We'll
update the few device repos that didn't enable CONFIG_USER_NS to disable
the feature at runtime.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
