### PR TITLE
linux-firmware: Include RTL8192EU firmware

### DIFF
--- a/meta-balena-common/recipes-core/packagegroups/packagegroup-balena-connectivity.bb
+++ b/meta-balena-common/recipes-core/packagegroups/packagegroup-balena-connectivity.bb
@@ -16,6 +16,7 @@ CONNECTIVITY_FIRMWARES ?= " \
     linux-firmware-ralink \
     linux-firmware-rtl8192cu \
     linux-firmware-rtl8192su \
+    linux-firmware-rtl8192eu \
     linux-firmware-rtl8723 \
     linux-firmware-rtl8723b-bt \
     "

--- a/meta-balena-common/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/meta-balena-common/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -4,6 +4,12 @@ FILES:${PN}-rtl8188eu = " \
     /lib/firmware/rtlwifi/rtl8188eu*.bin* \
     "
 
+PACKAGES =+ "${PN}-rtl8192eu"
+
+FILES_${PN}-rtl8192eu = " \
+    /lib/firmware/rtlwifi/rtl8192eu*.bin* \
+    "
+
 PACKAGES =+ "${PN}-iwlwifi-9260"
 
 FILES:${PN}-iwlwifi-9260 = " \


### PR DESCRIPTION
The RTL8192EU WiFi driver fails to find its firmware, so it is included now.

Change-type: patch
Signed-off-by: Zahari Petkov <zahari@balena.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
