### PR TITLE
balena-image-flasher: Add secure boot keys to boot partition

### DIFF
--- a/meta-balena-common/recipes-core/images/balena-image-flasher.bb
+++ b/meta-balena-common/recipes-core/images/balena-image-flasher.bb
@@ -43,6 +43,9 @@ BALENA_ROOTB_FS_LABEL = "flash-rootB"
 BALENA_STATE_FS_LABEL = "flash-state"
 BALENA_DATA_FS_LABEL = "flash-data"
 
+# add the secure boot keys if needed
+BALENA_BOOT_PARTITION_FILES:append = "${@oe.utils.conditional('SIGN_API','','','balena-keys:/balena-keys/',d)}"
+
 # Put the resin logo, uEnv.txt files inside the boot partition
 BALENA_BOOT_PARTITION_FILES:append = " balena-logo.png:/splash/balena-logo.png"
 


### PR DESCRIPTION
Having the keys available in the flasher image allows to use the
flasher image as source to program the keys in the EFI.

Changelog-entry: Add secure boot keys to the flasher boot partition
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
