### PR TITLE
connectivity: proxy: move nadoo/glider to container

### DIFF
--- a/tests/suites/os/tests/connectivity/Dockerfile.aarch64
+++ b/tests/suites/os/tests/connectivity/Dockerfile.aarch64
@@ -1,0 +1,1 @@
+FROM nadoo/glider@sha256:3febd815f02785c38f3c0637c2d0f04e7ff7690ff8fd55c22a3d27f136df4d86

--- a/tests/suites/os/tests/connectivity/Dockerfile.amd64
+++ b/tests/suites/os/tests/connectivity/Dockerfile.amd64
@@ -1,0 +1,1 @@
+FROM nadoo/glider@sha256:249fcf7905a3ab6638b5555e05e03bd305eb3365fe6ddbdcf42e24577b4d1bb8

--- a/tests/suites/os/tests/connectivity/Dockerfile.armv7hf
+++ b/tests/suites/os/tests/connectivity/Dockerfile.armv7hf
@@ -1,0 +1,1 @@
+FROM nadoo/glider@sha256:0ff0cfd93e73dc9ccd50fca848ef8823fd6f93c1369fe8ed008ea30cd76e1ef8

--- a/tests/suites/os/tests/connectivity/Dockerfile.template
+++ b/tests/suites/os/tests/connectivity/Dockerfile.template
@@ -1,0 +1,5 @@
+FROM balenalib/%%BALENA_ARCH%%-golang as build
+
+RUN go get -u github.com/nadoo/glider@v0.14.0
+
+ENTRYPOINT ["/go/bin/glider"]

--- a/tests/suites/os/tests/connectivity/docker-compose.yml
+++ b/tests/suites/os/tests/connectivity/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+  proxy:
+    build: .
+    network_mode: host
+    restart: on-failure
+    command: -verbose -listen :8123
+    user: 995 # run as redsocks user to avoid loop


### PR DESCRIPTION
Previously, the core service exposed a /proxy endpoint that would start
up a proxy remotely, which would be used by a test in the connectivity
module. However, the endpoint returned the address for the testbot to be
used as the proxy in the response, and this required manual
configuration of the interface. Additionally, it requires the worker
service to install and provide glider for forward proxying.

Move the proxy (glider) to a container on the device being tested,
which simplifies configuration, and reduces the complexity and size of
the interface of Leviathan.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>
See: https://github.com/balena-os/meta-balena/issues/2352

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
