### PR TITLE
timeinit/timesync-https: Update rtc after setting system time

### DIFF
--- a/meta-balena-common/recipes-core/systemd/timeinit/timesync-https.sh
+++ b/meta-balena-common/recipes-core/systemd/timeinit/timesync-https.sh
@@ -65,6 +65,7 @@ while [ true  ]; do
 				info "Time synchronised via HTTPS."
 				info "Old time: $(get_display_time_from_timestamp "$SYS_TIME")"
 				info "New time: $(get_display_time_from_timestamp "$SERVER_TIME")"
+				hwclock -w || true
 				exit 0
 			else
 				info "System time is already synchronised."


### PR DESCRIPTION
This solves a problem seen on a device on which, although
timeinit-rtc finishes running before timesync-https, chronyd
sets the system time to the incorrect rtc time
as soon as timesync-https finished running and setting the correct date
from the servers.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested - on Rockpi 4B with preloaded image
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

Logs from when the issue occurred:

```
root@2ddeefa:~# journalctl | grep time | grep -v balena
Mar 25 11:42:50 localhost kernel:         Build-time adjustment of leaf fanout to 64.
Mar 25 11:42:50 localhost kernel: Architected cp15 timer(s) running at 24.00MHz (phys).
Mar 25 11:42:50 localhost kernel: Calibrating delay loop (skipped), value calculated using timer frequency.. 48.00 BogoMIPS (lpj=96000)
Mar 25 11:42:50 localhost kernel: AppArmor: AppArmor disabled by boot time parameter
Mar 25 11:42:50 localhost kernel: rockchip-pcie f8000000.pcie: PCIe link training gen1 timeout!
Mar 25 11:42:50 localhost kernel: [drm] Supports vblank timestamp caching Rev 2 (21.10.2013).
Mar 25 11:42:50 localhost kernel: [drm] No driver support for vblank timestamp query.
Mar 25 11:42:50 localhost kernel: Synopsys Designware Multimedia Card Interface Driver
Mar 25 11:42:50 localhost systemd[1]: System time before build time, advancing clock.
Mar 25 11:42:50 localhost systemd-journald[998]: Runtime journal (/run/log/journal/654617a1baf4498eb4d2d61f472d8338) is 4.0M, max 32.0M, 28.0M free.
Mar 25 11:42:50 localhost timeinit-buildtime.sh[854]: [timeinit-buildtime.sh][INFO] Setting system time from build time.
Mar 25 11:42:50 localhost timeinit-buildtime.sh[854]: [timeinit-buildtime.sh][INFO] Old time: Thu Mar 24 22:31:04 UTC 2022
Mar 25 11:42:50 localhost timeinit-buildtime.sh[854]: [timeinit-buildtime.sh][INFO] New time: Fri Mar 25 11:42:50 UTC 2022
Mar 25 11:42:51 localhost timeinit-rtc.sh[1141]: [timeinit-rtc.sh][INFO] Setting system time from RTC.
Mar 25 11:42:51 localhost timeinit-rtc.sh[1141]: [timeinit-rtc.sh][INFO] System time is already set.
Mar 25 11:42:51 localhost timeinit-rtc.sh[1141]: [timeinit-rtc.sh][WARN] RTC time is in the past.
Mar 25 11:42:51 localhost timeinit-rtc.sh[1141]: [timeinit-rtc.sh][WARN] Check RTC battery if this issue persists.
Mar 25 11:42:52 localhost timeinit-rtc.sh[1141]: [timeinit-rtc.sh][WARN] RTC time:    Fri Jan 18 08:50:16 UTC 2013
Mar 25 11:42:52 localhost timeinit-rtc.sh[1141]: [timeinit-rtc.sh][WARN] System time: Fri Mar 25 11:42:51 UTC 2022
Mar 25 11:42:52 localhost timeinit-rtc.sh[1141]: [timeinit-rtc.sh][INFO]
Mar 25 11:42:52 localhost timeinit-rtc.sh[1141]: [timeinit-rtc.sh][INFO] Will touch timeinit-rtc-done file
Mar 25 11:42:52 localhost timeinit-rtc.sh[1141]: [timeinit-rtc.sh][INFO] Done touch
Mar 25 11:42:52 localhost timeinit-rtc.sh[1141]: [timeinit-rtc.sh][INFO] Ended timeinit-rtc script and date is
Mar 25 11:42:53 2ddeefa timesync-https.sh[1366]: [timesync-https.sh][INFO] Starting HTTPS time synchronisation.
Mar 25 11:43:00 2ddeefa timesync-https.sh[1366]: [timesync-https.sh][INFO] >>> SERVER_TIME: 20220408101502
Mar 25 11:43:00 2ddeefa timesync-https.sh[1366]: [timesync-https.sh][INFO] >>> TIME_DIFF: 1204323
Mar 25 11:43:00 2ddeefa timesync-https.sh[1366]: [timesync-https.sh][INFO] >>> SYS_TIME: 20220325114259
Mar 25 11:43:00 2ddeefa timesync-https.sh[1366]: [timesync-https.sh][INFO] >>> Will set time to 20220408101502
Apr 08 10:15:02 2ddeefa timesync-https.sh[1366]: [timesync-https.sh][INFO] >>> Time was set to 20220408101502
Apr 08 10:15:02 2ddeefa timesync-https.sh[1366]: [timesync-https.sh][INFO] Time synchronised via HTTPS.
Apr 08 10:15:02 2ddeefa timesync-https.sh[1366]: [timesync-https.sh][INFO] Old time: Fri Mar 25 11:42:59 UTC 2022
Apr 08 10:15:02 2ddeefa timesync-https.sh[1366]: [timesync-https.sh][INFO] New time: Fri Apr  8 10:15:02 UTC 2022
Jan 18 08:50:30 2ddeefa chronyd[1974]: 2013-01-18T08:50:30Z Backward time jump detected! <- chronyd started and used the rtc value
```

Logs with this patch:
```
Mar 25 11:42:50 localhost timeinit-buildtime.sh[867]: [timeinit-buildtime.sh][INFO] Setting system time from build time.
Mar 25 11:42:50 localhost timeinit-buildtime.sh[867]: [timeinit-buildtime.sh][INFO] Old time: Thu Mar 24 22:31:04 UTC 2022
Mar 25 11:42:50 localhost timeinit-buildtime.sh[867]: [timeinit-buildtime.sh][INFO] New time: Fri Mar 25 11:42:50 UTC 2022
Mar 25 11:42:51 localhost timeinit-rtc.sh[1141]: [timeinit-rtc.sh][INFO] Setting system time from RTC.
Mar 25 11:42:51 localhost timeinit-rtc.sh[1141]: [timeinit-rtc.sh][INFO] System time is already set.
Mar 25 11:42:51 localhost timeinit-rtc.sh[1141]: [timeinit-rtc.sh][WARN] RTC time is in the past.
Mar 25 11:42:51 localhost timeinit-rtc.sh[1141]: [timeinit-rtc.sh][WARN] Check RTC battery if this issue persists.
Mar 25 11:42:51 localhost timeinit-rtc.sh[1141]: [timeinit-rtc.sh][WARN] RTC time:    Fri Jan 18 08:50:15 UTC 2013
Mar 25 11:42:52 localhost timeinit-rtc.sh[1141]: [timeinit-rtc.sh][WARN] System time: Fri Mar 25 11:42:51 UTC 2022
Mar 25 11:42:53 30e9aeb timesync-https.sh[1357]: [timesync-https.sh][INFO] Starting HTTPS time synchronisation.
Apr 08 12:00:56 30e9aeb timesync-https.sh[1357]: [timesync-https.sh][INFO] Time synchronised via HTTPS.
Apr 08 12:00:56 30e9aeb timesync-https.sh[1357]: [timesync-https.sh][INFO] Old time: Fri Mar 25 11:42:59 UTC 2022
Apr 08 12:00:56 30e9aeb timesync-https.sh[1357]: [timesync-https.sh][INFO] New time: Fri Apr  8 12:00:56 UTC 2022

```