### PR TITLE
balena-engine: Remove deprecated development drop-in service file

### DIFF
--- a/meta-balena-common/recipes-containers/balena/balena/balena.conf.systemd
+++ b/meta-balena-common/recipes-containers/balena/balena/balena.conf.systemd
@@ -1,2 +1,0 @@
-[Service]
-Environment=BALENAD_HOST="-H fd:// -H unix:///var/run/balena.sock -H unix:///var/run/balena-engine.sock -H tcp://0.0.0.0:2375"

--- a/meta-balena-common/recipes-containers/balena/balena_git.bb
+++ b/meta-balena-common/recipes-containers/balena/balena_git.bb
@@ -22,7 +22,6 @@ SRC_URI = "\
 	file://balena-host.socket \
 	file://balena-healthcheck \
 	file://var-lib-docker.mount \
-	file://balena.conf.systemd \
 	file://balena.conf.storagemigration \
 	file://balena-tmpfiles.conf \
 	file://0001-imporve-hardcoded-CC-on-cross-compile-docker-ce.patch \


### PR DESCRIPTION
This file is no longer used since the merge of dev and prod images.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/balena-os/meta-balena/pull/2227

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
