### PR TITLE
rollback-parse-bootloader: Revert to grub.cfg if grubenv not available

### DIFF
--- a/meta-balena-common/recipes-core/balena-rollback/files/rollback-parse-bootloader
+++ b/meta-balena-common/recipes-core/balena-rollback/files/rollback-parse-bootloader
@@ -30,6 +30,10 @@ if [ -f "${BALENA_BOOT_MOUNTPOINT}/resinOS_uEnv.txt" ]; then
 	BOOTLOADER_FILE="${BALENA_BOOT_MOUNTPOINT}/resinOS_uEnv.txt"
 else
 	grub_env=$(find "${BALENA_BOOT_MOUNTPOINT}" -name grubenv)
+	if [ -z "${grub_env}" ]; then
+		# rollbacks to versions < v2.77 need this
+		grub_env=$(find "${BALENA_BOOT_MOUNTPOINT}" -name grub.cfg)
+	fi
 	if [ -f "${grub_env}" ]; then
 		BOOTLOADER_FILE="${grub_env}"
 	fi


### PR DESCRIPTION
Since meta-balena 76c82dd987215982dbfcbdf950588dafdc4c129e the grub
environment variables have moved from grub.cfg to grubenv.

However, when a hostOS update fails and the system rolls back, these
grub environments are used to restore the contents of the boot partition
to the old OS which does not have a grubenv file.

This commit will fallback to looking for a grub.cfg file if grubenv is
not present in the filesystem

Fixes #2350

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
