### PR TITLE
tests: wait for the chronyd service become active

### DIFF
--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -62,6 +62,8 @@ module.exports = {
 									.utils.createSSHKey(this.context.get().sshKeyPath),
 							],
 						},
+						// Set an API endpoint for the HTTPS time sync service.
+						apiEndpoint: 'https://api.balena-cloud.com',
 						// persistentLogging is managed by the supervisor and only read at first boot
 						persistentLogging: true,
 						// Set local mode so we can perform local pushes of containers to the DUT

--- a/tests/suites/os/tests/chrony/index.js
+++ b/tests/suites/os/tests/chrony/index.js
@@ -4,7 +4,17 @@ module.exports = {
 		{
 			title: 'Chronyd service',
 			run: async function(test) {
+				test.comment(`checking for chronyd service...`);
 				let result = '';
+				await this.context.get().utils.waitUntil(async () => {
+					result = await this.context
+						.get()
+						.worker.executeCommandInHostOS(
+							`systemctl is-active chronyd.service`,
+							this.context.get().link,
+						);
+					return result === 'active';
+				}, false);
 				result = await this.context
 					.get()
 					.worker.executeCommandInHostOS(


### PR DESCRIPTION
Add a test to wait for the chronyd service to become active before starting the time sync tests.

The current chronyd tests assume that the chronyd service is instantly available at boot time. With the addition of the new
HTTPS time synchronisation service the starting of chronyd can be delayed by a few seconds so we need to ensure that the service is actually running before proceeding.

Change-type: patch
Changelog-entry: tests: wait for the chronyd service become active
Signed-off-by: Mark Corbin <mark@balena.io>

--

Tested locally on a testbot rig with a RPi4.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [x] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
