### PR TITLE
chrony: fix mount service dependency for driftfile

### DIFF
--- a/meta-balena-common/recipes-core/chrony/files/chronyd.conf.systemd
+++ b/meta-balena-common/recipes-core/chrony/files/chronyd.conf.systemd
@@ -1,6 +1,6 @@
 [Unit]
-Wants=time-sync-https-wait.target var-volatile-lib.service
-After=time-sync-https-wait.target var-volatile-lib.service
+Wants=time-sync-https-wait.target bind-var-lib-chrony.service
+After=time-sync-https-wait.target bind-var-lib-chrony.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
The chrony driftfile is not being updated at shutdown due to an incorrect mount service dependency in the systemd chronyd.service file. The current dependency on 'var-volatile-lib' does not cover the subsequent bind mounting of the '/var/lib/chrony' sub-directory, so the chrony directory gets unmounted at shutdown before the drift file has been updated.

This issue is solved by changing the mount service dependency from 'var-volatile-lib' to 'bind-var-lib-chrony' (which is similar to the way bind mount dependencies are already handled for the NetworkManager and bluetooth services).

Change-type: patch
Connects-to: #1995
Changelog-entry: chrony: fix mount service dependency for driftfile
Signed-off-by: Mark Corbin <mark@balena.io>

--

Built and tested against balena-raspberrypi v2.88.5+rev1 and meta-balena v2.88.16 for Raspberry Pi 4. System was rebooted multiple times to ensure that a driftfile was created as necessary and updated correctly.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [x] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
