### PR TITLE
Make kexec work under kernel lockdown

### DIFF
--- a/meta-balena-common/classes/sign-efi.bbclass
+++ b/meta-balena-common/classes/sign-efi.bbclass
@@ -31,7 +31,6 @@ do_deploy:append:class-target() {
     for SIGNING_ARTIFACT in ${SIGNING_ARTIFACTS}; do
         if [ -f "${SIGNING_ARTIFACT}.signed" ]; then
             install -m 0644 "${SIGNING_ARTIFACT}.signed" "${DEPLOYDIR}/$(basename ${SIGNING_ARTIFACT})"
-            ln -sf "${DEPLOYDIR}/$(basename ${SIGNING_ARTIFACT})" "$(basename ${SIGNING_ARTIFACT}).signed"
         fi
     done
 }

--- a/meta-balena-common/classes/sign-gpg.bbclass
+++ b/meta-balena-common/classes/sign-gpg.bbclass
@@ -25,9 +25,8 @@ do_sign_gpg () {
 do_deploy:append() {
     for SIGNING_ARTIFACT in ${SIGNING_ARTIFACTS}; do
         if [ -f "${SIGNING_ARTIFACT}.sig" ]; then
-            # Both signed and unsigned versions are required
+            # Deploy the detached signature if available, the original file has already been deployed
             install -m 0644 "${SIGNING_ARTIFACT}.sig" "${DEPLOYDIR}/$(basename ${SIGNING_ARTIFACT}).sig"
-            install -m 0644 "${SIGNING_ARTIFACT}" "${DEPLOYDIR}/$(basename ${SIGNING_ARTIFACT})"
         fi
     done
 }

--- a/meta-balena-common/recipes-core/initrdscripts/files/kexec
+++ b/meta-balena-common/recipes-core/initrdscripts/files/kexec
@@ -30,7 +30,7 @@ kexec_run() {
     ROOT_UUID=$(findmnt "${ROOTFS_DIR}" -n -o UUID)
 
     BOOT_PARAMS="$(cat /proc/cmdline | sed -e s,balena_stage2,, | sed -e s,root=[^\ ]*,root=UUID=${ROOT_UUID},)"
-    kexec -l "${KERNEL_IMAGE}" --append="${BOOT_PARAMS}"
+    kexec -s -l "${KERNEL_IMAGE}" --append="${BOOT_PARAMS}"
 
     umount "${ROOTFS_DIR}"
 

--- a/meta-balena-common/recipes-kernel/linux/kernel-image-initramfs.bb
+++ b/meta-balena-common/recipes-kernel/linux/kernel-image-initramfs.bb
@@ -11,7 +11,8 @@ do_install() {
     for type in ${KERNEL_IMAGETYPE}; do
         install -m 0644 ${DEPLOY_DIR_IMAGE}/${type}-initramfs-${MACHINE}.bin ${D}/boot/${type}
         if [ -f "${DEPLOY_DIR_IMAGE}/${type}.initramfs.sig" ]; then
-            install -m 0644 "${DEPLOY_DIR_IMAGE}/${type}.initramfs.sig" "${D}/boot/${type}.initramfs.sig"
+            install -m 0644 ${DEPLOY_DIR_IMAGE}/${type}.initramfs ${D}/boot/${type}
+            install -m 0644 "${DEPLOY_DIR_IMAGE}/${type}.initramfs.sig" "${D}/boot/${type}.sig"
         fi
     done
 }


### PR DESCRIPTION
In the current state this produces an unbootable system - the unsigned bzImage is shipped within the image but the attached bzImage.sig is for the EFI-signed version.

- EFI sign bzImage first
- GPG sign the result
- Enable kexec signature check in the kernel
- Load EFI keys to the kernel keyring
- Use -s with kexec load command

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
