### PR TITLE
tests: connectivity: proxy: Add sleep before checking logs

### DIFF
--- a/tests/suites/os/tests/connectivity/index.js
+++ b/tests/suites/os/tests/connectivity/index.js
@@ -147,7 +147,7 @@ module.exports = {
 						await this.context
 							.get()
 							.worker.executeCommandInHostOS(
-								`curl -I https://${URL_TEST}`,
+								`curl -I https://${URL_TEST} && sleep 3`,
 								this.link,
 							);
 


### PR DESCRIPTION
Lately we have seen this test fail because at the second http-connect
test we would still fetch the old socks5 logs from the glider container.
So let's add a 3 seconds sleep in between the api ping call and the log
check. If even after this 3 seconds sleep we get the old logs then it's
an indication of a problem with either the container being slow to run
or a problem with slow logs output from the glider container.

Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
