### PR TITLE
linux-firmware: Include RTL8723BU firmware files

### DIFF
--- a/meta-balena-common/recipes-core/packagegroups/packagegroup-balena-connectivity.bb
+++ b/meta-balena-common/recipes-core/packagegroups/packagegroup-balena-connectivity.bb
@@ -15,6 +15,8 @@ CONNECTIVITY_FIRMWARES ?= " \
     linux-firmware-ralink \
     linux-firmware-rtl8192cu \
     linux-firmware-rtl8192su \
+    linux-firmware-rtl8723 \
+    linux-firmware-rtl8723b-bt \
     "
 
 CONNECTIVITY_PACKAGES = " \


### PR DESCRIPTION
The driver for RTL8723BU wireless chipset is present, but its firmware
files are not loaded. This patch includes them.

Change-type: patch
Signed-off-by: Zahari Petkov <zahari@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
