### PR TITLE
tests: os: fix unhandled exception when unwrapping non-flasher image

### DIFF
--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -109,11 +109,17 @@ module.exports = {
 					fse.createWriteStream(OUTPUT_IMG_PATH)
 					)
 				})
+
+				this.context.get().os.image.path = OUTPUT_IMG_PATH;
+				console.log(`Unwrapped flasher image!`);
 			}catch(e){
-				console.log(e)
+				// If the outer image doesn't contain an image for installation, ignore the error
+				if (e.code == 'ENOENT') {
+					console.log("Not a flasher image, skipping unwrap");
+				} else {
+					throw e;
+				}
 			}
-			this.context.get().os.image.path = OUTPUT_IMG_PATH
-			console.log(`Unwrapped flasher image!`)
 		}
 
 		// Configure OS image


### PR DESCRIPTION
Handle ENOENT ErrnoException when attempting to unwrap non-flasher image
in os/suite.js.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
