### PR TITLE
patch: Add archiveLogs Teardown for HUP suite

### DIFF
--- a/tests/suites/hup/suite.js
+++ b/tests/suites/hup/suite.js
@@ -238,6 +238,13 @@ module.exports = {
 		await this.context.get().hupOs.fetch();
 		// configure the image
 		await this.context.get().os.configure();
+    
+    // Retrieving journalctl logs
+		this.suite.teardown.register(async () => {
+			await this.context
+				.get()
+				.worker.archiveLogs(this.id, this.context.get().link);
+		});
 	},
 	tests: [
 		'./tests/smoke',

--- a/tests/suites/os/tests/device-tree/index.js
+++ b/tests/suites/os/tests/device-tree/index.js
@@ -159,11 +159,11 @@ module.exports = {
 				// Start of the device-tree practical test
 				await exportPin(4)
 				if (await getPinValue(4) === "0") {
-					test.true("Pin 4 was Low when the test started")
+					test.true(true, "Pin 4 was Low when the test started")
 					const targetState = await applySupervisorConfig("up")
 					test.equal(await getPinValueThroughDebug(4), '"hi"', "Pin 4 set to High after applying dtoverlay")
 				} else {
-					test.true("Pin 4 is High as expected")
+					test.true(true, "Pin 4 is High as expected")
 					const targetState = await applySupervisorConfig("down")
 					test.equal(await getPinValueThroughDebug(4), '"lo"', "Pin 4 set to Low after applying dtoverlay")
 				}


### PR DESCRIPTION
Added additional suite level teardown to get journalctl logs even for the scenario when - HUP fails in the first test of HUP suite or 
- If the registry fails to start. 

In both cases, journalctl logs weren't recorded and we all like some journalctl logs whenever we can have them. So why not. 

Also, patching a small issue in Dtoverlay test. 