### PR TITLE
recipes-devtools/e2fsprogs: Bring in e2fsprogs recipe from poky master

### DIFF
--- a/meta-balena-common/recipes-devtools/e2fsprogs/e2fsprogs.inc
+++ b/meta-balena-common/recipes-devtools/e2fsprogs/e2fsprogs.inc
@@ -1,0 +1,27 @@
+SUMMARY = "Ext2 Filesystem Utilities"
+DESCRIPTION = "The Ext2 Filesystem Utilities (e2fsprogs) contain all of the standard utilities for creating, \
+fixing, configuring , and debugging ext2 filesystems."
+HOMEPAGE = "http://e2fsprogs.sourceforge.net/"
+
+LICENSE = "GPLv2 & LGPLv2 & BSD-3-Clause & MIT"
+LICENSE:e2fsprogs-dumpe2fs = "GPLv2"
+LICENSE:e2fsprogs-e2fsck = "GPLv2"
+LICENSE:e2fsprogs-mke2fs = "GPLv2"
+LICENSE:e2fsprogs-tune2fs = "GPLv2"
+LICENSE:e2fsprogs-badblocks = "GPLv2"
+LIC_FILES_CHKSUM = "file://NOTICE;md5=d50be0580c0b0a7fbc7a4830bbe6c12b \
+                      file://lib/ext2fs/ext2fs.h;beginline=1;endline=9;md5=596a8dedcb4e731c6b21c7a46fba6bef \
+                      file://lib/e2p/e2p.h;beginline=1;endline=7;md5=8a74ade8f9d65095d70ef2d4bf48e36a \
+                      file://lib/uuid/uuid.h.in;beginline=1;endline=32;md5=dbb8079e114a5f841934b99e59c8820a \
+                      file://lib/uuid/COPYING;md5=58dcd8452651fc8b07d1f65ce07ca8af \
+                      file://lib/et/et_name.c;beginline=1;endline=11;md5=ead236447dac7b980dbc5b4804d8c836 \
+                      file://lib/ss/ss.h;beginline=1;endline=20;md5=6e89ad47da6e75fecd2b5e0e81e1d4a6"
+SECTION = "base"
+DEPENDS = "util-linux attr autoconf-archive"
+
+SRC_URI = "git://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git"
+S = "${WORKDIR}/git"
+
+inherit autotools gettext texinfo pkgconfig multilib_header update-alternatives ptest
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-balena-common/recipes-devtools/e2fsprogs/e2fsprogs/0001-tests-u_direct_io-expect-correct-expected-output.patch
+++ b/meta-balena-common/recipes-devtools/e2fsprogs/e2fsprogs/0001-tests-u_direct_io-expect-correct-expected-output.patch
@@ -1,0 +1,69 @@
+From ea5adf259e01c790f9ba69d6fe88d691de410b6f Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Sun, 22 Aug 2021 14:37:32 +0200
+Subject: [PATCH] tests/u_direct_io/expect: correct expected output
+
+This is likely the right fix, but upstream needs to confirm.
+
+Upstream-Status: Inappropriate [issue reported https://github.com/tytso/e2fsprogs/issues/80]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ tests/u_direct_io/expect | 16 +++++++++-------
+ 1 file changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/tests/u_direct_io/expect b/tests/u_direct_io/expect
+index b0cdc730..830cbd75 100644
+--- a/tests/u_direct_io/expect
++++ b/tests/u_direct_io/expect
+@@ -19,8 +19,8 @@ Filesystem OS type:       Linux
+ Inode count:              32768
+ Block count:              32768
+ Reserved block count:     1638
+-Overhead clusters:        5131
+-Free blocks:              27631
++Overhead clusters:        6155
++Free blocks:              26607
+ Free inodes:              32757
+ First block:              0
+ Block size:               4096
+@@ -29,27 +29,29 @@ Reserved GDT blocks:      7
+ Blocks per group:         32768
+ Fragments per group:      32768
+ Inodes per group:         32768
+-Inode blocks per group:   1024
++Inode blocks per group:   2048
+ Flex block group size:    16
+ Mount count:              0
+ Check interval:           15552000 (6 months)
+ Reserved blocks uid:      0
+ Reserved blocks gid:      0
+ First inode:              11
+-Inode size:	          128
++Inode size:	          256
++Required extra isize:     32
++Desired extra isize:      32
+ Journal inode:            8
+ Default directory hash:   half_md4
+ Journal backup:           inode blocks
+ Directories:              2
+  Group  0: block bitmap at 9, inode bitmap at 25, inode table at 41
+-           27631 free blocks, 32757 free inodes, 2 used directories
++           26607 free blocks, 32757 free inodes, 2 used directories
+ e2fsck -fn -N test_filesys $LOOP
+ Pass 1: Checking inodes, blocks, and sizes
+ Pass 2: Checking directory structure
+ Pass 3: Checking directory connectivity
+ Pass 4: Checking reference counts
+ Pass 5: Checking group summary information
+-test_filesys: 11/32768 files (9.1% non-contiguous), 5137/32768 blocks
++test_filesys: 11/32768 files (9.1% non-contiguous), 6161/32768 blocks
+ Exit status is 0
+ e2fsck -fn -N test_filesys $TMPFILE
+ Pass 1: Checking inodes, blocks, and sizes
+@@ -57,5 +59,5 @@ Pass 2: Checking directory structure
+ Pass 3: Checking directory connectivity
+ Pass 4: Checking reference counts
+ Pass 5: Checking group summary information
+-test_filesys: 11/32768 files (9.1% non-contiguous), 5137/32768 blocks
++test_filesys: 11/32768 files (9.1% non-contiguous), 6161/32768 blocks
+ Exit status is 0

--- a/meta-balena-common/recipes-devtools/e2fsprogs/e2fsprogs/e2fsprogs-fix-missing-check-for-permission-denied.patch
+++ b/meta-balena-common/recipes-devtools/e2fsprogs/e2fsprogs/e2fsprogs-fix-missing-check-for-permission-denied.patch
@@ -1,0 +1,33 @@
+From f1e161a48f74b46ae3c99921971c4b5ae8d587c9 Mon Sep 17 00:00:00 2001
+From: Jackie Huang <jackie.huang@windriver.com>
+Date: Wed, 10 Aug 2016 11:19:44 +0800
+Subject: [PATCH] Fix missing check for permission denied.
+
+If the path to "ROOT_SYSCONFDIR/mke2fs.conf" has a permission denied problem,
+then the get_dirlist() call will return EACCES. But the code in profile_init
+will treat that as a fatal error and all executions will fail with:
+      Couldn't init profile successfully (error: 13).
+
+Upstream-Status: Pending
+
+Written-by: Henrik Wallin <henrik.b.wallin@ericsson.com>
+
+Signed-off-by: Jackie Huang <jackie.huang@windriver.com>
+
+---
+ lib/support/profile.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/support/profile.c b/lib/support/profile.c
+index f54739e7..53ea68f1 100644
+--- a/lib/support/profile.c
++++ b/lib/support/profile.c
+@@ -335,7 +335,7 @@ profile_init(const char * const *files, profile_t *ret_profile)
+ 				*last = new_file;
+ 				last = &new_file->next;
+ 			}
+-		} else if ((retval != ENOTDIR) &&
++		} else if ((retval != ENOTDIR) && (retval != EACCES) &&
+ 			   strcmp(*fs, default_filename))
+ 			goto errout;
+ 

--- a/meta-balena-common/recipes-devtools/e2fsprogs/e2fsprogs/mkdir_p.patch
+++ b/meta-balena-common/recipes-devtools/e2fsprogs/e2fsprogs/mkdir_p.patch
@@ -1,0 +1,29 @@
+From e3a30baa5c1e2f0ac7e246539db1c7db5a2fe302 Mon Sep 17 00:00:00 2001
+From: Joe Slater <jslater@windriver.com>
+Date: Tue, 7 Mar 2017 14:53:19 -0800
+Subject: [PATCH] e2fsprogs: expand @mkdir_p@
+
+Add AC_SUBST to configure.ac.  @mkdir_p@ is currently
+not expanded so no locale data is written into usr/share/locale.
+
+Upstream-Status: Pending
+
+Signed-off-by: Joe Slater <jslater@windriver.com>
+
+---
+ configure.ac | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index 4c4b5523..3475c707 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -919,6 +919,8 @@ AC_SUBST(PACKAGE)
+ AC_SUBST(VERSION)
+ 
+ AM_GNU_GETTEXT([external])
++dnl @MKDIR_P@ is expanded in AM_GNU_GETTEXT
++AC_SUBST([mkdir_p],['$(MKDIR_P)'])
+ dnl
+ dnl End of configuration options
+ dnl

--- a/meta-balena-common/recipes-devtools/e2fsprogs/e2fsprogs/ptest.patch
+++ b/meta-balena-common/recipes-devtools/e2fsprogs/e2fsprogs/ptest.patch
@@ -1,0 +1,83 @@
+From b8842065ad621a03a971dfd50db862c5bffdeb49 Mon Sep 17 00:00:00 2001
+From: Dmitry Eremin-Solenikov <dmitry_eremin@mentor.com>
+Date: Sat, 18 Apr 2015 17:58:17 +0300
+Subject: [PATCH] e2fsprogs: add ptest
+
+Upstream-Status: Inappropriate
+
+Rebase for e2fsprogs 1.45.3.
+
+Signed-off-by: Kai Kang <kai.kang@windriver.com>
+---
+ tests/Makefile.in |  4 ++--
+ tests/test_config | 32 ++++++++++++++++----------------
+ 2 files changed, 18 insertions(+), 18 deletions(-)
+
+diff --git a/tests/Makefile.in b/tests/Makefile.in
+index 8c4d2048..e021af32 100644
+--- a/tests/Makefile.in
++++ b/tests/Makefile.in
+@@ -19,7 +19,7 @@ test_one: $(srcdir)/test_one.in Makefile mke2fs.conf
+ 	@echo "#!/bin/sh" > test_one
+ 	@echo "HTREE=y" >> test_one
+ 	@echo "QUOTA=y" >> test_one
+-	@echo "SRCDIR=@srcdir@" >> test_one
++	@echo "SRCDIR=${prefix}${libdir}/e2fsprogs/ptest/test" >> test_one
+ 	@echo "DIFF_OPTS=@UNI_DIFF_OPTS@" >> test_one
+ 	@echo "SIZEOF_TIME_T=@SIZEOF_TIME_T@" >> test_one
+ 	@echo "DD=@DD@" >>test_one
+@@ -30,7 +30,7 @@ test_script: test_one test_script.in Makefile mke2fs.conf
+ 	@echo "Creating test_script..."
+ 	@[ -f test_script ] && chmod u+w test_script || true
+ 	@echo "#!/bin/sh" > test_script
+-	@echo "SRCDIR=@srcdir@" >> test_script
++	@echo "SRCDIR=${prefix}${libdir}/e2fsprogs/ptest/test" >> test_script
+ 	@cat $(srcdir)/test_script.in >> test_script
+ 	@chmod +x-w test_script
+ 
+diff --git a/tests/test_config b/tests/test_config
+index 9dc762ce..a5fbdef6 100644
+--- a/tests/test_config
++++ b/tests/test_config
+@@ -3,25 +3,25 @@
+ #
+ 
+ unset LANG LANGUAGE LC_ADDRESS LC_ALL LC_COLLATE LC_CTYPE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE LC_TIME PAGER
+-FSCK="$USE_VALGRIND ../e2fsck/e2fsck"
+-MKE2FS="$USE_VALGRIND ../misc/mke2fs"
+-DUMPE2FS="$USE_VALGRIND ../misc/dumpe2fs"
+-TUNE2FS="$USE_VALGRIND ../misc/tune2fs"
+-CHATTR="$USE_VALGRIND../misc/chattr"
+-LSATTR="$USE_VALGRIND ../misc/lsattr"
+-E2IMAGE="$USE_VALGRIND ../misc/e2image"
+-E2IMAGE_EXE="../misc/e2image"
+-DEBUGFS="$USE_VALGRIND ../debugfs/debugfs"
+-DEBUGFS_EXE="../debugfs/debugfs"
++FSCK="$USE_VALGRIND e2fsck"
++MKE2FS="$USE_VALGRIND mke2fs"
++DUMPE2FS="$USE_VALGRIND dumpe2fs"
++TUNE2FS="$USE_VALGRIND tune2fs"
++CHATTR="$USE_VALGRIND chattr"
++LSATTR="$USE_VALGRIND lsattr"
++E2IMAGE="$USE_VALGRIND e2image"
++E2IMAGE_EXE="/sbin/e2image"
++DEBUGFS="$USE_VALGRIND debugfs"
++DEBUGFS_EXE="/sbin/debugfs"
+ TEST_BITS="test_data.tmp"
+-RESIZE2FS_EXE="../resize/resize2fs"
++RESIZE2FS_EXE="/sbin/resize2fs"
+ RESIZE2FS="$USE_VALGRIND $RESIZE2FS_EXE"
+-E2UNDO_EXE="../misc/e2undo"
++E2UNDO_EXE="/sbin/e2undo"
+ E2UNDO="$USE_VALGRIND $E2UNDO_EXE"
+-E2MMPSTATUS="$USE_VALGRIND ../misc/dumpe2fs -m"
+-TEST_REL=../tests/progs/test_rel
+-TEST_ICOUNT=../tests/progs/test_icount
+-CRCSUM=../tests/progs/crcsum
++E2MMPSTATUS="$USE_VALGRIND dumpe2fs -m"
++TEST_REL=./progs/test_rel
++TEST_ICOUNT=./progs/test_icount
++CRCSUM=./progs/crcsum
+ CLEAN_OUTPUT="sed -f $cmd_dir/filter.sed"
+ LD_LIBRARY_PATH=../lib:../lib/ext2fs:../lib/e2p:../lib/et:../lib/ss:${LD_LIBRARY_PATH}
+ DYLD_LIBRARY_PATH=../lib:../lib/ext2fs:../lib/e2p:../lib/et:../lib/ss:${DYLD_LIBRARY_PATH}

--- a/meta-balena-common/recipes-devtools/e2fsprogs/e2fsprogs/quiet-debugfs.patch
+++ b/meta-balena-common/recipes-devtools/e2fsprogs/e2fsprogs/quiet-debugfs.patch
@@ -1,0 +1,28 @@
+From 550b5fbece84dde16ce9910c2cad390ea4a2f5d5 Mon Sep 17 00:00:00 2001
+From: Ross Burton <ross.burton@intel.com>
+Date: Mon, 23 Dec 2013 13:38:34 +0000
+Subject: [PATCH] e2fsprogs: silence debugfs
+
+When executing a script don't echo every command, as we do this for entire
+filesystems at rootfs time.
+
+Upstream-Status: Inappropriate
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+
+---
+ debugfs/debugfs.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/debugfs/debugfs.c b/debugfs/debugfs.c
+index b67a88bc..76dd5556 100644
+--- a/debugfs/debugfs.c
++++ b/debugfs/debugfs.c
+@@ -2518,7 +2518,7 @@ static int source_file(const char *cmd_file, int ss_idx)
+ 		cp = strchr(buf, '\r');
+ 		if (cp)
+ 			*cp = 0;
+-		printf("debugfs: %s\n", buf);
++		/*printf("debugfs: %s\n", buf);*/
+ 		retval = ss_execute_line(ss_idx, buf);
+ 		if (retval) {
+ 			ss_perror(ss_idx, retval, buf);

--- a/meta-balena-common/recipes-devtools/e2fsprogs/e2fsprogs/remove.ldconfig.call.patch
+++ b/meta-balena-common/recipes-devtools/e2fsprogs/e2fsprogs/remove.ldconfig.call.patch
@@ -1,0 +1,44 @@
+From b139e03ac2f72e644e547c7ee9b1514383af4d97 Mon Sep 17 00:00:00 2001
+From: Andrei Dinu <andrei.adrianx.dinu@intel.com>
+Date: Wed, 30 Jan 2013 15:22:04 +0200
+Subject: [PATCH] When /etc/ld.so.cache is writeable by user running bitbake
+ then it creates invalid cache (in my case libstdc++.so
+ cannot be found after building zlib(-native) and I have to
+ call touch */libstdc++.so && /sbin/ldconfig to fix it.
+
+So remove ldconfig call from make install-libs
+
+Patch authored by Martin Jansa.
+
+Upstream-Status: Inappropriate [disable feature]
+
+Signed-off-by: Scott Garman <scott.a.garman@intel.com>
+Signed-off-by: Andrei Dinu <andrei.adrianx.dinu@intel.com>
+---
+ lib/Makefile.elf-lib |    3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/lib/Makefile.elf-lib b/lib/Makefile.elf-lib
+index 78479d3..4a4a5ac 100644
+--- a/lib/Makefile.elf-lib
++++ b/lib/Makefile.elf-lib
+@@ -50,8 +50,6 @@ install-shlibs install:: $(ELF_LIB) installdirs-elf-lib $(DEP_INSTALL_SYMLINK)
+ 	$(E) "	SYMLINK $(libdir)/$(ELF_IMAGE).so"
+ 	$(Q) $(INSTALL_SYMLINK) $(ELF_INSTALL_DIR)/$(ELF_SONAME) \
+ 		$(libdir)/$(ELF_IMAGE).so $(DESTDIR)
+-	$(E) "	LDCONFIG"
+-	$(Q) -$(LDCONFIG)
+ 
+ install-strip: install
+ 	$(E) "	STRIP-LIB $(ELF_INSTALL_DIR)/$(ELF_LIB)"
+@@ -67,7 +65,6 @@ uninstall-shlibs uninstall::
+ 	$(RM) -f $(DESTDIR)$(ELF_INSTALL_DIR)/$(ELF_LIB) \
+ 		$(DESTDIR)$(ELF_INSTALL_DIR)/$(ELF_SONAME) \
+ 		$(DESTDIR)$(libdir)/$(ELF_IMAGE).so
+-	-$(LDCONFIG)
+ 
+ clean::
+ 	$(RM) -rf elfshared
+-- 
+1.7.9.5
+

--- a/meta-balena-common/recipes-devtools/e2fsprogs/e2fsprogs/run-ptest
+++ b/meta-balena-common/recipes-devtools/e2fsprogs/e2fsprogs/run-ptest
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+cd ./test
+SKIP_SLOW_TESTS=yes ./test_script | sed -u -e '/:[[:space:]]ok/s/^/PASS: /' -e '/:[[:space:]]failed/s/^/FAIL: /' -e '/:[[:space:]]skipped/s/^/SKIP: /'
+rm -rf /var/volatile/tmp/*e2fsprogs*
+rm -f tmp-*
+rm -f *.tmp
+rm -f *.ok
+rm -f *.failed
+rm -f *.log

--- a/meta-balena-common/recipes-devtools/e2fsprogs/e2fsprogs_1.46.4.bb
+++ b/meta-balena-common/recipes-devtools/e2fsprogs/e2fsprogs_1.46.4.bb
@@ -1,0 +1,141 @@
+require e2fsprogs.inc
+
+SRC_URI += "file://remove.ldconfig.call.patch \
+           file://run-ptest \
+           file://ptest.patch \
+           file://mkdir_p.patch \
+           file://0001-tests-u_direct_io-expect-correct-expected-output.patch \
+           "
+
+SRC_URI:append:class-native = " file://e2fsprogs-fix-missing-check-for-permission-denied.patch \
+                                file://quiet-debugfs.patch \
+"
+
+SRCREV = "849005eac51ea2097bd9e5f2b0adc16b53c5486d"
+UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>\d+\.\d+(\.\d+)*)$"
+
+EXTRA_OECONF += "--libdir=${base_libdir} --sbindir=${base_sbindir} \
+                --enable-elf-shlibs --disable-libuuid --disable-uuidd \
+                --disable-libblkid --enable-verbose-makecmds \
+                --with-crond-dir=no"
+
+EXTRA_OECONF:darwin = "--libdir=${base_libdir} --sbindir=${base_sbindir} --enable-bsd-shlibs"
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[fuse] = '--enable-fuse2fs,--disable-fuse2fs,fuse'
+
+# make locale rules sometimes fire, sometimes don't as git doesn't preserve
+# file mktime. Touch the files introducing non-determinism to the build
+do_compile:prepend (){
+	find ${S}/po -type f -name "*.po" -exec touch {} +
+}
+
+do_install () {
+	oe_runmake 'DESTDIR=${D}' install
+	oe_runmake 'DESTDIR=${D}' install-libs
+	# We use blkid from util-linux now so remove from here
+	rm -f ${D}${base_libdir}/libblkid*
+	rm -rf ${D}${includedir}/blkid
+	rm -f ${D}${base_libdir}/pkgconfig/blkid.pc
+	rm -f ${D}${base_sbindir}/blkid
+	rm -f ${D}${base_sbindir}/fsck
+	rm -f ${D}${base_sbindir}/findfs
+
+	# e2initrd_helper and the pkgconfig files belong in libdir
+	if [ ! ${D}${libdir} -ef ${D}${base_libdir} ]; then
+		install -d ${D}${libdir}
+		mv ${D}${base_libdir}/e2initrd_helper ${D}${libdir}
+		mv ${D}${base_libdir}/pkgconfig ${D}${libdir}
+	fi
+
+	oe_multilib_header ext2fs/ext2_types.h
+	install -d ${D}${base_bindir}
+	mv ${D}${bindir}/chattr ${D}${base_bindir}/chattr.e2fsprogs
+
+	install -v -m 755 ${S}/contrib/populate-extfs.sh ${D}${base_sbindir}/
+
+	# Clean host path (build directory) in compile_et, mk_cmds
+	sed -i -e "s,\(ET_DIR=.*\)${S}/lib/et\(.*\),\1${datadir}/et\2,g" ${D}${bindir}/compile_et
+	sed -i -e "s,\(SS_DIR=.*\)${S}/lib/ss\(.*\),\1${datadir}/ss\2,g" ${D}${bindir}/mk_cmds
+}
+
+# Need to find the right mke2fs.conf file
+e2fsprogs_conf_fixup () {
+	for i in mke2fs mkfs.ext2 mkfs.ext3 mkfs.ext4; do
+		create_wrapper ${D}${base_sbindir}/$i MKE2FS_CONFIG=${sysconfdir}/mke2fs.conf
+	done
+}
+
+do_install:append:class-native() {
+	e2fsprogs_conf_fixup
+}
+
+do_install:append:class-nativesdk() {
+	e2fsprogs_conf_fixup
+}
+
+do_install:append:class-target() {
+	mv ${D}${base_sbindir}/mke2fs ${D}${base_sbindir}/mke2fs.e2fsprogs
+	mv ${D}${base_sbindir}/mkfs.ext2 ${D}${base_sbindir}/mkfs.ext2.e2fsprogs
+	mv ${D}${base_sbindir}/tune2fs ${D}${base_sbindir}/tune2fs.e2fsprogs
+}
+
+RDEPENDS:e2fsprogs = "e2fsprogs-badblocks e2fsprogs-dumpe2fs"
+RRECOMMENDS:e2fsprogs = "e2fsprogs-mke2fs e2fsprogs-e2fsck"
+
+PACKAGES =+ "e2fsprogs-badblocks e2fsprogs-dumpe2fs e2fsprogs-e2fsck e2fsprogs-e2scrub e2fsprogs-mke2fs e2fsprogs-resize2fs e2fsprogs-tune2fs"
+PACKAGES =+ "libcomerr libss libe2p libext2fs"
+
+FILES:e2fsprogs-dumpe2fs = "${base_sbindir}/dumpe2fs"
+FILES:e2fsprogs-resize2fs = "${base_sbindir}/resize2fs*"
+FILES:e2fsprogs-e2fsck = "${base_sbindir}/e2fsck ${base_sbindir}/fsck.ext*"
+FILES:e2fsprogs-e2scrub = "${base_sbindir}/e2scrub*"
+FILES:e2fsprogs-mke2fs = "${base_sbindir}/mke2fs.e2fsprogs ${base_sbindir}/mkfs.ext* ${sysconfdir}/mke2fs.conf"
+FILES:e2fsprogs-tune2fs = "${base_sbindir}/tune2fs.e2fsprogs ${base_sbindir}/e2label"
+FILES:e2fsprogs-badblocks = "${base_sbindir}/badblocks"
+FILES:libcomerr = "${base_libdir}/libcom_err.so.*"
+FILES:libss = "${base_libdir}/libss.so.*"
+FILES:libe2p = "${base_libdir}/libe2p.so.*"
+FILES:libext2fs = "${libdir}/e2initrd_helper ${base_libdir}/libext2fs.so.*"
+FILES:${PN}-dev += "${datadir}/*/*.awk ${datadir}/*/*.sed ${base_libdir}/*.so ${bindir}/compile_et ${bindir}/mk_cmds"
+
+ALTERNATIVE:${PN} = "chattr"
+ALTERNATIVE_PRIORITY = "100"
+ALTERNATIVE_LINK_NAME[chattr] = "${base_bindir}/chattr"
+ALTERNATIVE_TARGET[chattr] = "${base_bindir}/chattr.e2fsprogs"
+
+ALTERNATIVE:${PN}-doc = "fsck.8"
+ALTERNATIVE_LINK_NAME[fsck.8] = "${mandir}/man8/fsck.8"
+
+ALTERNATIVE:${PN}-mke2fs = "mke2fs mkfs.ext2"
+ALTERNATIVE_LINK_NAME[mke2fs] = "${base_sbindir}/mke2fs"
+ALTERNATIVE_LINK_NAME[mkfs.ext2] = "${base_sbindir}/mkfs.ext2"
+
+ALTERNATIVE:${PN}-tune2fs = "tune2fs"
+ALTERNATIVE_LINK_NAME[tune2fs] = "${base_sbindir}/tune2fs"
+
+RDEPENDS:e2fsprogs-e2scrub = "bash"
+RDEPENDS:${PN}-ptest += "coreutils procps bash bzip2 diffutils perl sed"
+RDEPENDS:${PN}-ptest += "e2fsprogs-badblocks e2fsprogs-dumpe2fs e2fsprogs-e2fsck e2fsprogs-mke2fs e2fsprogs-resize2fs e2fsprogs-tune2fs"
+
+do_compile_ptest() {
+	oe_runmake -C ${B}/tests
+}
+
+do_install_ptest() {
+	# This file's permissions depends on the host umask so be deterministic
+	chmod 0644 ${B}/tests/test_data.tmp
+	cp -R --no-dereference --preserve=mode,links -v ${B}/tests ${D}${PTEST_PATH}/test
+	cp -R --no-dereference --preserve=mode,links -v ${S}/tests/* ${D}${PTEST_PATH}/test
+	sed -e 's!../e2fsck/e2fsck!e2fsck!g' \
+	    -e 's!../misc/tune2fs!tune2fs!g' -i ${D}${PTEST_PATH}/test/*/expect*
+	sed -e 's!../e2fsck/e2fsck!${base_sbindir}/e2fsck!g' -i ${D}${PTEST_PATH}/test/*/script
+
+	# Remove various files
+	find "${D}${PTEST_PATH}" -type f \
+	    \( -name 'Makefile' -o -name 'Makefile.in' -o -name '*.o' -o -name '*.c' -o -name '*.h' \)\
+	    -exec  rm -f {} +
+
+        install -d ${D}${PTEST_PATH}/lib
+        install -m 0644 ${B}/lib/config.h  ${D}${PTEST_PATH}/lib/
+}


### PR DESCRIPTION
Various boards may fail testbot fsck runs due to older
tune2fs versions not supporting various options.

eg:
   not ok 1 - tune2fs -E force_fsck ... failed. stderr: Bad options specified.

Let's bring in the e2fsprogs recipe from Poky Honister.
Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
