### PR TITLE
balena-supervisor: Randomize the updater timer period

### DIFF
--- a/meta-balena-common/recipes-containers/balena-supervisor/balena-supervisor/update-balena-supervisor.timer
+++ b/meta-balena-common/recipes-containers/balena-supervisor/balena-supervisor/update-balena-supervisor.timer
@@ -4,6 +4,7 @@ Description=Balena supervisor updater timer
 [Timer]
 OnBootSec=15min
 OnUnitInactiveSec=1d
+RandomizedDelaySec=3600
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
To avoid fleets updating the supervisor at the same time,
distribute the timer adding a random time between 0 and 1 hour.

Fixes #2631

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
