### PR TITLE
u-boot: Move config fragments merging code out of common layer

### DIFF
--- a/meta-balena-thud/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-balena-thud/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -10,7 +10,7 @@ inherit uboot-config uboot-extlinux-config uboot-sign deploy cml1
 # break do_install without additional changes to do_compile first
 # https://github.com/balena-os/poky/commit/d7b8ae3faa9344f2ada22e0402066c2fff5958c6
 UBOOT_INITIAL_ENV = ""
-ALLOW_EMPTY:${PN}-env = "1"
+ALLOW_EMPTY_${PN}-env = "1"
 
 # returns all the elements from the src uri that are .cfg files
 def find_cfgs(d):

--- a/meta-resin-pyro/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-resin-pyro/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,0 +1,79 @@
+# Since 11278e3b2c75be80645b9841763a97dbb35daadc u-boot.inc has support
+# for ammending the bsp uboot with config fragments. We copy that
+# over in meta-balena-common to apply to pre-warrior layers.
+
+DEPENDS += "kern-tools-native"
+
+inherit uboot-config uboot-extlinux-config uboot-sign deploy cml1
+
+# disable u-boot-initial-env as we don't need it and it would
+# break do_install without additional changes to do_compile first
+# https://github.com/balena-os/poky/commit/d7b8ae3faa9344f2ada22e0402066c2fff5958c6
+UBOOT_INITIAL_ENV = ""
+ALLOW_EMPTY_${PN}-env = "1"
+
+# returns all the elements from the src uri that are .cfg files
+def find_cfgs(d):
+    sources=src_patches(d, True)
+    sources_list=[]
+    for s in sources:
+        if s.endswith('.cfg'):
+            sources_list.append(s)
+
+    return sources_list
+
+do_configure () {
+    if [ -z "${UBOOT_CONFIG}" ]; then
+        if [ -n "${UBOOT_MACHINE}" ]; then
+            oe_runmake -C ${S} O=${B} ${UBOOT_MACHINE}
+        else
+            oe_runmake -C ${S} O=${B} oldconfig
+        fi
+        merge_config.sh -m .config ${@" ".join(find_cfgs(d))}
+        cml1_do_configure
+    fi
+}
+
+do_compile () {
+	if [ "${@bb.utils.filter('DISTRO_FEATURES', 'ld-is-gold', d)}" ]; then
+		sed -i 's/$(CROSS_COMPILE)ld$/$(CROSS_COMPILE)ld.bfd/g' ${S}/config.mk
+	fi
+
+	unset LDFLAGS
+	unset CFLAGS
+	unset CPPFLAGS
+
+	if [ ! -e ${B}/.scmversion -a ! -e ${S}/.scmversion ]
+	then
+		echo ${UBOOT_LOCALVERSION} > ${B}/.scmversion
+		echo ${UBOOT_LOCALVERSION} > ${S}/.scmversion
+	fi
+
+    if [ -n "${UBOOT_CONFIG}" ]
+    then
+        unset i j k
+        for config in ${UBOOT_MACHINE}; do
+            i=$(expr $i + 1);
+            for type in ${UBOOT_CONFIG}; do
+                j=$(expr $j + 1);
+                if [ $j -eq $i ]
+                then
+                    oe_runmake -C ${S} O=${B}/${config} ${config}
+                    oe_runmake -C ${S} O=${B}/${config} ${UBOOT_MAKE_TARGET}
+                    for binary in ${UBOOT_BINARIES}; do
+                        k=$(expr $k + 1);
+                        if [ $k -eq $i ]; then
+                            cp ${B}/${config}/${binary} ${B}/${config}/u-boot-${type}.${UBOOT_SUFFIX}
+                        fi
+                    done
+                    unset k
+                fi
+            done
+            unset  j
+        done
+        unset  i
+    else
+        oe_runmake -C ${S} O=${B} ${UBOOT_MAKE_TARGET}
+    fi
+
+}

--- a/meta-resin-rocko/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-resin-rocko/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,0 +1,79 @@
+# Since 11278e3b2c75be80645b9841763a97dbb35daadc u-boot.inc has support
+# for ammending the bsp uboot with config fragments. We copy that
+# over in meta-balena-common to apply to pre-warrior layers.
+
+DEPENDS += "kern-tools-native"
+
+inherit uboot-config uboot-extlinux-config uboot-sign deploy cml1
+
+# disable u-boot-initial-env as we don't need it and it would
+# break do_install without additional changes to do_compile first
+# https://github.com/balena-os/poky/commit/d7b8ae3faa9344f2ada22e0402066c2fff5958c6
+UBOOT_INITIAL_ENV = ""
+ALLOW_EMPTY_${PN}-env = "1"
+
+# returns all the elements from the src uri that are .cfg files
+def find_cfgs(d):
+    sources=src_patches(d, True)
+    sources_list=[]
+    for s in sources:
+        if s.endswith('.cfg'):
+            sources_list.append(s)
+
+    return sources_list
+
+do_configure () {
+    if [ -z "${UBOOT_CONFIG}" ]; then
+        if [ -n "${UBOOT_MACHINE}" ]; then
+            oe_runmake -C ${S} O=${B} ${UBOOT_MACHINE}
+        else
+            oe_runmake -C ${S} O=${B} oldconfig
+        fi
+        merge_config.sh -m .config ${@" ".join(find_cfgs(d))}
+        cml1_do_configure
+    fi
+}
+
+do_compile () {
+	if [ "${@bb.utils.filter('DISTRO_FEATURES', 'ld-is-gold', d)}" ]; then
+		sed -i 's/$(CROSS_COMPILE)ld$/$(CROSS_COMPILE)ld.bfd/g' ${S}/config.mk
+	fi
+
+	unset LDFLAGS
+	unset CFLAGS
+	unset CPPFLAGS
+
+	if [ ! -e ${B}/.scmversion -a ! -e ${S}/.scmversion ]
+	then
+		echo ${UBOOT_LOCALVERSION} > ${B}/.scmversion
+		echo ${UBOOT_LOCALVERSION} > ${S}/.scmversion
+	fi
+
+    if [ -n "${UBOOT_CONFIG}" ]
+    then
+        unset i j k
+        for config in ${UBOOT_MACHINE}; do
+            i=$(expr $i + 1);
+            for type in ${UBOOT_CONFIG}; do
+                j=$(expr $j + 1);
+                if [ $j -eq $i ]
+                then
+                    oe_runmake -C ${S} O=${B}/${config} ${config}
+                    oe_runmake -C ${S} O=${B}/${config} ${UBOOT_MAKE_TARGET}
+                    for binary in ${UBOOT_BINARIES}; do
+                        k=$(expr $k + 1);
+                        if [ $k -eq $i ]; then
+                            cp ${B}/${config}/${binary} ${B}/${config}/u-boot-${type}.${UBOOT_SUFFIX}
+                        fi
+                    done
+                    unset k
+                fi
+            done
+            unset  j
+        done
+        unset  i
+    else
+        oe_runmake -C ${S} O=${B} ${UBOOT_MAKE_TARGET}
+    fi
+
+}

--- a/meta-resin-sumo/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-resin-sumo/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,0 +1,79 @@
+# Since 11278e3b2c75be80645b9841763a97dbb35daadc u-boot.inc has support
+# for ammending the bsp uboot with config fragments. We copy that
+# over in meta-balena-common to apply to pre-warrior layers.
+
+DEPENDS += "kern-tools-native"
+
+inherit uboot-config uboot-extlinux-config uboot-sign deploy cml1
+
+# disable u-boot-initial-env as we don't need it and it would
+# break do_install without additional changes to do_compile first
+# https://github.com/balena-os/poky/commit/d7b8ae3faa9344f2ada22e0402066c2fff5958c6
+UBOOT_INITIAL_ENV = ""
+ALLOW_EMPTY_${PN}-env = "1"
+
+# returns all the elements from the src uri that are .cfg files
+def find_cfgs(d):
+    sources=src_patches(d, True)
+    sources_list=[]
+    for s in sources:
+        if s.endswith('.cfg'):
+            sources_list.append(s)
+
+    return sources_list
+
+do_configure () {
+    if [ -z "${UBOOT_CONFIG}" ]; then
+        if [ -n "${UBOOT_MACHINE}" ]; then
+            oe_runmake -C ${S} O=${B} ${UBOOT_MACHINE}
+        else
+            oe_runmake -C ${S} O=${B} oldconfig
+        fi
+        merge_config.sh -m .config ${@" ".join(find_cfgs(d))}
+        cml1_do_configure
+    fi
+}
+
+do_compile () {
+	if [ "${@bb.utils.filter('DISTRO_FEATURES', 'ld-is-gold', d)}" ]; then
+		sed -i 's/$(CROSS_COMPILE)ld$/$(CROSS_COMPILE)ld.bfd/g' ${S}/config.mk
+	fi
+
+	unset LDFLAGS
+	unset CFLAGS
+	unset CPPFLAGS
+
+	if [ ! -e ${B}/.scmversion -a ! -e ${S}/.scmversion ]
+	then
+		echo ${UBOOT_LOCALVERSION} > ${B}/.scmversion
+		echo ${UBOOT_LOCALVERSION} > ${S}/.scmversion
+	fi
+
+    if [ -n "${UBOOT_CONFIG}" ]
+    then
+        unset i j k
+        for config in ${UBOOT_MACHINE}; do
+            i=$(expr $i + 1);
+            for type in ${UBOOT_CONFIG}; do
+                j=$(expr $j + 1);
+                if [ $j -eq $i ]
+                then
+                    oe_runmake -C ${S} O=${B}/${config} ${config}
+                    oe_runmake -C ${S} O=${B}/${config} ${UBOOT_MAKE_TARGET}
+                    for binary in ${UBOOT_BINARIES}; do
+                        k=$(expr $k + 1);
+                        if [ $k -eq $i ]; then
+                            cp ${B}/${config}/${binary} ${B}/${config}/u-boot-${type}.${UBOOT_SUFFIX}
+                        fi
+                    done
+                    unset k
+                fi
+            done
+            unset  j
+        done
+        unset  i
+    else
+        oe_runmake -C ${S} O=${B} ${UBOOT_MAKE_TARGET}
+    fi
+
+}


### PR DESCRIPTION
Let's only apply this code to pre-warrior as intended. Starting
with warrior this code is in poky so we can rely on it from
there instead of keeping a duplicate in meta-balena-common.
This helps with BSPs that may define their own tasks (configure,
compile and so on) for u-boot (keeping this fragments merging
code in meta-balena-common would have the effect of overwriting
these tasks from here and thus breaking the build).

Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
