### PR TITLE
linux-firmware: Fix quz-a0-hr-b0 and quz-a0-jf-b0 packaging for compression

### DIFF
--- a/meta-balena-common/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/meta-balena-common/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -163,10 +163,10 @@ FILES:${PN}-i915-dg1 = " \
 PACKAGES =+ "${PN}-iwlwifi-quz-a0-hr-b0"
 
 FILES:${PN}-iwlwifi-quz-a0-hr-b0 = " \
-    ${nonarch_base_libdir}/firmware/iwlwifi-QuZ-a0-hr-b0-48.ucode \
+    ${nonarch_base_libdir}/firmware/iwlwifi-QuZ-a0-hr-b0-48.ucode* \
 "
 
 PACKAGES =+ "${PN}-iwlwifi-quz-a0-jf-b0"
 FILES:${PN}-iwlwifi-quz-a0-jf-b0 = " \
-    ${nonarch_base_libdir}/firmware/iwlwifi-QuZ-a0-jf-b0-*.ucode \
+    ${nonarch_base_libdir}/firmware/iwlwifi-QuZ-a0-jf-b0-*.ucode* \
 "


### PR DESCRIPTION
Add a missing asterisk to FILES for iwlwifi-quz-a0-hr-b0 and iwlwifi-quz-a0-jf-b0 to include compressed firmware files. Without it the packages end up empty as we have compression enabled.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
