### PR TITLE
hostapp-update-hooks: Blacklist Rock Pi configuration file

### DIFF
--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-bootfiles
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-bootfiles
@@ -18,6 +18,7 @@ bootfiles_blacklist="\
 	/extra_uEnv.txt \
 	/grub_extraenv \
 	/configfs.json \
+	/hw_intfc.conf \
 	"
 boot_mountpoint="/mnt/boot"
 DURING_UPDATE=${DURING_UPDATE:-0}


### PR DESCRIPTION
The Rock Pi 4B uses a file named hw_intf.conf for
enabling/disabling interfaces and for loading overlays.
Just noting that the syntax is also slightly different
from the config.txt file on RaspberryPi.

Let's blacklist this file to avoid overriding
it during OS updates.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Connects-to: https://github.com/balena-os/balena-rockpi/issues/13
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
