### PR TITLE
grub-efi: add support for signature verification in secure boot mode

### DIFF
--- a/meta-balena-common/recipes-bsp/grub/grub-conf.bb
+++ b/meta-balena-common/recipes-bsp/grub/grub-conf.bb
@@ -13,6 +13,8 @@ inherit deploy nopackages
 INHIBIT_DEFAULT_DEPS = "1"
 BOOTLOADER_TIMEOUT = "${@bb.utils.contains('OS_DEV_GRUB_DELAY', '1', '3', '0', d)}"
 
+DEPENDS = "ca-certificates-native coreutils-native curl-native jq-native"
+
 do_configure[noexec] = '1'
 do_compile() {
     sed -e 's/@@TIMEOUT@@/${BOOTLOADER_TIMEOUT}/' \
@@ -26,7 +28,37 @@ do_compile() {
         "${WORKDIR}/grub.cfg_external_template" > "${B}/grub.cfg_external"
 
 }
+
+do_sign() {
+    if [ "${SIGN}" != "true" ]; then
+        return 0
+    fi
+
+    # Sign grub configs
+    TO_SIGN=$(mktemp)
+
+    echo "${B}/grub.cfg_external" > "${TO_SIGN}"
+    echo "${B}/grub.cfg_internal" >> "${TO_SIGN}"
+
+    export CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt"
+
+    for FILE_TO_SIGN in $(cat "${TO_SIGN}")
+    do
+        REQUEST_FILE=$(mktemp)
+        RESPONSE_FILE=$(mktemp)
+        echo "{\"key_id\": \"${SIGN_GRUB_KEY_ID}\", \"payload\": \"$(base64 -w 0 ${FILE_TO_SIGN})\"}" > "${REQUEST_FILE}"
+        curl --fail "${SIGN_API}/gpg/sign" -X POST -H "Content-Type: application/json" -H "X-API-Key: ${SIGN_API_KEY}" -d "@${REQUEST_FILE}" > "${RESPONSE_FILE}"
+        jq -r .signature < "${RESPONSE_FILE}" | base64 -d > "${FILE_TO_SIGN}.sig"
+        rm -f "${REQUEST_FILE}" "${RESPONSE_FILE}"
+    done
+
+    rm -f "${TO_SIGN}"
+}
+
+addtask sign before do_install after do_compile
+
 do_install[noexec] = '1'
+
 do_deploy() {
     install -m 644 ${B}/grub.cfg_external ${DEPLOYDIR}
     install -m 644 ${B}/grub.cfg_internal ${DEPLOYDIR}
@@ -34,6 +66,10 @@ do_deploy() {
     install -m 644 ${WORKDIR}/grubenv ${DEPLOYDIR}/grubenv
     touch ${DEPLOYDIR}/grub_extraenv
 
+    if [ "${SIGN}" = "true" ]; then
+        install -m 644 ${B}/grub.cfg_external.sig ${DEPLOYDIR}/grub.cfg_external.sig
+        install -m 644 ${B}/grub.cfg_internal.sig ${DEPLOYDIR}/grub.cfg_internal.sig
+    fi
 }
 
 addtask do_deploy before do_package after do_install

--- a/meta-balena-common/recipes-bsp/grub/grub-efi/pass-secure-boot.patch
+++ b/meta-balena-common/recipes-bsp/grub/grub-efi/pass-secure-boot.patch
@@ -1,0 +1,61 @@
++++ b/grub-core/loader/i386/linux.c	2021-03-18 05:42:23.238455042 +0100
+@@ -614,6 +614,27 @@ grub_linux_boot (void)
+ 	ctx.params->v0204.efi_mmap_size = efi_mmap_size;
+       }
+   }
++
++  /* Populate secure boot configuration to linux */
++  grub_uint8_t *secureboot, *setupmode;
++  grub_size_t secureboot_size, setupmode_size;
++  grub_efi_guid_t global_guid = GRUB_EFI_GLOBAL_VARIABLE_GUID;
++  secureboot = grub_efi_get_variable("SecureBoot", &global_guid, &secureboot_size);
++  setupmode = grub_efi_get_variable("SetupMode", &global_guid, &setupmode_size);
++
++  if (secureboot == NULL || secureboot_size == 0 || setupmode == NULL || setupmode_size == 0)
++    ctx.params->secure_boot = efi_secureboot_mode_unset;
++  else if (secureboot[0] == 1 && setupmode[0] == 0)
++    ctx.params->secure_boot = efi_secureboot_mode_enabled;
++  else if (secureboot[0] == 0 || setupmode[0] == 1)
++    ctx.params->secure_boot = efi_secureboot_mode_disabled;
++  else
++    ctx.params->secure_boot = efi_secureboot_mode_unknown;
++
++  if (secureboot != NULL)
++    grub_free(secureboot);
++  if (setupmode != NULL)
++    grub_free(setupmode);
+ #endif
+ 
+   /* FIXME.  */
+diff -urp a/include/grub/i386/linux.h b/include/grub/i386/linux.h
+--- a/include/grub/i386/linux.h	2019-04-23 10:54:47.000000000 +0200
++++ b/include/grub/i386/linux.h	2021-03-17 17:10:32.384737853 +0100
+@@ -90,6 +90,15 @@ enum
+     GRUB_VIDEO_LINUX_TYPE_SIMPLE = 0x70    /* Linear framebuffer without any additional functions.  */
+   };
+ 
++/* From linux/efi.h */
++enum efi_secureboot_mode
++  {
++    efi_secureboot_mode_unset,
++    efi_secureboot_mode_unknown,
++    efi_secureboot_mode_disabled,
++    efi_secureboot_mode_enabled
++  };
++
+ /* For the Linux/i386 boot protocol version 2.10.  */
+ struct linux_i386_kernel_header
+ {
+@@ -275,7 +284,11 @@ struct linux_kernel_params
+ 
+   grub_uint8_t mmap_size;		/* 1e8 */
+ 
+-  grub_uint8_t padding9[0x1f1 - 0x1e9];
++  grub_uint8_t padding9[0x1ec - 0x1e9];
++
++  grub_uint8_t secure_boot;		/* 1ec */
++
++  grub_uint8_t padding9_1[0x1f1 - 0x1ed];
+ 
+   /* Linux setup header copy - BEGIN. */
+   grub_uint8_t setup_sects;		/* The size of the setup in sectors */

--- a/meta-balena-common/recipes-bsp/grub/grub-efi_%.bbappend
+++ b/meta-balena-common/recipes-bsp/grub/grub-efi_%.bbappend
@@ -1,3 +1,29 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/grub-efi:"
+
+SRC_URI += " \
+    file://pass-secure-boot.patch \
+    "
+
+DEPENDS:append = " ca-certificates-native coreutils-native curl-native jq-native"
+
+# build in additional required modules
+GRUB_BUILDIN:append = " gcry_sha256 gcry_sha512 gcry_rijndael gcry_rsa regexp probe gzio"
+
+do_configure:append:class-target() {
+    if [ "${SIGN}" != "true" ]; then
+        return 0
+    fi
+
+    export CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt"
+
+    # Get public key for mkimage
+    RESPONSE_FILE=$(mktemp)
+    PUBKEY_FILE="${B}/pubkey.gpg"
+    curl --fail "${SIGN_API}/gpg/key/${SIGN_GRUB_KEY_ID}" > "${RESPONSE_FILE}"
+    jq -r ".key" < "${RESPONSE_FILE}" | gpg --dearmor > "${PUBKEY_FILE}"
+    rm -f "${RESPONSE_FILE}"
+}
+
 # We don't want grub modules in our sysroot
 do_install:append:class-target() {
     rm -rf ${D}${prefix}
@@ -9,5 +35,40 @@ do_deploy:append:class-target() {
     install -d ${DEPLOYDIR}/grub/${GRUB_TARGET}-efi/
 }
 
-# build in additional required modules
-GRUB_BUILDIN:append = " regexp probe gzio"
+do_mkimage() {
+    cd ${B}
+
+    if [ "${SIGN}" = "true" ]; then
+        GRUB_PUBKEY_ARG="--pubkey "${B}/pubkey.gpg""
+    fi
+
+    # Search for the grub.cfg on the local boot media by using the
+    # built in cfg file provided via this recipe
+    grub-mkimage -c ../cfg -p ${EFIDIR} -d ./grub-core/ \
+           -O ${GRUB_TARGET}-efi -o ./${GRUB_IMAGE_PREFIX}${GRUB_IMAGE} \
+           ${GRUB_BUILDIN} ${GRUB_PUBKEY_ARG}
+}
+
+do_sign_efi() {
+    if [ "${SIGN}" != "true" ]; then
+        return 0
+    fi
+
+    export CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt"
+
+    EFI_APP="${B}/${GRUB_IMAGE_PREFIX}${GRUB_IMAGE}"
+    REQUEST_FILE=$(mktemp)
+    RESPONSE_FILE=$(mktemp)
+    echo "{\"key_id\": \"${SIGN_EFI_KEY_ID}\", \"payload\": \"$(base64 -w 0 ${EFI_APP})\"}" > "${REQUEST_FILE}"
+    curl --fail "${SIGN_API}/secureboot/efi" -X POST -H "Content-Type: application/json" -H "X-API-Key: ${SIGN_API_KEY}" -d "@${REQUEST_FILE}" > "${RESPONSE_FILE}"
+    jq -r .signed < "${RESPONSE_FILE}" | base64 -d > "${EFI_APP}.signed"
+    rm -f "${REQUEST_FILE}" "${RESPONSE_FILE}"
+
+    mv "${EFI_APP}.signed" "${EFI_APP}"
+}
+
+do_sign_efi:class-native() {
+    :
+}
+
+addtask sign_efi after do_mkimage before do_install


### PR DESCRIPTION
This incorporates multiple changes:
- Patch grub to propagate secure boot mode to the kernel
- Enable GPG signature verification in GRUB
- Sign GRUB config files
- Sign the grub EFI binary for secure boot

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
