### PR TITLE
balena-supervisor: Update balena-supervisor to v12.11.16

### DIFF
--- a/meta-balena-common/recipes-containers/balena-supervisor/balena-supervisor.inc
+++ b/meta-balena-common/recipes-containers/balena-supervisor/balena-supervisor.inc
@@ -17,4 +17,4 @@ SUPERVISOR_REPOSITORY:x86-64 ?= "balena/amd64-supervisor"
 SUPERVISOR_REPOSITORY_intel-quark ?= "balena/i386-nlp-supervisor"
 
 # Balena supervisor default tag
-SUPERVISOR_TAG ?= "v12.11.0"
+SUPERVISOR_TAG ?= "v12.11.16"


### PR DESCRIPTION
Version has been released for 14 days..provides happy eyeballs algorithm which improves device connectivity on IPv6 networks. Otherwise also allows nano 2gb dev kit to be configured via extra-uEnv backend.