### PR TITLE
openvpn: Remove dependency on timesync-http target

### DIFF
--- a/meta-balena-common/recipes-connectivity/openvpn/files/openvpn.service
+++ b/meta-balena-common/recipes-connectivity/openvpn/files/openvpn.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=OpenVPN
-Requires=prepare-openvpn.service bind-etc-openvpn.service time-sync-https-wait.target
-After=syslog.target network.target prepare-openvpn.service bind-etc-openvpn.service time-sync-https-wait.target
+Requires=prepare-openvpn.service bind-etc-openvpn.service
+After=syslog.target network.target prepare-openvpn.service bind-etc-openvpn.service
 ConditionFileNotEmpty=/etc/openvpn/openvpn.conf
 
 [Service]


### PR DESCRIPTION
We want the VPN to start unconditionally even if the connectivity URL
is not reachable.

The rationale for adding the dependency in the first place was that
without an initial timesync certificate checks may fail. This can still
happen, but the VPN will retry continuously and eventually succeed once
the time is synched.

What happens now is that the VPN is delayed until the http sync, so if
the connectivity URL is blocked or unreachable, but the internet is
accessible, VPN will not even launch and no remote debugging is possible.

Fixes #2508

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
