### PR TITLE
renovate: Override commit body for meta-balena to Change-type

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,16 +9,5 @@
     "**/test/**",
     "**/tests/suites/**",
     "**/__fixtures__/**"
-  ],
-  "packageRules": [
-    {
-      "matchPackagePatterns": ["*"],
-      "excludePackagePatterns": [".*leviathan"],
-      "enabled": false
-    },
-    {
-      "matchManagers": ["git-submodules"],
-      "automerge": true
-    }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,5 +9,6 @@
     "**/test/**",
     "**/tests/suites/**",
     "**/__fixtures__/**"
-  ]
+  ],
+  "commitBody": "Update {{depName}}\nChange-type: patch"
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
