### PR TITLE
initramfs-framework: Make cleaning udev database the last step

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -24,7 +24,7 @@ do_install:append() {
     install -m 0755 ${WORKDIR}/machineid ${D}/init.d/91-machineid
     install -m 0755 ${WORKDIR}/resindataexpander ${D}/init.d/88-resindataexpander
     install -m 0755 ${WORKDIR}/rorootfs ${D}/init.d/89-rorootfs
-    install -m 0755 ${WORKDIR}/udevcleanup ${D}/init.d/89-udevcleanup
+    install -m 0755 ${WORKDIR}/udevcleanup ${D}/init.d/98-udevcleanup
     install -m 0755 ${WORKDIR}/cryptsetup ${D}/init.d/72-cryptsetup
     install -m 0755 ${WORKDIR}/kexec ${D}/init.d/92-kexec
 }
@@ -84,4 +84,4 @@ FILES:initramfs-module-kexec = "/init.d/92-kexec"
 
 SUMMARY:initramfs-module-udevcleanaup = "Cleanup the udev database before transitioning to the rootfs"
 RDEPENDS:initramfs-module-udevcleanaup = "${PN}-base"
-FILES:initramfs-module-udevcleanup = "/init.d/89-udevcleanup"
+FILES:initramfs-module-udevcleanup = "/init.d/98-udevcleanup"


### PR DESCRIPTION
To avoid issues, move the udev database cleanup just before switching
roots.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
