### PR TITLE
tests/os: Wait for os-config-json service to be inactive

### DIFF
--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -85,7 +85,7 @@ module.exports = {
 					async () => {
 						return worker
 							.executeCommandInHostOS(
-								`systemctl is-active ${serviceName}`,
+								`systemctl is-active ${serviceName} || true`,
 								target,
 							)
 							.then((serviceStatus) => {


### PR DESCRIPTION
Wait for os-config-json service to be inactive between tests
so the next changes to config.json are not missed by systemd.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
