### PR TITLE
Ryan/boot splash improvement

### DIFF
--- a/tests/suites/os/tests/boot-splash/index.js
+++ b/tests/suites/os/tests/boot-splash/index.js
@@ -108,7 +108,7 @@ module.exports = {
 					});
 
 					let testDistance = hammingDistance(referenceHash, capturedHash);
-					if (testDistance < 20) {
+					if (testDistance < 23) {
 						test.comment(
 							`Found match, image ${image}, hamming distance from reference: ${testDistance}`,
 						);


### PR DESCRIPTION
This PR has 2 improvements to the boot-splash test
1. relax the comparison between the reference image and the captured image - this will let us run this test with a greater range of hdmi capture devices
2. Make the test execute only when the HDMI capture hardware is attached to the worker. This is reliant on these 2 PRs being merged: https://github.com/balena-os/leviathan/pull/630 and https://github.com/balena-os/meta-balena/pull/2478

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
