### PR TITLE
connectivity: reduce ping interval to minimum

### DIFF
--- a/tests/suites/os/tests/connectivity/index.js
+++ b/tests/suites/os/tests/connectivity/index.js
@@ -56,7 +56,7 @@ module.exports = {
 						let ping = await this.context
 							.get()
 							.worker.executeCommandInHostOS(
-								`ping -c 10 -I ${iface} ${URL_TEST}`,
+								`ping -c 10 -i 0.002 -I ${iface} ${URL_TEST}`,
 								this.context.get().link,
 							);
 


### PR DESCRIPTION
The interface test uses a simple ping to ensure a specific interface
works. It sends ten packets, and expects ten packets back. However, the
default interval is one second, which increases the time taken for the
test while not adding anything of value.

Reduce the timeout to the minimum non-privileged interval of 2ms.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
