### PR TITLE
tests: Update leviathan default config for generic devices

### DIFF
--- a/tests/suites/config.js
+++ b/tests/suites/config.js
@@ -1,26 +1,23 @@
 module.exports = [{
-	deviceType: `raspberrypi3`,
+	deviceType: `genericx86-64-ext`,
 	suite: `${__dirname}/../suites/os`,
 	config: {
 		networkWired: false,
-		networkWireless: true,
+		networkWireless: false,
 		interactiveTests: false, // redundant
 		balenaApiKey: process.env.BALENA_CLOUD_API_KEY,
 		balenaApiUrl: 'balena-cloud.com',
 		organization: process.env.BALENA_CLOUD_ORG
 	},
 	image: `${__dirname}/balena.img.gz`,
-	workers: {
-		balenaApplication: process.env.BALENA_CLOUD_APP_NAME,
-		apiKey: process.env.BALENA_CLOUD_API_KEY,
-	},
+	workers: ['http://localhost'],
 },
 {
-	deviceType: `raspberrypi3`,
+	deviceType: `genericx86-64-ext`,
 	suite: `${__dirname}/../suites/hup`,
 	config: {
 		networkWired: false,
-		networkWireless: true,
+		networkWireless: false,
 		downloadVersion: 'latest',
 		interactiveTests: false, // redundant
 		balenaApiKey: process.env.BALENA_CLOUD_API_KEY,
@@ -28,8 +25,5 @@ module.exports = [{
 		organization: process.env.BALENA_CLOUD_ORG
 	},
 	image: `${__dirname}/balena-image.docker`,
-	workers: {
-		balenaApplication: process.env.BALENA_CLOUD_APP_NAME,
-		apiKey: process.env.BALENA_CLOUD_API_KEY,
-	},
+	workers: ['http://localhost'],
 }];


### PR DESCRIPTION
These values are updated by the Jenkins leviathan jobs but
it is preferrable to have sane defaults that assume a local
QEMU test is being used for meta-balena PRs.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
