### PR TITLE
meta-balena-common: Extend 64bit time support to other tools

### DIFF
--- a/meta-balena-common/conf/distro/include/balena-os.inc
+++ b/meta-balena-common/conf/distro/include/balena-os.inc
@@ -121,3 +121,10 @@ SIGN_EFI_KEY_ID ?= "balenaos-db"
 SIGN_KMOD_KEY_ID ?= "balenaos-kmod"
 SIGN_EFI_PK_KEY_ID ?= "balenaos-PK"
 SIGN_EFI_KEK_KEY_ID ?= "balenaos-KEK"
+
+# glibc enables 64bit time for stat and similar routines only if both
+# _FILE_OFFSET_BITS=64 and _TIME_BITS=64 are set on 32bit platforms.
+# We thus set them for the tools that read or modify config.json or other files
+# that may have an invalid modification date
+# See https://www.phoronix.com/scan.php?page=news_item&px=Glibc-More-Y2038-Work
+TARGET_CFLAGS += " -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64 "

--- a/meta-balena-common/recipes-core/glibc/glibc%.bbappend
+++ b/meta-balena-common/recipes-core/glibc/glibc%.bbappend
@@ -1,0 +1,8 @@
+# These flags are enabled system-wide
+# so that 32bit applications can succesfully
+# access files with invalid modification times (i.e config.json)
+# However, some packages fail to build with these
+# so we therefore remove them.
+# See https://www.phoronix.com/scan.php?page=news_item&px=Glibc-More-Y2038-Work
+TARGET_CFLAGS:remove = "-D_TIME_BITS=64"
+TARGET_CFLAGS:remove = "-D_FILE_OFFSET_BITS=64"

--- a/meta-balena-common/recipes-core/kbd/kbd_%.bbappend
+++ b/meta-balena-common/recipes-core/kbd/kbd_%.bbappend
@@ -1,0 +1,8 @@
+# These flags are enabled system-wide
+# so that 32bit kernels can succesfully
+# access files with invalid modification times (i.e config.json)
+# However, some packages fail to build with these
+# so we therefore remove them
+# See https://www.phoronix.com/scan.php?page=news_item&px=Glibc-More-Y2038-Work
+TARGET_CFLAGS:remove = "-D_TIME_BITS=64"
+TARGET_CFLAGS:remove = "-D_FILE_OFFSET_BITS=64"

--- a/meta-balena-common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-balena-common/recipes-core/systemd/systemd_%.bbappend
@@ -1,5 +1,13 @@
 FILESEXTRAPATHS:append := ":${THISDIR}/${PN}"
 
+# This flag is enabled system-wide
+# so that 32bit kernels can succesfully
+# access files with invalid modification times (i.e config.json)
+# However, some packages fail to build with this flag
+# so we therefore remove it only for them
+# See https://www.phoronix.com/scan.php?page=news_item&px=Glibc-More-Y2038-Work
+TARGET_CFLAGS:remove = "-D_TIME_BITS=64"
+
 SRC_URI:append = " \
     file://coredump.conf \
     file://reboot.target.conf \

--- a/meta-balena-common/recipes-core/zlib/zlib_%.bbappend
+++ b/meta-balena-common/recipes-core/zlib/zlib_%.bbappend
@@ -1,0 +1,7 @@
+# This flag is enabled system-wide
+# so that 32bit kernels can succesfully
+# access files with invalid modification times (i.e config.json)
+# However, some packages fail to build with this flag
+# so we therefore remove it only for them
+# See https://www.phoronix.com/scan.php?page=news_item&px=Glibc-More-Y2038-Work
+TARGET_CFLAGS:remove = "-D_TIME_BITS=64"

--- a/meta-balena-common/recipes-devtools/elfutils/elfutils_%.bbappend
+++ b/meta-balena-common/recipes-devtools/elfutils/elfutils_%.bbappend
@@ -1,0 +1,7 @@
+# These flags are enabled system-wide
+# so that 32bit kernels can succesfully
+# access files with invalid modification times (i.e config.json)
+# However, some packages fail to build with these
+# so we therefore remove them
+TARGET_CFLAGS:remove = "-D_TIME_BITS=64"
+TARGET_CFLAGS:remove = "-D_FILE_OFFSET_BITS=64"

--- a/meta-balena-common/recipes-devtools/gcc/gcc%.bbappend
+++ b/meta-balena-common/recipes-devtools/gcc/gcc%.bbappend
@@ -1,0 +1,7 @@
+# These flags are enabled system-wide
+# so that 32bit kernels can succesfully
+# access files with invalid modification times (i.e config.json)
+# However, some packages fail to build with these
+# so we therefore remove them
+TARGET_CFLAGS:remove = "-D_TIME_BITS=64"
+TARGET_CFLAGS:remove = "-D_FILE_OFFSET_BITS=64"

--- a/meta-balena-common/recipes-support/db/db_%.bbappend
+++ b/meta-balena-common/recipes-support/db/db_%.bbappend
@@ -1,0 +1,7 @@
+# This flag is enabled system-wide
+# so that 32bit applications can succesfully
+# access files with invalid modification times (i.e config.json)
+# However, some packages fail to build with this flag
+# so we therefore remove it only for them
+# See https://www.phoronix.com/scan.php?page=news_item&px=Glibc-More-Y2038-Work
+TARGET_CFLAGS:remove = "-D_TIME_BITS=64"

--- a/meta-balena-common/recipes-support/icu/icu_%.bbappend
+++ b/meta-balena-common/recipes-support/icu/icu_%.bbappend
@@ -1,0 +1,7 @@
+# This flag is enabled system-wide
+# so that 32bit kernels can succesfully
+# access files with invalid modification times (i.e config.json)
+# However, some packages fail to build with this flag
+# so we therefore remove it only for them
+# See https://www.phoronix.com/scan.php?page=news_item&px=Glibc-More-Y2038-Work
+TARGET_CFLAGS:remove = "-D_TIME_BITS=64"

--- a/meta-balena-common/recipes-support/libical/libical_%.bbappend
+++ b/meta-balena-common/recipes-support/libical/libical_%.bbappend
@@ -1,0 +1,7 @@
+# This flag is enabled system-wide
+# so that 32bit kernels can succesfully
+# access files with invalid modification times (i.e config.json)
+# However, some packages fail to build with this flag
+# so we therefore remove it only for them
+# See https://www.phoronix.com/scan.php?page=news_item&px=Glibc-More-Y2038-Work
+TARGET_CFLAGS:remove = "-D_TIME_BITS=64"


### PR DESCRIPTION
that manage config.json

We have noticed on the testbot Pi3 leviathan HUP test that
the modified date for config.json is 2098, and this
causes os-config to fail, as well as other tools like jq,
that edit or read config.json.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
