### PR TITLE
kernel-balena: Enable Real-Time group scheduling

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -208,6 +208,7 @@ BALENA_CONFIGS[balena] ?= " \
     CONFIG_MEMCG=y \
     CONFIG_MEMCG_SWAP=y \
     CONFIG_OVERLAY_FS=y \
+    CONFIG_RT_GROUP_SCHED=y \
     "
 
 FIRMWARE_COMPRESS = "${@configure_from_version("5.3", "firmware_compress", "", d)}"


### PR DESCRIPTION
In order to use the real-time group scheduling feature offered by the engine we need to have this feature enabled in the kernel.

https://www.kernel.org/doc/html/v5.3/scheduler/sched-rt-group.html

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>

FD discussion: https://www.flowdock.com/app/rulemotion/r-resinos/threads/cFmNSVPwzxVbBYJuVoZJZpwqI86
JF Improvement: https://jel.ly.fish/improvement-assign-higher-resource-priority-to-critical-os-tasks-8df3381f-0e02-4ac0-ac1a-ece04d125591

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
