### PR TITLE
hostapp-update: Mount data partition on target balena/tmp

### DIFF
--- a/meta-balena-common/recipes-containers/hostapp-update/files/hostapp-update
+++ b/meta-balena-common/recipes-containers/hostapp-update/files/hostapp-update
@@ -40,6 +40,7 @@ fi
 
 export DOCKER_HOST="unix:///var/run/balena-host.sock"
 SYSROOT="/mnt/sysroot/inactive"
+LOADTMP="/mnt/data/resin-data/tmp"
 
 if [ -d /mnt/state ]; then
 	# Save VPN state for rollbacks
@@ -80,7 +81,18 @@ done
 
 # Load new hostapp
 if [ "$local_image" != "" ]; then
+	# bind mount the data partition for temporary extract/load files
+	if ! mountpoint "${SYSROOT}/balena/tmp"; then
+		mkdir -p "${LOADTMP}"
+		mount --bind "${LOADTMP}" "${SYSROOT}/balena/tmp"
+	fi
+
+	# load a local image tarball
 	HOSTAPP_IMAGE=$(balena load --quiet -i "$local_image" | cut -d: -f1 --complement | tr -d ' ')
+
+	# attempt to unmount and clean up the temporary extract/load files but ignore failures
+	umount "${SYSROOT}/balena/tmp" || true
+	rm -rf "${LOADTMP}" || true
 elif [ "$remote_image" != "" ]; then
 	HOSTAPP_IMAGE="$remote_image"
 	balena pull "$HOSTAPP_IMAGE"


### PR DESCRIPTION
In most cases there is not enough space on rootfs to extract
and load a local hostapp image when the balena-host tmpdir
is on the same partition.

This uses a tmpfs mount to ensure temporary extracted files of the
compressed image will not fill the target sysroot.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/balena-os/meta-balena/issues/2507

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
