### PR TITLE
systemd/timeinit: handle missing date field in HTTPS header

### DIFF
--- a/meta-balena-common/recipes-core/systemd/timeinit/timesync-https.sh
+++ b/meta-balena-common/recipes-core/systemd/timeinit/timesync-https.sh
@@ -70,6 +70,10 @@ while [ true  ]; do
 				info "System time is already synchronised."
 				exit 0
 			fi
+		else
+			warn "HTTPS header did not return a date field."
+			warn "System time not updated."
+			exit 0
 		fi
 	fi
 	sleep $HTTPS_POLL_DELAY


### PR DESCRIPTION
Update the timesync-https.sh script to handle the case where the date field is missing from the returned HTTPS header.

When the date field is not present the script will now exit with a warning rather than blocking indefinitely.

Change-type: patch
Changelog-entry: systemd/timeinit: handle missing date field in HTTPS header
Signed-off-by: Mark Corbin <mark@balena.io>

--

Built and tested against balena-raspberrypi v2.88.5+rev1 and meta-balena v2.88.11 for Raspberry Pi 4. A text file was used to simulate an HTTPS header with no date field.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [x] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
