### PR TITLE
tests: os: Add exposed engine socket test

### DIFF
--- a/tests/suites/os/package.json
+++ b/tests/suites/os/package.json
@@ -8,6 +8,7 @@
 		"mz": "^2.7.0",
 		"request": "^2.88.0",
 		"request-promise": "^4.2.4",
+		"dockerode": "^2.5.8",
 		"tar-stream": "^2.1.0"
 	}
 }

--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -130,6 +130,7 @@ module.exports = {
 		'./tests/config-json',
 		'./tests/boot-splash',
 		'./tests/connectivity',
+		'./tests/engine-socket',
 		'./tests/udev',
 		'./tests/device-tree',
 		'./tests/purge-data',

--- a/tests/suites/os/tests/engine-socket/index.js
+++ b/tests/suites/os/tests/engine-socket/index.js
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+module.exports = {
+	title: 'Engine socket exposure test',
+	tests: [
+		{
+			title: 'Engine socket is exposed in development images',
+			run: async function(test) {
+				const Docker = require('dockerode');
+				let ip = await this.context.get().worker.ip(this.context.get().link)
+				const docker = new Docker({host: `http://${ip}`, port: 2375})
+				test.comment(`Setting system in development mode...`)
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						`tmp=$(mktemp)&&cat /mnt/boot/config.json | jq '.developmentMode="true"' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
+						this.context.get().link,
+				);
+				test.comment(`Waiting for engine to restart...`)
+				await this.context.get().utils.waitUntil(async () => {
+					return (
+						(await this.context
+							.get()
+							.worker.executeCommandInHostOS(
+								`systemctl is-active balena.service`,
+								this.context.get().link,
+						)) == 'active'
+					);
+				}, false);
+				test.comment(`Verify engine socket is exposed`)
+
+				await test.doesNotThrow(
+						docker.info(function (err, info) {
+							if (err) {
+								throw new Error(`Docker info failed: ${err}`);
+							}
+						}),
+					"Engine socket should be exposed in development images"
+				);
+			},
+		},
+		{
+			title: 'Engine socket is not exposed in production images',
+			run: async function(test) {
+				const Docker = require('dockerode');
+				let ip = await this.context.get().worker.ip(this.context.get().link)
+				const docker = new Docker({host: `http://${ip}`, port: 2375})
+				test.comment(`Setting system in production mode...`)
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						`tmp=$(mktemp)&&cat /mnt/boot/config.json | jq '.developmentMode="false"' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
+						this.context.get().link,
+				);
+				test.comment(`Waiting for engine to restart...`)
+				await this.context.get().utils.waitUntil(async () => {
+					return (
+						(await this.context
+							.get()
+							.worker.executeCommandInHostOS(
+								`systemctl is-active balena.service`,
+								this.context.get().link,
+						)) == 'active'
+					);
+				}, false);
+				test.comment(`Verify engine socket is not exposed`)
+
+				await test.throws(
+						docker.info(function (err, info) {
+							if (!err && info && info.lenght) {
+								throw new Error(`Docker info succeeded: ${info}`)
+							}
+						}), {},
+					"Engine socket should not be exposed in production images"
+				);
+				test.comment(`Leaving system in development mode...`)
+				await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						`tmp=$(mktemp)&&cat /mnt/boot/config.json | jq '.developmentMode="true"' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
+						this.context.get().link,
+				);
+			},
+		},
+	],
+};


### PR DESCRIPTION
This tests the engine socket being exposed in development mode but not
in production mode.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
