### PR TITLE
tests: os: optimize suite setup

### DIFF
--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -86,66 +86,75 @@ module.exports = {
 			return this.context.get().worker.teardown();
 		});
 
-		this.log('Setting up worker');
 
-		// Create network AP on testbot
-		await this.context
-			.get()
-			.worker.network(this.suite.options.balenaOS.network);
-
-		// Unpack OS image .gz
-		await this.context.get().os.fetch();
-
-		// If this is a flasher image, and we are using qemu, unwrap
-		if(this.suite.deviceType.data.storage.internal && (process.env.WORKER_TYPE === `qemu`)){
-			const RAW_IMAGE_PATH = `/opt/balena-image-${this.suite.deviceType.slug}.balenaos-img`
-			const OUTPUT_IMG_PATH = '/data/downloads/unwrapped.img'
-			console.log(`Unwrapping file ${this.context.get().os.image.path}`)
-			console.log(`Looking for ${RAW_IMAGE_PATH}`)
-			try{
-				await imagefs.interact(this.context.get().os.image.path, 2, async (fsImg) => {
-					await pipeline(
-					fsImg.createReadStream(RAW_IMAGE_PATH),
-					fse.createWriteStream(OUTPUT_IMG_PATH)
-					)
-				})
-
-				this.context.get().os.image.path = OUTPUT_IMG_PATH;
-				console.log(`Unwrapped flasher image!`);
-			}catch(e){
-				// If the outer image doesn't contain an image for installation, ignore the error
-				if (e.code == 'ENOENT') {
-					console.log("Not a flasher image, skipping unwrap");
-				} else {
-					throw e;
-				}
+		async function unwrapImage() {
+			// If this is a flasher image, and we are using qemu, unwrap
+			if (this.suite.deviceType.data.storage.internal
+				&& (process.env.WORKER_TYPE === `qemu`)) {
+				const RAW_IMAGE_PATH = `/opt/balena-image-${this.suite.deviceType.slug}.balenaos-img`
+				const OUTPUT_IMG_PATH = '/data/downloads/unwrapped.img'
+				console.log(`Unwrapping file ${this.context.get().os.image.path}`)
+				console.log(`Looking for ${RAW_IMAGE_PATH}`)
+				return imagefs.interact(this.context.get().os.image.path, 2, async (fsImg) => {
+					return new Promise((resolve, reject) => {
+						pipeline(
+							fsImg.createReadStream(RAW_IMAGE_PATH),
+							fse.createWriteStream(OUTPUT_IMG_PATH)
+						).then(resolve);
+					});
+				}).then(() => {
+					this.context.get().os.image.path = OUTPUT_IMG_PATH;
+					console.log(`Unwrapped flasher image!`);
+				}).catch((e) => {
+					// If the outer image doesn't contain an image for installation, ignore the error
+					if (e.code == 'ENOENT') {
+						console.log("Not a flasher image, skipping unwrap");
+					} else {
+						throw e;
+					}
+				});
 			}
 		}
 
-		// Configure OS image
-		await this.context.get().os.configure();
+		this.log('Setting up worker');
 
-		// Flash the DUT
-		await this.context.get().worker.off(); // Ensure DUT is off before starting tests
-		await this.context.get().worker.flash(this.context.get().os.image.path);
-		await this.context.get().worker.on();
-
-		this.log('Waiting for device to be reachable');
-		assert.equal(
-			await this.context
-				.get()
-				.worker.executeCommandInHostOS(
-					'cat /etc/hostname',
-					this.context.get().link,
-				),
-			this.context.get().link.split('.')[0],
-			'Device should be reachable',
+		return Promise.all(
+			[
+				this.context.get().worker.network(this.suite.options.balenaOS.network),
+				this.context.get().os.fetch()
+					.then(() => {
+						return this.context.get().os.configure();
+					}).then(() => {
+						return this.context.get().worker.off();
+					}).then(() => {
+						return this.context.get().worker.flash(this.context.get().os.image.path)
+					}).then(() => {
+						this.context.get().worker.on();
+					}).then(() => {
+						this.log('Waiting for device to be reachable');
+						return this.context.get().worker.executeCommandInHostOS(
+							'cat /etc/hostname',
+							this.context.get().link,
+						);
+					}).then((hostname) => {
+						// wait for new hostname to be configured
+						return this.context.get().utils.waitUntil(async () => {
+							return hostname === this.context.get().link.split('.')[0];
+						}, false, 60, 1000);
+					}).then(() => {
+						// Retrieving journalctl logs: register teardown after device is reachable
+						this.suite.teardown.register(async () => {
+							return this.context.get().worker.archiveLogs(
+								this.id,
+								this.context.get().link
+							);
+						});
+					});
+				}).catch((err) => {
+					console.log(`Failed worker setup with '${err}'`);
+				}),
+			]
 		);
-
-    // Retrieving journalctl logs: register teardown after device is reachable
-    this.suite.teardown.register(async () => {
-			await this.context.get().worker.archiveLogs(this.id, this.context.get().link);
-		});
 
 	},
 	tests: [


### PR DESCRIPTION
Chain operations using Promise.then() and run operations in parallel
when they don't have dependencies.

This significantly reduces time taken during suite setup. Below are
results when only running os-release tests.

- # time=37306.174ms
+ # time=21844.522ms

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
