### PR TITLE
Cleanup config json tests

### DIFF
--- a/tests/suites/os/tests/config-json/index.js
+++ b/tests/suites/os/tests/config-json/index.js
@@ -24,59 +24,50 @@ module.exports = {
 					.toString(36)
 					.substring(2, 10);
 
+				const context = this.context.get();
+
 				// Add hostname
-				await this.context
-					.get()
-					.worker.executeCommandInHostOS(
-						`tmp=$(mktemp)&&cat /mnt/boot/config.json | jq '.hostname="${hostname}"' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
-						this.context.get().link,
-					);
-
-				// Wait for new hostname to be active
-				test.comment(`Waiting for avahi service to be active...`);
-				await this.context.get().utils.waitUntil(async () => {
-					return (
-						(await this.context
-							.get()
-							.worker.executeCommandInHostOS(
-								`systemctl is-active avahi-daemon.service`,
-								`${hostname}.local`,
-							)) === 'active'
-					);
-				}, false);
-
-				test.equal(
-					await this.context
-						.get()
-						.worker.executeCommandInHostOS(
-							'cat /etc/hostname',
-							`${hostname}.local`,
-						),
-					hostname,
-					'Device should have new hostname',
-				);
-
-				// Remove hostname
-				await this.context
-					.get()
-					.worker.executeCommandInHostOS(
-						'tmp=$(mktemp)&&cat /mnt/boot/config.json | jq "del(.hostname)" > $tmp&&mv "$tmp" /mnt/boot/config.json',
+				return context.worker.executeCommandInHostOS(
+					[
+						`tmp=$(mktemp)`,
+						`&&`, `cat`,  `/mnt/boot/config.json`,
+						`|`, `jq`, `'.hostname="${hostname}"'`,
+						`>`, `$tmp`,
+						`&&`, `mv`, `"$tmp"`, `/mnt/boot/config.json`,
+					].join(' '),
+					context.link,
+				).then(() => {
+					return context.systemd.waitForServiceState(
+						'avahi-daemon.service',
+						'active',
+						`${hostname}.local`,
+					)
+				}).then(() => {
+					return context.worker.executeCommandInHostOS(
+						'cat /etc/hostname',
+						`${hostname}.local`
+					)
+				}).then((actual) => {
+					const expected = hostname;
+					test.equal(actual, expected, 'Device should have a new hostname');
+				}).then(() => {
+					// Remove hostname
+					return context.worker.executeCommandInHostOS(
+						[
+							`tmp=$(mktemp)`,
+							`&&`, `jq`, `"del(.hostname)"`, `/mnt/boot/config.json`,
+							`>`, `$tmp`, `&&`, `mv`, `"$tmp"`, `/mnt/boot/config.json`
+						].join(' '),
 						`${hostname}.local`,
 					);
-
-
-				// Wait for old hostname to be active again
-				test.comment(`Waiting for avahi service to be active...`);
-				await this.context.get().utils.waitUntil(async () => {
-					return (
-						(await this.context
-							.get()
-							.worker.executeCommandInHostOS(
-								`systemctl is-active avahi-daemon.service`,
-								this.context.get().link,
-							)) === 'active'
+				}).then(() => {
+					// Wait for old hostname to be active again
+					return context.systemd.waitForServiceState(
+						'avahi-daemon.service',
+						'active',
+						context.link,
 					);
-				}, false);
+				});
 			},
 		},
 		{

--- a/tests/suites/os/tests/config-json/index.js
+++ b/tests/suites/os/tests/config-json/index.js
@@ -373,13 +373,11 @@ module.exports = {
 		{
 			title: 'sshKeys test',
 			run: async function(test) {
-				await test.resolves(
-					this.context
-						.get()
-						.worker.executeCommandInHostOS(
-							'echo true',
-							this.context.get().link,
-						),
+				return test.resolves(
+					this.context.get().worker.executeCommandInHostOS(
+						'echo true',
+						this.context.get().link,
+					),
 					'Should be able to establish ssh connection to the device',
 				);
 			},


### PR DESCRIPTION
This PR aims to make several tests in the config-json module more concise and readable, primarily with the use of the `waitForServiceState()` helper. Additionally, several unnecessary reboots were removed to save time.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
