### PR TITLE
Update bootfiles timestamps

### DIFF
--- a/meta-balena-common/recipes-core/busybox/busybox_%.bbappend
+++ b/meta-balena-common/recipes-core/busybox/busybox_%.bbappend
@@ -7,3 +7,8 @@ SRC_URI:append = " \
 RDEPENDS:${PN}:append = " openssl"
 
 ALTERNATIVE_PRIORITY[hwclock] = "100"
+
+# glibc enables 64bit time for stat and similar routines only if both _FILE_OFFSET_BITS=64 and _TIME_BITS=64 are set on 32bit platforms.
+#
+#   See https://www.phoronix.com/scan.php?page=news_item&px=Glibc-More-Y2038-Work
+CFLAGS:append:class-target = " -DHAVE_PROC_UPTIME -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64"

--- a/meta-balena-common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-balena-common/recipes-core/systemd/systemd_%.bbappend
@@ -97,6 +97,10 @@ do_install:append() {
     install -m 0644 ${WORKDIR}/getty-target-development-features.conf ${D}${sysconfdir}/systemd/system/getty.target.d/development-features.conf
     install -d -m 0755 ${D}${sysconfdir}/systemd/system/getty@.service.d
     install -m 0644 ${WORKDIR}/getty-service-development-features.conf ${D}${sysconfdir}/systemd/system/getty@.service.d/development-features.conf
+
+    # We don't have audit configs enabled in the kernel, so we can remove the audit sockets
+    rm ${D}/lib/systemd/system/sockets.target.wants/systemd-journald-audit.socket || true
+    rm ${D}/lib/systemd/system/systemd-journald-audit.socket || true
 }
 
 PACKAGES =+ "${PN}-zram-swap"

--- a/meta-balena-common/recipes-extended/bash/bash_%.bbappend
+++ b/meta-balena-common/recipes-extended/bash/bash_%.bbappend
@@ -1,0 +1,4 @@
+# glibc enables 64bit time for stat and similar routines only if both _FILE_OFFSET_BITS=64 and _TIME_BITS=64 are set on 32bit platforms.
+#
+#   See https://www.phoronix.com/scan.php?page=news_item&px=Glibc-More-Y2038-Work
+CFLAGS:append:class-target = " -DHAVE_PROC_UPTIME -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64"

--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/1-bootfiles
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/1-bootfiles
@@ -168,6 +168,10 @@ for filepath in $(find /resin-boot -type f | sed 's#^/resin-boot##g'); do
 done
 echo "success."
 
+printf "[INFO] Updating timestamps for all files in ${boot_mountpoint}..."
+find "${boot_mountpoint}/" -exec touch {} +
+printf " done"
+
 # Deploy all files in the bootfiles list except fingerprint
 new_deployed_files=""
 for filepath in $(find /resin-boot -type f | sed 's#^/resin-boot##g'); do


### PR DESCRIPTION
    Files in the boot partition may have incorrect modification
    timestamps which can cause problems for programs that have
    been compiled against glibc 2.34 or newer. stat() fails in
    such cases with EOVERFLOW, so let's ensure that files have
    correct modification timestamps.

Connects to and needs to be included in: https://github.com/balena-os/balena-raspberrypi/pull/755



---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
