### PR TITLE
fix cloud suite teardown

### DIFF
--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -276,16 +276,6 @@ module.exports = {
     if (supportsBootConfig(this.suite.deviceType.slug)) {
       await enableSerialConsole(this.context.get().os.image.path);
     }
-
-
-    this.suite.teardown.register(async () => {
-      await this.archiver.add(this.id, this.context.get().os.image.path);
-    });
-
-
-    this.suite.teardown.register(async () => {
-      await this.context.get().worker.archiveLogs(this.id,  `${this.context.get().balena.uuid.slice(0, 7)}.local`,);
-    });
     
     await this.context.get().worker.off();
     await this.context.get().worker.flash(this.context.get().os.image.path);
@@ -330,6 +320,10 @@ module.exports = {
 
       return unpinned
     }, false);
+
+    this.suite.teardown.register(async () => {
+      await this.context.get().worker.archiveLogs(this.id,  `${this.context.get().balena.uuid.slice(0, 7)}.local`,);
+    });
 
     // wait until the service is running before continuing
     await this.context.get().cloud.waitUntilServicesRunning(


### PR DESCRIPTION
This patch to the cloud suite is an attempt to stop a problem happening in the teardown. When used with real hardware, there's a possibility that some problem in the teardown leads to the core service crashing, which then can ruin the next test: example is here: https://jenkins.product-os.io/job/leviathan-raspberrypi4-64/1007/

I remove the archiving of the image during the teardown as it is no longer needed, and takes a long time. I think this long time when done on the testbot is partly responsible for the teardown problems in the cloud suite.

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
