### PR TITLE
Refresh PKI assets from config endpoint

### DIFF
--- a/meta-balena-common/recipes-connectivity/openvpn/files/openvpn.service
+++ b/meta-balena-common/recipes-connectivity/openvpn/files/openvpn.service
@@ -11,6 +11,7 @@ RestartSec=10s
 #Adjust OOMscore to -1000 to disable OOM killing for openvpn
 OOMScoreAdjust=-1000
 PIDFile=/run/openvpn/openvpn.pid
+ExecStartPre=-/bin/systemctl restart os-config
 ExecStart=/usr/sbin/openvpn --writepid /run/openvpn/openvpn.pid --cd /etc/openvpn/ --config /etc/openvpn/openvpn.conf --connect-retry 5 120
 
 [Install]


### PR DESCRIPTION
* ensure OpenVPN client always starts with the latest CA certificate
  from API config endpoint as this certificate may have changed and
  we don't want VPN to be down for ~24 hours until os-config is triggered
  by systemd timer

Change-type: minor
Fixes: #2569