### PR TITLE
tests: Ensure BDADDR is initialized

### DIFF
--- a/tests/suites/os/tests/bluetooth/index.js
+++ b/tests/suites/os/tests/bluetooth/index.js
@@ -59,6 +59,20 @@ module.exports = {
 						true,
 						'DUT should be able to see testbot when scanning for bluetooth devices',
 					);
+
+					test.comment('Checking if BD Address is initialized');
+					const devMac = await this.context
+							.get()
+							.worker.executeCommandInHostOS(
+								'hcitool dev',
+								this.context.get().link,
+							);
+
+					test.is(
+						devMac.includes('AA:AA:AA:AA:AA:AA'),
+						false,
+						'BD Address should not be AA:AA:AA:AA:AA:AA',
+					);
 				}
 			},
 		},


### PR DESCRIPTION
The CM4 IO-Board exhibited an issue in which
the MAC address was set to an
un-programmed value AA:AA:AA...:AA.

We've addressed this in the device repo,
meanwhile it has been fixed in upstream
too, so let's check and catch this should
it happen again.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Connects to: https://github.com/balena-os/balena-raspberrypi/issues/731


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
