### PR TITLE
Don't update bootstamps on blacklisted files

### DIFF
--- a/meta-balena-common/recipes-devtools/jq/jq_%.bbappend
+++ b/meta-balena-common/recipes-devtools/jq/jq_%.bbappend
@@ -1,0 +1,4 @@
+# glibc enables 64bit time for stat and similar routines only if both _FILE_OFFSET_BITS=64 and _TIME_BITS=64 are set on 32bit platforms.
+# jq is used in the HUP scripts to access config.json.
+#   See https://www.phoronix.com/scan.php?page=news_item&px=Glibc-More-Y2038-Work
+CFLAGS:append:class-target = " -DHAVE_PROC_UPTIME -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64"

--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/1-bootfiles
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/1-bootfiles
@@ -169,8 +169,8 @@ done
 echo "success."
 
 printf "[INFO] Updating timestamps for all files in ${boot_mountpoint}..."
-find "${boot_mountpoint}/" -exec touch {} +
-printf " done"
+find /mnt/boot/ $(printf "! -name %s " $(for blacklisted_file in  $bootfiles_blacklist; do echo $blacklisted_file | awk -F'/' '{print $NF}'; done)) -exec touch {} +
+echo " done"
 
 # Deploy all files in the bootfiles list except fingerprint
 new_deployed_files=""


### PR DESCRIPTION
We noticed that when performing a touch on blacklisted files, like for instance config.json, in order to update their bootstamps, services are reloaded and this implies the registry on the DUT is also restarted. This happens when the starting BalenaOS version is newer and includes dev/prod unification. Also, the ssh connection over which hup is triggered (i.e webterminal) is lost when updating from the newer unified images.

This behavior isn't visible if testing from an older release, or if triggering hup from uart using a remote registry, i.e dockerhub.

The issue has been introduced in 2.88.22 in https://github.com/balena-os/meta-balena/commit/96cecbeac2887d2fc78817c9bfd10746bd139960 so in this PR we avoid touching files that are blacklisted and which may be watched by other services.

Testbot results in raspberrypi test PR: https://github.com/balena-os/balena-raspberrypi/pull/769


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
