### PR TITLE
resin-u-boot.bbclass: Do not error if no config_defaults.h

### DIFF
--- a/meta-balena-common/classes/resin-u-boot.bbclass
+++ b/meta-balena-common/classes/resin-u-boot.bbclass
@@ -99,7 +99,7 @@ do_generate_resin_uboot_configuration[vardeps] += "${UBOOT_VARS}"
 # config_default to be able to inject config options that aren't
 # changeable via Kconfig and config fragments.
 do_inject_config_resin () {
-    sed -i '/^#endif.*/i #include <config_resin.h>' ${S}/include/config_defaults.h
+    sed -i '/^#endif.*/i #include <config_resin.h>' ${S}/include/config_defaults.h || true
 }
 
 do_deploy:append() {


### PR DESCRIPTION
The header has been removed in this commit:
https://github.com/u-boot/u-boot/commit
/5c6a4d5a2779d7c2611319076d9aa4a23981855f

Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
