### PR TITLE
resindataexpander: also resize LUKS volume if necessary

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/resindataexpander
+++ b/meta-balena-common/recipes-core/initrdscripts/files/resindataexpander
@@ -2,8 +2,18 @@
 
 FREESPACE_LIMIT=10
 datapart=$(get_state_path_from_label "resin-data")
+dataparttype=$(lsblk "${datapart}" -nlo type)
 datapartdev=$(basename $(readlink -f "${datapart}"))
-datadev=$(lsblk "$(readlink -f "$datapart")" -n -o PKNAME)
+if [ "${dataparttype}" = "crypt" ]; then
+    if [ "$(ls /sys/class/block/${datapartdev}/slaves | wc -l)" != "1" ]; then
+        # This is just a disaster circuit breaker, it should never happen
+        fail "Unable to determine parent partition for ${datapartdev}"
+    fi
+
+    # We have asserted that there is a single slave device
+    datapartdev=$(ls "/sys/class/block/${datapartdev}/slaves")
+fi
+datadev=$(lsblk "/dev/${datapartdev}" -d -n -o PKNAME)
 
 get_part_table_type() {
     parted -s "$1" print | grep "Partition Table" | tr -d " " |cut -d ":" -f2
@@ -54,6 +64,15 @@ resindataexpander_run() {
 	        info "resindataexpander: Finished expanding data partition."
 	        partprobe
 	        sync
+
+		if [ "${dataparttype}" = "crypt" ]; then
+			datapartmap=$(lsblk ${datapart} -nlo name)
+			info "resindataexpander: Expand LUKS volume for data partition..."
+			cryptsetup resize "${datapartmap}"
+			info "resindataexpander: Expanded LUKS volume for data partition"
+			sync
+               fi
+
                 # We return when we've done the expansion
 		info "Data partition at $datapart expanded."
 		# Expand filesystem


### PR DESCRIPTION
The behaviour for non-LUKS system should be the same as before,
an extra step is performed when LUKS resize is necessary.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
