### PR TITLE
docker-disk: Tag the supervisor digest with the repo name

### DIFF
--- a/meta-balena-common/recipes-containers/docker-disk/files/entry.sh
+++ b/meta-balena-common/recipes-containers/docker-disk/files/entry.sh
@@ -65,7 +65,12 @@ done
 if [ -n "${TARGET_REPOSITORY}" ] && [ -n "${TARGET_TAG}" ]; then
 	_supervisor_image=$(balena_api_fetch_image_from_app "${TARGET_REPOSITORY}" "${TARGET_TAG#v}" "${BALENA_API_ENV}" "${BALENA_API_TOKEN}")
 	echo "Pulling ${TARGET_REPOSITORY}:${TARGET_TAG}"
-	docker pull "${_supervisor_image}"
+	if docker pull "${_supervisor_image}"; then
+		docker tag "${_supervisor_image}" "${_supervisor_image%@*}"
+	else
+		echo "Not able to pull ${_supervisor_image}"
+		exit 1
+	fi
 fi
 
 echo "Stopping docker..."


### PR DESCRIPTION
This will allow us to refer to the supervisor image by the repo name
in docker commands, like docker inspect, and prevent re-downloading the
image even though it already exists as an untagged digest.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/balena-os/meta-balena/issues/2492

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
