### PR TITLE
tests/cloud: Set track latest once, then loop to confirm

### DIFF
--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -313,20 +313,20 @@ module.exports = {
       return hostname === this.context.get().balena.uuid.slice(0, 7)
     }, false);
 
-    this.log("Unpinning");
-    await this.context.get().utils.waitUntil(async () => {
-      this.log(`Unpinning device from release`)
-      await this.context
+    this.log(`Unpinning device from release`)
+    await this.context
       .get()
       .cloud.balena.models.device.trackApplicationRelease(
         this.context.get().balena.uuid
-      );
+    );
 
-      let unpinned = await this.context
-      .get()
-      .cloud.balena.models.device.isTrackingApplicationRelease(this.context.get().balena.uuid)
-
-      return unpinned
+    await this.context.get().utils.waitUntil(async () => {
+      console.log('Checking all services are running latest commit...')
+      return await this.context
+        .get()
+        .cloud.balena.models.device.isTrackingApplicationRelease(
+          this.context.get().balena.uuid
+        )
     }, false);
 
     // wait until the service is running before continuing


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
