### PR TITLE
Fix issues related to boot partition file timestamps

### DIFF
--- a/meta-balena-common/classes/image_types_balena.bbclass
+++ b/meta-balena-common/classes/image_types_balena.bbclass
@@ -301,7 +301,7 @@ IMAGE_CMD:balenaos-img () {
     fi
     eval mkfs.vfat "$OPTS" "${BALENA_BOOT_FS}" "${BALENA_BOOT_BLOCKS}"
     if [ "$(ls -A ${BALENA_BOOT_WORKDIR})" ]; then
-        mcopy -i ${BALENA_BOOT_FS} -sv ${BALENA_BOOT_WORKDIR}/* ::
+        mcopy -i ${BALENA_BOOT_FS} -svm ${BALENA_BOOT_WORKDIR}/* ::
     else
         bbwarn "Boot partition was detected empty."
     fi

--- a/meta-balena-common/conf/distro/include/balena-os.inc
+++ b/meta-balena-common/conf/distro/include/balena-os.inc
@@ -100,11 +100,11 @@ PREFERRED_VERSION_upx-native:arm = "3.94"
 PREFERRED_VERSION_linux-firmware = "20210511"
 
 # Preferred rust version
-PREFERRED_VERSION_rust-native = "1.36.0"
-PREFERRED_VERSION_rust-cross-arm = "1.36.0"
-PREFERRED_VERSION_rust-llvm-native = "1.36.0"
-PREFERRED_VERSION_cargo-native = "1.36.0"
-PREFERRED_VERSION_libstd-rs = "1.36.0"
+PREFERRED_VERSION_rust-native = "1.54.0"
+PREFERRED_VERSION_rust-cross-${TARGET_ARCH} = "1.54.0"
+PREFERRED_VERSION_rust-llvm-native = "1.54.0"
+PREFERRED_VERSION_cargo-native = "1.54.0"
+PREFERRED_VERSION_libstd-rs = "1.54.0"
 
 # balena-engine go version requirement
 GOVERSION = "1.12.17"

--- a/meta-balena-common/recipes-core/coreutils/coreutils_%.bbappend
+++ b/meta-balena-common/recipes-core/coreutils/coreutils_%.bbappend
@@ -1,1 +1,13 @@
-CFLAGS:append:class-target = " -DHAVE_PROC_UPTIME"
+# glibc enables 64bit time for stat and similar routines only if both _FILE_OFFSET_BITS=64 and _TIME_BITS=64 are set on 32bit platforms.
+#
+# We thus set them to avoid HUP failing when both conditions below are met simultaneously:
+# - files in the current OS boot partitions have any of m_time/c_time/a_time set to a value that exceeds year 2038,
+#   because mtcopy did not preserve the creation date during copying to the boot partition at build time.
+# - HUP is done to a system that uses glibc 2.34 or newer, which now returns EOVERFLOW if 32bit fallback functions are
+#   used on time structures that hold 64bit time values.
+#
+#   HUP failure would have been caused by commands like mkdir mv etc, which would return an error exit code when checking
+#   if the file to be created/replaced already exists by using stat() internally.
+#
+#   See https://www.phoronix.com/scan.php?page=news_item&px=Glibc-More-Y2038-Work
+CFLAGS:append:class-target = " -DHAVE_PROC_UPTIME -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64"

--- a/meta-balena-common/recipes-devtools/go/go-native.inc
+++ b/meta-balena-common/recipes-devtools/go/go-native.inc
@@ -1,5 +1,3 @@
-inherit native
-
 SRC_URI:append = " https://dl.google.com/go/go1.4-bootstrap-20171003.tar.gz;name=bootstrap;subdir=go1.4"
 SRC_URI[bootstrap.md5sum] = "dbf727a4b0e365bf88d97cbfde590016"
 SRC_URI[bootstrap.sha256sum] = "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52"

--- a/meta-balena-common/recipes-devtools/go/go-native_1.12.bb
+++ b/meta-balena-common/recipes-devtools/go/go-native_1.12.bb
@@ -1,2 +1,4 @@
 require ${PN}.inc
 require go-${PV}.inc
+
+inherit native


### PR DESCRIPTION
While working on the Honister switch for the RPI boards we noticed that for some releases, like for instance the Pi3 32bit v2.83, the boot partition files timestamps were incorrect, for instance:
```

root@6335d78:~# stat /mnt/boot/overlays/audremap.dtbo
  File: /mnt/boot/overlays/audremap.dtbo
  Size: 971             Blocks: 2          IO Block: 512    regular file
Device: b301h/45825d    Inode: 2436        Links: 1
Access: (0755/-rwxr-xr-x)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 1961-11-25 17:31:44.000000000 +0000
Modify: 1961-11-25 17:31:44.000000000 +0000
Change: 1961-11-25 17:31:44.000000000 +0000
 Birth: -
```
This caused the commands stat, mv, mkdir etc in the new Honister release to fail with ' Value too large for defined data type', although the file on which the operation was performed was very small, and happened if any of the Access/Modify/Change fields was larger than the corresponding stat structure field would accept. 

The observed behavior was that the first HUP attempt to the newer Honister release would fail, and the second would succeed, because the rollback hooks from the current OS updated the bootfiles timestamps.

We fix the timestamp issue at build time by instructing mcopy to preserve the modification time and also enable coreutils to use the 64bit time structures from glibc.


Connects to: https://github.com/balena-os/balena-raspberrypi/pull/755

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
