### PR TITLE
fix journal log retrieval in cloud suite, and try to make override lock test consistant

### DIFF
--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -281,6 +281,10 @@ module.exports = {
     await this.context.get().worker.flash(this.context.get().os.image.path);
     await this.context.get().worker.on();
 
+    this.suite.teardown.register(async () => {
+      await this.context.get().worker.archiveLogs(this.id, `${this.context.get().balena.uuid.slice(0, 7)}.local`,);
+    });
+
     this.log("Waiting for device to be reachable");
     await this.context.get().utils.waitUntil(async() => {
       console.log(`checking device is online in the dashboard....`)
@@ -320,10 +324,6 @@ module.exports = {
 
       return unpinned
     }, false);
-
-    this.suite.teardown.register(async () => {
-      await this.context.get().worker.archiveLogs(this.id,  `${this.context.get().balena.uuid.slice(0, 7)}.local`,);
-    });
 
     // wait until the service is running before continuing
     await this.context.get().cloud.waitUntilServicesRunning(

--- a/tests/suites/cloud/tests/supervisor/index.js
+++ b/tests/suites/cloud/tests/supervisor/index.js
@@ -127,10 +127,15 @@ module.exports = {
           `Release should be downloaded, but not running due to lockfile`
         );
 
-        let updatesLocked = await this.context.get().cloud.checkLogsContain(
-          this.context.get().balena.uuid, 
-          `Updates are locked`,           
-        );
+        let updatesLocked = false;
+        await this.context.get().utils.waitUntil(async () => {
+          updatesLocked = await this.context.get().cloud.checkLogsContain(
+            this.context.get().balena.uuid, 
+            `Updates are locked`
+          );
+
+          return updatesLocked === true
+        })
 
         test.ok(updatesLocked, `Update lock message should appear in logs`)
 


### PR DESCRIPTION
This addresses 2 issues:

1. If the cloud test suite failed before the DUT would connect to balenaCloud, there would be no journal logs stored - making it impossible to determine why.
2. The `Override lock test` was flaking, with the `Updates are locked` message not appearing in the DUT logs - I think this most likely would be due to a race condition, as we check the logs only once. If this check happens too quickly, there is a chance that the message wouldn't have appeared yet. I added a retry to this check. It can be seen in this job: https://jenkins.product-os.io/job/leviathan-genericx86-64-ext/407/ where the test fails, that the update lock message does appear (check the journal logs stored in `artifacts-localho-cloud.tar.gz`



[artifacts-localho-cloud.tar.gz](https://jenkins.product-os.io/job/leviathan-genericx86-64-ext/407/artifact/reports/artifacts-localho-cloud.tar.gz)

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
