### PR TITLE
kernel-headers-test: clean tools like fixdep

### DIFF
--- a/meta-balena-common/recipes-kernel/linux/files/Dockerfile
+++ b/meta-balena-common/recipes-kernel/linux/files/Dockerfile
@@ -24,6 +24,9 @@ RUN ARCH=${kernel_arch} CROSS_COMPILE=${cross_compile_prefix} make -C /usr/src/a
 RUN ARCH=${kernel_arch} CROSS_COMPILE=${cross_compile_prefix} make -C /usr/src/app/kernel_source/*/build/ M=/usr/src/app/example_module_headers_src
 
 # Compile external hello module using pre-built headers
-# We run modules_prepare again because the tools pre-compiled are actually the target device arch. While we cross-compile for testing.
+# We run modules_prepare again because the tools pre-compiled are actually the target device arch, and ensure tools like fixdep are built in this container. While we cross-compile for testing.
+RUN if [ -f /usr/src/app/kernel_modules_headers/tools/objtool/fixdep ]; then \
+        ARCH=${kernel_arch} CROSS_COMPILE=${cross_compile_prefix} make -C /usr/src/app/kernel_modules_headers/tools/objtool clean ; \
+    fi;
 RUN ARCH=${kernel_arch} CROSS_COMPILE=${cross_compile_prefix} make -C /usr/src/app/kernel_modules_headers/ modules_prepare
 RUN ARCH=${kernel_arch} CROSS_COMPILE=${cross_compile_prefix} make -C /usr/src/app/kernel_modules_headers/ M=/usr/src/app/example_module_headers_built

--- a/meta-balena-common/recipes-kernel/linux/files/example_module/hello.c
+++ b/meta-balena-common/recipes-kernel/linux/files/example_module/hello.c
@@ -1,6 +1,8 @@
 #include <linux/init.h>
 #include <linux/module.h>
 
+MODULE_LICENSE("GPLv2");
+
 static int __init
 hello_init(void)
 {


### PR DESCRIPTION
Let's ensure tools like fixdep are built in container
and not reused from the yocto build, otherwise they
may not run if they were linked against a different
version of libc that may not be available in the kernel
modules build container.

This fixes the following error encountered when doing
a Poky Honister build for the balena-intel repository:

  scripts/basic/fixdep: /lib64/libc.so.6: version `GLIBC_2.34'
  not found (required by scripts/basic/fixdep)

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
