### PR TITLE
[tests]: Add under-voltage check for OS and HUP suites

### DIFF
--- a/tests/suites/hup/suite.js
+++ b/tests/suites/hup/suite.js
@@ -37,6 +37,24 @@ const supportsBootConfig = (deviceType) => {
 	);
 };
 
+const checkUnderVoltage = async (that, test) => {
+	test.comment(`checking for under-voltage reports in kernel logs...`);
+	let result = '';
+	result = await that.context
+			.get()
+			.worker.executeCommandInHostOS(
+				`dmesg | grep -q "Under-voltage detected" ; echo $?`,
+				that.context.get().link,
+			);
+
+	if (result.includes('0')) {
+		test.comment(`not ok! - Under-voltage detected on device, please check power source and cable!`);
+	} else {
+		test.comment(`ok - No under-voltage reports in the kernel logs`);
+	}
+};
+
+
 const enableSerialConsole = async (imagePath) => {
 	const bootConfig = await imagefs.interact(imagePath, 1, async (_fs) => {
 		return require('bluebird')
@@ -227,6 +245,7 @@ module.exports = {
 
 		this.suite.context.set({
 			hup: {
+				checkUnderVoltage: checkUnderVoltage,
 				doHUP: doHUP,
 				initDUT: initDUT,
 				runRegistry: runRegistry,

--- a/tests/suites/hup/tests/smoke.js
+++ b/tests/suites/hup/tests/smoke.js
@@ -17,6 +17,14 @@ module.exports = {
 
 		test.comment(`OS version before HUP: ${versionBeforeHup}`);
 
+		// Check for under-voltage before HUP, in the old OS
+		await this.context
+			.get()
+			.hup.checkUnderVoltage(
+				this,
+				test
+			);
+
 		await this.context
 			.get()
 			.worker.executeCommandInHostOS(
@@ -118,5 +126,13 @@ module.exports = {
 			'0',
 			'Volume should not be lost during HUP',
 		);
+
+		// Check for under-voltage after HUP, in the new OS
+		await this.context
+			.get()
+			.hup.checkUnderVoltage(
+				this,
+				test
+			);
 	},
 };

--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -252,6 +252,7 @@ module.exports = {
 		'./tests/boot-splash',
 		'./tests/connectivity',
 		'./tests/engine-socket',
+		'./tests/under-voltage',
 		'./tests/udev',
 		'./tests/device-tree',
 		'./tests/purge-data',

--- a/tests/suites/os/tests/under-voltage/index.js
+++ b/tests/suites/os/tests/under-voltage/index.js
@@ -1,0 +1,21 @@
+module.exports = {
+	title: 'Under-voltage test',
+	run: async function(test) {
+		test.comment(`Checking for under-voltage reports in kernel logs...`);
+		let result = '';
+		result = await this.context
+			.get()
+			.worker.executeCommandInHostOS(
+				`dmesg | grep -q "Under-voltage detected" ; echo $?`,
+				this.context.get().link,
+			);
+
+		if (result.includes('0')) {
+			test.comment(`not ok! - Under-voltage detected on device, please check power source and cable!`);
+		} else {
+			test.comment(`ok - No under-voltage reports in the kernel logs`);
+		}
+
+		test.is(true, true, 'Under-voltage check completed');
+	},
+};


### PR DESCRIPTION
We add this this check since we discovered
that with newer boot firmware the Pi4 will
not reboot when under-voltage is reported.

We do not mark the test as failed in
this case, since there may be devices that
continue to work even if under-powered and we
do not want to block or delay development if the
DUT is remote and cannot be checked or replaced
easily.

This check provides an indication for further
debugging of failed test cases.




---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
