### PR TITLE
tests/os: check supervisor is pulled  after purge

### DIFF
--- a/tests/suites/os/tests/purge-data/index.js
+++ b/tests/suites/os/tests/purge-data/index.js
@@ -13,6 +13,21 @@
  */
 
 'use strict';
+const request = require('request-promise');
+
+async function waitUntilSupervisorActive(test, context){
+	const ip = await context.worker.ip(context.link);
+
+	await context.utils.waitUntil(async () => {
+		test.comment(`Waiting for DUT supervisor to be reachable on port 48484...`)
+		return (
+			(await request({
+				method: 'GET',
+				uri: `http://${ip}:48484/ping`,
+			})) === 'OK'
+		);
+	}, false);
+}
 
 module.exports = {
 	title: 'Reset tests',
@@ -150,6 +165,8 @@ module.exports = {
 					);
 				}, false);
 
+				await waitUntilSupervisorActive(test, this.context.get());
+
 				test.is(
 					await this.context
 						.get()
@@ -219,6 +236,8 @@ module.exports = {
 							)) === 'active'
 					);
 				}, false);
+
+				await waitUntilSupervisorActive(test, this.context.get());
 
 				test.is(
 					await this.context


### PR DESCRIPTION
Check the supervisor is re-downloaded and running after data partition reset/pruning all images. Before we were just waiting to see if the supervisor systemd service was running.

This make sure the test brings us coverage given by manual test case TC26 - Supervisor Reload Test 

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
