### PR TITLE
Allow os suite to run with flasher or normal image

### DIFF
--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -100,7 +100,7 @@ module.exports = {
 		if(this.suite.deviceType.data.storage.internal && (process.env.WORKER_TYPE === `qemu`)){
 			const RAW_IMAGE_PATH = `/opt/balena-image-${this.suite.deviceType.slug}.balenaos-img`
 			const OUTPUT_IMG_PATH = '/data/downloads/unwrapped.img'
-			console.log(`Unwrapping file ${this.context.get().os.image.path}`)
+			console.log(`Trying to unwrap file ${this.context.get().os.image.path}`)
 			console.log(`Looking for ${RAW_IMAGE_PATH}`)
 			try{
 				await imagefs.interact(this.context.get().os.image.path, 2, async (fsImg) => {
@@ -109,11 +109,11 @@ module.exports = {
 					fse.createWriteStream(OUTPUT_IMG_PATH)
 					)
 				})
+				this.context.get().os.image.path = OUTPUT_IMG_PATH;
+				console.log(`Unwrapped flasher image!`);
 			}catch(e){
-				console.log(e)
-			}
-			this.context.get().os.image.path = OUTPUT_IMG_PATH
-			console.log(`Unwrapped flasher image!`)
+				console.log(`Could not unwrap flasher image - assuming that this is a raw image`);
+			}	
 		}
 
 		// Configure OS image


### PR DESCRIPTION
This updates the OS suite to unwrap a flasher image if its being run with a qemu worker, if the image is a flasher image, only if it is a flasher image, otherwise it will continue as normal

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
