### PR TITLE
Revert "sign-efi.class, sign-kmod.class: Replace original files with signed ones"

### DIFF
--- a/meta-balena-common/classes/sign-efi.bbclass
+++ b/meta-balena-common/classes/sign-efi.bbclass
@@ -27,7 +27,7 @@ do_sign_efi () {
     done
 }
 
-do_deploy_append:class-target() {
+do_deploy:append:class-target() {
     for SIGNING_ARTIFACT in ${SIGNING_ARTIFACTS}; do
         if [ -f "${SIGNING_ARTIFACT}.signed" ]; then
             install -m 0644 "${SIGNING_ARTIFACT}.signed" "${DEPLOYDIR}/"$(basename ${SIGNING_ARTIFACT}).signed

--- a/meta-balena-common/classes/sign-efi.bbclass
+++ b/meta-balena-common/classes/sign-efi.bbclass
@@ -15,30 +15,23 @@ do_sign_efi () {
     fi
 
     for SIGNING_ARTIFACT in ${SIGNING_ARTIFACTS}; do
-        if [ -z "${SIGNING_ARTIFACT}" ]; then
+        if [ -z "${SIGNING_ARTIFACT}" ] || [ ! -f "${SIGNING_ARTIFACT}" ]; then
             bbfatal "Nothing to sign"
         fi
-
-        UNSIGNED_ARTIFACT="${SIGNING_ARTIFACT}.unsigned"
-        if [ -f "${UNSIGNED_ARTIFACT}" ]; then
-            # We have already backed up the unsigned version, use it and remove the destination
-            # This should only happen when re-running do_sign_efi
-            rm -f "${SIGNING_ARTIFACT}"
-        elif [ -f "${SIGNING_ARTIFACT}" ]; then
-            # No backup has been performed but the unsigned file exists
-            # Back up the unsigned version and clean up the destination
-            # This should be the most common path
-            mv "${SIGNING_ARTIFACT}" "${UNSIGNED_ARTIFACT}"
-        else
-            bbfatal "Unable to find ${SIGNING_ARTIFACT}"
-        fi
-
         REQUEST_FILE=$(mktemp)
         RESPONSE_FILE=$(mktemp)
-        echo "{\"key_id\": \"${SIGN_EFI_KEY_ID}\", \"payload\": \"$(base64 -w 0 ${UNSIGNED_ARTIFACT})\"}" > "${REQUEST_FILE}"
+        echo "{\"key_id\": \"${SIGN_EFI_KEY_ID}\", \"payload\": \"$(base64 -w 0 ${SIGNING_ARTIFACT})\"}" > "${REQUEST_FILE}"
         CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt" curl --fail "${SIGN_API}/secureboot/efi" -X POST -H "Content-Type: application/json" -H "X-API-Key: ${SIGN_API_KEY}" -d "@${REQUEST_FILE}" > "${RESPONSE_FILE}"
-        jq -r ".signed" < "${RESPONSE_FILE}" | base64 -d > "${SIGNING_ARTIFACT}"
+        jq -r ".signed" < "${RESPONSE_FILE}" | base64 -d > "${SIGNING_ARTIFACT}.signed"
         rm -f "${REQUEST_FILE}" "${RESPONSE_FILE}"
+    done
+}
+
+do_deploy_append:class-target() {
+    for SIGNING_ARTIFACT in ${SIGNING_ARTIFACTS}; do
+        if [ -f "${SIGNING_ARTIFACT}.signed" ]; then
+            install -m 0644 "${SIGNING_ARTIFACT}.signed" "${DEPLOYDIR}/"$(basename ${SIGNING_ARTIFACT}).signed
+        fi
     done
 }
 

--- a/meta-balena-common/classes/sign-kmod.bbclass
+++ b/meta-balena-common/classes/sign-kmod.bbclass
@@ -10,29 +10,14 @@ do_sign_kmod () {
     fi
 
     for SIGNING_ARTIFACT in ${SIGNING_ARTIFACTS}; do
-        if [ -z "${SIGNING_ARTIFACT}" ]; then
+        if [ -z "${SIGNING_ARTIFACT}" ] || [ ! -f "${SIGNING_ARTIFACT}" ]; then
             bbfatal "Nothing to sign"
         fi
-
-        UNSIGNED_ARTIFACT="${SIGNING_ARTIFACT}.unsigned"
-        if [ -f "${UNSIGNED_ARTIFACT}" ]; then
-            # We have already backed up the unsigned version, use it and remove the destination
-            # This should only happen when re-running do_sign_kmod
-            rm -f "${SIGNING_ARTIFACT}"
-        elif [ -f "${SIGNING_ARTIFACT}" ]; then
-            # No backup has been performed but the unsigned file exists
-            # Back up the unsigned version and clean up the destination
-            # This should be the most common path
-            mv "${SIGNING_ARTIFACT}" "${UNSIGNED_ARTIFACT}"
-        else
-            bbfatal "Unable to find ${SIGNING_ARTIFACT}"
-        fi
-
         REQUEST_FILE=$(mktemp)
         RESPONSE_FILE=$(mktemp)
-        echo "{\"key_id\": \"${SIGN_KMOD_KEY_ID}\", \"payload\": \"$(base64 -w 0 ${UNSIGNED_ARTIFACT})\"}" > "${REQUEST_FILE}"
+        echo "{\"key_id\": \"${SIGN_KMOD_KEY_ID}\", \"payload\": \"$(base64 -w 0 ${SIGNING_ARTIFACT})\"}" > "${REQUEST_FILE}"
         CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt" curl --fail --silent "${SIGN_API}/kmod/sign" -X POST -H "Content-Type: application/json" -H "X-API-Key: ${SIGN_API_KEY}" -d "@${REQUEST_FILE}" > "${RESPONSE_FILE}"
-        jq -r ".signed" < "${RESPONSE_FILE}" | base64 -d > "${SIGNING_ARTIFACT}"
+        jq -r ".signed" < "${RESPONSE_FILE}" | base64 -d > "${SIGNING_ARTIFACT}.signed"
         rm -f "${REQUEST_FILE}" "${RESPONSE_FILE}"
     done
 }


### PR DESCRIPTION
This reverts commit 853656e6bcfed0b0206d031c32cd1cde811b8146.

The change overwrites build files, though that is what we need, it is a hacky
approach and we will look for a clean solution.

Change-type: patch
Signed-off-by: Michal Toman <michalt@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
