### PR TITLE
conf/distro: Prefer rust v1.36 for releases older than Honister

### DIFF
--- a/meta-balena-common/conf/distro/include/balena-os.inc
+++ b/meta-balena-common/conf/distro/include/balena-os.inc
@@ -100,11 +100,12 @@ PREFERRED_VERSION_upx-native:arm = "3.94"
 PREFERRED_VERSION_linux-firmware = "20210511"
 
 # Preferred rust version
-PREFERRED_VERSION_rust-native = "1.54.0"
-PREFERRED_VERSION_rust-cross-${TARGET_ARCH} = "1.54.0"
-PREFERRED_VERSION_rust-llvm-native = "1.54.0"
-PREFERRED_VERSION_cargo-native = "1.54.0"
-PREFERRED_VERSION_libstd-rs = "1.54.0"
+PREFERRED_VERSION_rust ?= "1.54.0"
+PREFERRED_VERSION_rust-native ?= "1.54.0"
+PREFERRED_VERSION_rust-cross-${TARGET_ARCH} ?= "1.54.0"
+PREFERRED_VERSION_rust-llvm-native ?= "1.54.0"
+PREFERRED_VERSION_cargo-native ?= "1.54.0"
+PREFERRED_VERSION_libstd-rs ?= "1.54.0"
 
 # balena-engine go version requirement
 GOVERSION = "1.12.17"

--- a/meta-balena-dunfell/conf/distro/include/balena-os-yocto-version.inc
+++ b/meta-balena-dunfell/conf/distro/include/balena-os-yocto-version.inc
@@ -1,5 +1,3 @@
-include conf/distro/include/security_flags.inc
-
 PREFERRED_VERSION_rust = "1.36.0"
 PREFERRED_VERSION_rust-native = "1.36.0"
 PREFERRED_VERSION_rust-cross-${TARGET_ARCH} = "1.36.0"

--- a/meta-balena-thud/conf/distro/include/balena-os-yocto-version.inc
+++ b/meta-balena-thud/conf/distro/include/balena-os-yocto-version.inc
@@ -1,5 +1,3 @@
-include conf/distro/include/security_flags.inc
-
 PREFERRED_VERSION_rust = "1.36.0"
 PREFERRED_VERSION_rust-native = "1.36.0"
 PREFERRED_VERSION_rust-cross-${TARGET_ARCH} = "1.36.0"

--- a/meta-balena-warrior/conf/distro/include/balena-os-yocto-version.inc
+++ b/meta-balena-warrior/conf/distro/include/balena-os-yocto-version.inc
@@ -1,5 +1,3 @@
-include conf/distro/include/security_flags.inc
-
 PREFERRED_VERSION_rust = "1.36.0"
 PREFERRED_VERSION_rust-native = "1.36.0"
 PREFERRED_VERSION_rust-cross-${TARGET_ARCH} = "1.36.0"

--- a/meta-resin-rocko/conf/distro/include/balena-os-yocto-version.inc
+++ b/meta-resin-rocko/conf/distro/include/balena-os-yocto-version.inc
@@ -1,1 +1,8 @@
 include conf/distro/include/security_flags.inc
+
+PREFERRED_VERSION_rust = "1.36.0"
+PREFERRED_VERSION_rust-native = "1.36.0"
+PREFERRED_VERSION_rust-cross-${TARGET_ARCH} = "1.36.0"
+PREFERRED_VERSION_rust-llvm-native = "1.36.0"
+PREFERRED_VERSION_cargo-native = "1.36.0"
+PREFERRED_VERSION_libstd-rs = "1.36.0"

--- a/meta-resin-sumo/conf/distro/include/balena-os-yocto-version.inc
+++ b/meta-resin-sumo/conf/distro/include/balena-os-yocto-version.inc
@@ -1,1 +1,8 @@
 include conf/distro/include/security_flags.inc
+
+PREFERRED_VERSION_rust = "1.36.0"
+PREFERRED_VERSION_rust-native = "1.36.0"
+PREFERRED_VERSION_rust-cross-${TARGET_ARCH} = "1.36.0"
+PREFERRED_VERSION_rust-llvm-native = "1.36.0"
+PREFERRED_VERSION_cargo-native = "1.36.0"
+PREFERRED_VERSION_libstd-rs = "1.36.0"


### PR DESCRIPTION
Poky releases older than Honister should stick to rust v1.36
which has been used in balenaOS builds so far.

Newer ones should prefer v1.54, which is the latest rust
version to use the Honister syntax.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
