### PR TITLE
hostapp-update-hooks: Handle developmentMode updates

### DIFF
--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/1-bootfiles
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/1-bootfiles
@@ -104,6 +104,19 @@ deploy() {
 				printf " done.\n"
 				return
 			fi
+		elif [ "$_file" = "/config.json" ]; then
+			development_mode="$(jq -r ".developmentMode" "/resin-boot$_file")"
+			if [ "${development_mode}" = "true" ]; then
+				# New OS has development mode configured
+				# Only configure developmentMode if updating from a legacy development image
+				old_os_os_release=$(find "/mnt/sysroot/active" -path "*/etc/os-release")
+				if grep -i -q 'VARIANT="Development"' "${old_os_os_release}"; then
+					jq -S ".developmentMode=true" < "${boot_mountpoint}/config.json" > "/tmp/config.json"
+					mv "/tmp/config.json" "${boot_mountpoint}/config.json"
+					sync -f "${boot_mountpoint}"
+					printf "Development mode set in new OS... "
+				fi
+			fi
 		fi
 		printf "file blacklisted. Ignoring.\n"
 	else


### PR DESCRIPTION
When updating from a legacy development image which has no developmentMode
set in config.json to an image configured with development mode, the hooks
need to set developmentMode accordingly in config.json.

Updating to a development mode image from a production image will not
set developmentMode.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
