### PR TITLE
balena-healthcheck: Remove redundant steps and rely on hello-world

### DIFF
--- a/meta-balena-common/recipes-containers/balena/balena/balena-healthcheck
+++ b/meta-balena-common/recipes-containers/balena/balena/balena-healthcheck
@@ -2,12 +2,6 @@
 
 set -o errexit
 
-# Check that info works
-balena info > /dev/null 2>&1
-
-# Check that we can read containers from disk
-balena ps > /dev/null
-
 if ! balena image inspect balena-healthcheck-image > /dev/null 2>&1; then
 	balena image load -i /usr/lib/balena/balena-healthcheck-image.tar
 


### PR DESCRIPTION
In situations with limited resources the info and ps commands can take
an unecessarily long time when we really only need to know that a
container can be started.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
