### PR TITLE
networkmanager: Set DHCP timeout to 90s for IPv4

### DIFF
--- a/meta-balena-common/recipes-connectivity/networkmanager/balena-files/NetworkManager.conf
+++ b/meta-balena-common/recipes-connectivity/networkmanager/balena-files/NetworkManager.conf
@@ -8,4 +8,4 @@ hostname-mode=none
 unmanaged-devices=interface-name:balena*;interface-name:resin*;interface-name:br*;type:veth
 
 [connection]
-ipv4.dhcp-timeout=2147483647
+ipv4.dhcp-timeout=90


### PR DESCRIPTION
networkmanager: Set DHCP timeout to 90 seconds for IPv4

[Issue #2578]

Fixes issue where routers that do not renew leases properly loose connectivity completely once the lease expires. 
For example a router power cycle may cause this.
Default dhcp timeout value on Debian is 90 seconds

Signed-off-by: Jesse Jämsén <jasse.jamsen@gmail.com>

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
