### PR TITLE
image-balena: Remove localMode from standalone image configuration

### DIFF
--- a/meta-balena-common/classes/image-balena.bbclass
+++ b/meta-balena-common/classes/image-balena.bbclass
@@ -50,9 +50,6 @@ init_config_json() {
    # Default no to persistent-logging
    echo "$(cat ${1}/config.json | jq -S ".persistentLogging=false")" > ${1}/config.json
 
-   # Default localMode to true
-   echo "$(cat ${1}/config.json | jq -S ".localMode=true")" > ${1}/config.json
-
    # Find board json and extract slug
    json_path=${BALENA_COREBASE}/../../../${MACHINE}.json
    slug=$(jq .slug $json_path)


### PR DESCRIPTION
The `localMode` variable in `config.json` is not longer used and it can be removed

Fixes #2041

Change-type: patch
Changelog-entry: Remove localMode setting from standalone image configuration
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
