### PR TITLE
resin-device-register: improve provisioning

### DIFF
--- a/meta-balena-common/recipes-support/resin-device-register/resin-device-register/resin-device-register
+++ b/meta-balena-common/recipes-support/resin-device-register/resin-device-register/resin-device-register
@@ -48,7 +48,7 @@ if [ -z "$API_ENDPOINT" ] || [ -z "$CONFIG_PATH" ]; then
     exit 1
 fi
 
-while true; do
+for retries in {1..3}; do
     if curl -sL -w '%{http_code}' "$API_ENDPOINT"/ping -o /dev/null | egrep "20[0-9]|30[0-9]" >/dev/null
     then
         if [ -n "${REGISTERED_AT}" ]; then


### PR DESCRIPTION
Starting with v2.91.6 device provisioning will not start if the device
was unable to register in the cloud due to lack of internet connectivity.
To avoid this, we switch to retrying 3 times with the usual 2 second delay
between attempts, after which the flashing process will start.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Fixes https://github.com/balena-os/meta-balena/issues/2576


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested - on flasher device
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
