### PR TITLE
Run iwlwifi firmware cleanup in fakeroot

### DIFF
--- a/meta-balena-common/classes/balena-linux-firmware.bbclass
+++ b/meta-balena-common/classes/balena-linux-firmware.bbclass
@@ -12,7 +12,7 @@ DEPENDS += "xz-native"
 # IWLWIFI_REGEX is the regex defining how to parse the filename to extract
 #   the version and the api.
 
-python do_iwlwifi_firmware_clean() {
+fakeroot python do_iwlwifi_firmware_clean() {
     import os,re
 
     path = os.path.join(d.getVar("D",True), d.getVar("IWLWIFI_PATH",True))


### PR DESCRIPTION
This prevents downstream linux-firmware fakeroot tasks, such as
firmware compression, from encountering Pseudo Abort due to files
changing outside the fakeroot context.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
