### PR TITLE
tests: restrict dtoverlay test to rpi devices

### DIFF
--- a/tests/suites/os/tests/device-tree/index.js
+++ b/tests/suites/os/tests/device-tree/index.js
@@ -20,6 +20,21 @@ const fs = require('fs');
 
 module.exports = {
 	title: 'Device Tree tests',
+	deviceType: {
+		type: 'object',
+		required: ['slug'],
+		properties: {
+			slug: {
+				type: 'string',
+				enum: [
+					'raspberrypi3',
+					'raspberrypi4-64',
+					'raspberry-pi2',
+					'raspberry-pi',
+				],
+			},
+		},
+	},
 	tests: [
 		{
 			title: 'DToverlay & DTparam tests',


### PR DESCRIPTION
Currently the device tree test will run on any device - if it tries to run on the nuc, then the test will fail because there are no GPIO pins.

I added a schema to the top of the test that ensures the test will only run on the RPi family of devices. Marking as draft because I need to make sure the tests still run on rpi devices before anything is merged.

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
