### PR TITLE
0-signed-update HUP hook: mount efivarfs if necessary

### DIFF
--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 DURING_UPDATE="${DURING_UPDATE:-0}"
+UMOUNT_EFIVARS=0
 SECUREBOOT_VAR="8be4df61-93ca-11d2-aa0d-00e098032b8c-SecureBoot"
 SETUPMODE_VAR="8be4df61-93ca-11d2-aa0d-00e098032b8c-SetupMode"
 EFIVAR_RE="s,^[^ ]*  *\([^ ]*\) .*$,\1,"
@@ -15,15 +16,28 @@ if [ ! -d "/sys/firmware/efi" ]; then
     exit 0
 fi
 
-# Only applicable when in secure boot mode
+# Mount efivarfs if necessary
+if ! mount | grep -q "type efivarfs"; then
+    mount -t efivarfs efivarfs /sys/firmware/efi/efivars
+    UMOUNT_EFIVARS=1
+fi
+
+# Read EFI variables
 SECUREBOOT_VAL=$(efivar -p -n "${SECUREBOOT_VAR}" | tail -n 1 | sed -e "${EFIVAR_RE}")
-if [ "${SECUREBOOT_VAL}" -ne "1" ]; then
+SETUPMODE_VAL=$(efivar -p -n "${SETUPMODE_VAR}" | tail -n 1 | sed -e "${EFIVAR_RE}")
+
+# Leave the system in the original state - unmount efivarfs if we mounted it
+if [ "${UMOUNT_EFIVARS}" = 1 ]; then
+    umount /sys/firmware/efi/efivars
+fi
+
+# Only applicable when in secure boot mode
+if [ -z "${SECUREBOOT_VAL}" ] || [ "${SECUREBOOT_VAL}" -ne "1" ]; then
     exit 0
 fi
 
 # Not applicable when secure boot is in setup mode
-SETUPMODE_VAL=$(efivar -p -n "${SETUPMODE_VAR}" | tail -n 1 | sed -e "${EFIVAR_RE}")
-if [ "${SETUPMODE_VAL}" -ne "0" ]; then
+if [ -n "${SETUPMODE_VAL}" ] && [ "${SETUPMODE_VAL}" -ne "0" ]; then
     exit 0
 fi
 


### PR DESCRIPTION
The hook tries to read EFI variables from efivarfs but this is not always
mounted within the container. We have already validated that we are running
in EFI mode therefore we can just check whether it is already mounted
and eventually mount with no further checks.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
