### PR TITLE
tests: make led test work with beaglebone

### DIFF
--- a/tests/suites/os/tests/led/index.js
+++ b/tests/suites/os/tests/led/index.js
@@ -108,10 +108,11 @@ module.exports = {
 
 		let count = 0;
 		for (let i = 0; i < result.length; i += 2) {
-			if (Math.abs(result[i] - result[i + 1]) === 255) {
+			if (Math.abs(result[i] !== result[i + 1])) {
 				++count;
 			}
 		}
+		test.comment(`Count is: ${count}`)
 		test.is(count > 10, true, `Led should have blinked multiple times`);
 	},
 };


### PR DESCRIPTION
At the moment, the led blink test monitors the $LED_FILE of the device and looks to see if it changes between 0 and 255 when the supervisor `v1/blink` endpoint is posted to. This causes it to fail with the beaglebone black (as well as other devices I'm sure), who only support a value of 0 or 1 (not between 0 and 255 like the PI). 

This fix will make the test work with both situations

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
