### PR TITLE
Check volume contents over HUPs

### DIFF
--- a/tests/suites/hup/tests/smoke.js
+++ b/tests/suites/hup/tests/smoke.js
@@ -10,263 +10,151 @@ module.exports = {
 	title: 'Smoke tests',
 	tests: [
 		{
+			// HUP from the previous release to the release under test.
 			title: 'HUP from previous release',
 			run: async function (test) {
 				await this.hup.initDUT(this, test, this.link);
-
-				const activePartition = await this.worker.executeCommandInHostOS(
-					`findmnt --noheadings --canonicalize --output SOURCE /mnt/sysroot/active`,
-					this.link,
-				);
-
-				// Check for under-voltage before HUP, in the old OS
-				await this.hup.checkUnderVoltage(this, test);
-
-				test.is(
-					await this.worker.executeCommandInHostOS(
-						`balena volume create hello-world`,
-						this.link,
-					),
-					'hello-world',
-					'Should create hello-world volume'
-				);
-
-				test.comment('Creating files on the volume');
-				await this.worker.executeCommandInHostOS(
-					`balena run -v hello-world:/the-volume --entrypoint "/bin/sh" alpine -c 'echo "Howdy!" > /the-volume/the-file.txt' &&
-					balena run -v hello-world:/the-volume --entrypoint "/bin/sh" alpine -c 'md5sum /the-volume/the-file.txt > /the-volume/MD5.SUM'`,
-					this.link,
-				);
-
-				await this.hup.doHUP(
-					this,
-					test,
-					'local',
-					this.hupOs.image.path,
-					this.link,
-				);
-
-				test.is(
-					await this.worker.executeCommandInHostOS(
-						`sed -i -e "s/COUNT=.*/COUNT=3/g" -e "s/TIMEOUT=.*/TIMEOUT=10/g" $(find /mnt/sysroot/inactive/ | grep "bin/rollback-health") ; echo $?`,
-						this.link,
-					),
-					'0',	// does not confirm that sed replaced the values, only that the command did not fail
-					'Should reduce rollback-health timeout to 3x10s'
-				);
-
-				await this.worker.rebootDut(this.link);
-
-				// 0 means file exists, 1 means file does not exist
-				await test.resolves(
-					this.utils.waitUntil(async () => {
-						return this.worker.executeCommandInHostOS(
-							`test -f /mnt/state/rollback-health-breadcrumb ; echo $?`,
-							this.link,
-						).then(out => {
-							return out === '1';
-						})
-					}, false, 5 * 60, 1000),	// 5 min
-					'Should not have rollback-health-breadcrumb in the state partition'
-				);
-
-				// 0 means file exists, 1 means file does not exist
-				test.is(
-					await this.worker.executeCommandInHostOS(
-						`test -f /mnt/state/rollback-altboot-breadcrumb ; echo $?`,
-						this.link,
-					),
-					'1',
-					'Should not have rollback-altboot-breadcrumb in the state partition',
-				);
-
-				// 0 means file exists, 1 means file does not exist
-				test.is(
-					await this.worker.executeCommandInHostOS(
-						`test -f /mnt/state/rollback-altboot-triggered ; echo $?`,
-						this.link,
-					),
-					'1',
-					'Should not have rollback-altboot-triggered in the state partition',
-				);
-
-				// 0 means file exists, 1 means file does not exist
-				test.is(
-					await this.worker.executeCommandInHostOS(
-						`test -f /mnt/state/rollback-health-triggered ; echo $?`,
-						this.link,
-					),
-					'1',
-					'Should not have rollback-health-triggered in the state partition',
-				);
-
-				// 0 means file exists, 1 means file does not exist
-				test.is(
-					await this.worker.executeCommandInHostOS(
-						`test -f /mnt/state/rollback-health-failed ; echo $?`,
-						this.link,
-					),
-					'1',
-					'Should not have rollback-health-failed in the state partition',
-				);
-		
-				test.not(
-					await this.worker.executeCommandInHostOS(
-						`findmnt --noheadings --canonicalize --output SOURCE /mnt/sysroot/active`,
-						this.link,
-					),
-					activePartition,
-					`Should not have rolled back to the original root partition`,
-				);
-
-				test.is(
-					await this.worker.executeCommandInHostOS(
-						`balena volume inspect hello-world 1>/dev/null 2>&1; echo $?`,
-						this.link,
-					),
-					'0',
-					'Volume should not be lost during HUP',
-				);
-
-				test.comment('Checking files on the volume');
-				test.is(
-					await this.worker.executeCommandInHostOS(
-						`balena run -v hello-world:/the-volume alpine md5sum -c /the-volume/MD5.SUM &> /dev/null ; echo $?`,
-						this.link,
-					),
-					'0',
-					'Volume contents should have been preserved during HUP',
-				);
-
-				// Check for under-voltage after HUP, in the new OS
-				await this.hup.checkUnderVoltage(this, test);
+				await runSmokeTest(this, test);
 			},
 		},
 		{
+			// A second HUP to make sure the release under test didn't break
+			// HUPs. (We are updating from the release under test to itself,
+			// which is fine for our purposes.)
 			title: 'HUP from this release',
 			run: async function (test) {
-
-				const activePartition = await this.worker.executeCommandInHostOS(
-					`findmnt --noheadings --canonicalize --output SOURCE /mnt/sysroot/active`,
-					this.link,
-				);
-
-				test.is(
-					await this.worker.executeCommandInHostOS(
-						`balena volume create hello-world`,
-						this.link,
-					),
-					'hello-world',
-					'Should create hello-world volume'
-				);
-
-				test.comment('Creating files on the volume');
-				await this.worker.executeCommandInHostOS(
-					`balena run -v hello-world:/the-volume --entrypoint "/bin/sh" alpine -c 'echo "Howdy!" > /the-volume/the-file.txt' &&
-					balena run -v hello-world:/the-volume --entrypoint "/bin/sh" alpine -c 'md5sum /the-volume/the-file.txt > /the-volume/MD5.SUM'`,
-					this.link,
-				);
-
-				await this.hup.doHUP(
-					this,
-					test,
-					'local',
-					this.hupOs.image.path,
-					this.link,
-				);
-
-				test.is(
-					await this.worker.executeCommandInHostOS(
-						`sed -i -e "s/COUNT=.*/COUNT=3/g" -e "s/TIMEOUT=.*/TIMEOUT=10/g" $(find /mnt/sysroot/inactive/ | grep "bin/rollback-health") ; echo $?`,
-						this.link,
-					),
-					'0',	// does not confirm that sed replaced the values, only that the command did not fail
-					'Should reduce rollback-health timeout to 3x10s'
-				);
-
-				await this.worker.rebootDut(this.link);
-
-				// 0 means file exists, 1 means file does not exist
-				await test.resolves(
-					this.utils.waitUntil(async () => {
-						return this.worker.executeCommandInHostOS(
-							`test -f /mnt/state/rollback-health-breadcrumb ; echo $?`,
-							this.link,
-						).then(out => {
-							return out === '1';
-						})
-					}, false, 5 * 60, 1000),	// 5 min
-					'Should not have rollback-health-breadcrumb in the state partition'
-				);
-
-				// 0 means file exists, 1 means file does not exist
-				test.is(
-					await this.worker.executeCommandInHostOS(
-						`test -f /mnt/state/rollback-altboot-breadcrumb ; echo $?`,
-						this.link,
-					),
-					'1',
-					'Should not have rollback-altboot-breadcrumb in the state partition',
-				);
-
-				// 0 means file exists, 1 means file does not exist
-				test.is(
-					await this.worker.executeCommandInHostOS(
-						`test -f /mnt/state/rollback-altboot-triggered ; echo $?`,
-						this.link,
-					),
-					'1',
-					'Should not have rollback-altboot-triggered in the state partition',
-				);
-
-				// 0 means file exists, 1 means file does not exist
-				test.is(
-					await this.worker.executeCommandInHostOS(
-						`test -f /mnt/state/rollback-health-triggered ; echo $?`,
-						this.link,
-					),
-					'1',
-					'Should not have rollback-health-triggered in the state partition',
-				);
-
-				// 0 means file exists, 1 means file does not exist
-				test.is(
-					await this.worker.executeCommandInHostOS(
-						`test -f /mnt/state/rollback-health-failed ; echo $?`,
-						this.link,
-					),
-					'1',
-					'Should not have rollback-health-failed in the state partition',
-				);
-		
-				test.not(
-					await this.worker.executeCommandInHostOS(
-						`findmnt --noheadings --canonicalize --output SOURCE /mnt/sysroot/active`,
-						this.link,
-					),
-					activePartition,
-					`Should not have rolled back to the original root partition`,
-				);
-
-				test.is(
-					await this.worker.executeCommandInHostOS(
-						`balena volume inspect hello-world 1>/dev/null 2>&1; echo $?`,
-						this.link,
-					),
-					'0',
-					'Volume should not be lost during HUP',
-				);
-
-				test.comment('Checking files on the volume');
-				test.is(
-					await this.worker.executeCommandInHostOS(
-						`balena run -v hello-world:/the-volume alpine md5sum -c /the-volume/MD5.SUM &> /dev/null ; echo $?`,
-						this.link,
-					),
-					'0',
-					'Volume contents should have been preserved during HUP',
-				);
+				await runSmokeTest(this, test);
 			},
 		},
 	],
 };
+
+
+async function runSmokeTest(that, test) {
+	const activePartition = await that.worker.executeCommandInHostOS(
+		`findmnt --noheadings --canonicalize --output SOURCE /mnt/sysroot/active`,
+		that.link,
+	);
+
+	// Check for under-voltage before HUP, in the old OS
+	await that.hup.checkUnderVoltage(that, test);
+
+	test.is(
+		await that.worker.executeCommandInHostOS(
+			`balena volume create hello-world`,
+			that.link,
+		),
+		'hello-world',
+		'Should create hello-world volume'
+	);
+
+	test.comment('Creating files on the volume');
+	await that.worker.executeCommandInHostOS(
+		`balena run -v hello-world:/the-volume --entrypoint "/bin/sh" alpine -c 'echo "Howdy!" > /the-volume/the-file.txt' &&
+		balena run -v hello-world:/the-volume --entrypoint "/bin/sh" alpine -c 'md5sum /the-volume/the-file.txt > /the-volume/MD5.SUM'`,
+		that.link,
+	);
+
+	await that.hup.doHUP(
+		that,
+		test,
+		'local',
+		that.hupOs.image.path,
+		that.link,
+	);
+
+	test.is(
+		await that.worker.executeCommandInHostOS(
+			`sed -i -e "s/COUNT=.*/COUNT=3/g" -e "s/TIMEOUT=.*/TIMEOUT=10/g" $(find /mnt/sysroot/inactive/ | grep "bin/rollback-health") ; echo $?`,
+			that.link,
+		),
+		'0',	// does not confirm that sed replaced the values, only that the command did not fail
+		'Should reduce rollback-health timeout to 3x10s'
+	);
+
+	await that.worker.rebootDut(that.link);
+
+	// 0 means file exists, 1 means file does not exist
+	await test.resolves(
+		that.utils.waitUntil(async () => {
+			return that.worker.executeCommandInHostOS(
+				`test -f /mnt/state/rollback-health-breadcrumb ; echo $?`,
+				that.link,
+			).then(out => {
+				return out === '1';
+			})
+		}, false, 5 * 60, 1000),	// 5 min
+		'Should not have rollback-health-breadcrumb in the state partition'
+	);
+
+	// 0 means file exists, 1 means file does not exist
+	test.is(
+		await that.worker.executeCommandInHostOS(
+			`test -f /mnt/state/rollback-altboot-breadcrumb ; echo $?`,
+			that.link,
+		),
+		'1',
+		'Should not have rollback-altboot-breadcrumb in the state partition',
+	);
+
+	// 0 means file exists, 1 means file does not exist
+	test.is(
+		await that.worker.executeCommandInHostOS(
+			`test -f /mnt/state/rollback-altboot-triggered ; echo $?`,
+			that.link,
+		),
+		'1',
+		'Should not have rollback-altboot-triggered in the state partition',
+	);
+
+	// 0 means file exists, 1 means file does not exist
+	test.is(
+		await that.worker.executeCommandInHostOS(
+			`test -f /mnt/state/rollback-health-triggered ; echo $?`,
+			that.link,
+		),
+		'1',
+		'Should not have rollback-health-triggered in the state partition',
+	);
+
+	// 0 means file exists, 1 means file does not exist
+	test.is(
+		await that.worker.executeCommandInHostOS(
+			`test -f /mnt/state/rollback-health-failed ; echo $?`,
+			that.link,
+		),
+		'1',
+		'Should not have rollback-health-failed in the state partition',
+	);
+
+	test.not(
+		await that.worker.executeCommandInHostOS(
+			`findmnt --noheadings --canonicalize --output SOURCE /mnt/sysroot/active`,
+			that.link,
+		),
+		activePartition,
+		`Should not have rolled back to the original root partition`,
+	);
+
+	test.is(
+		await that.worker.executeCommandInHostOS(
+			`balena volume inspect hello-world 1>/dev/null 2>&1; echo $?`,
+			that.link,
+		),
+		'0',
+		'Volume should not be lost during HUP',
+	);
+
+	test.comment('Checking files on the volume');
+	test.is(
+		await that.worker.executeCommandInHostOS(
+			`balena run -v hello-world:/the-volume alpine md5sum -c /the-volume/MD5.SUM &> /dev/null ; echo $?`,
+			that.link,
+		),
+		'0',
+		'Volume contents should have been preserved during HUP',
+	);
+
+	// Check for under-voltage after HUP, in the new OS
+	await that.hup.checkUnderVoltage(that, test);
+}


### PR DESCRIPTION
This is a small improvement over our previous test: in addition to
checking that the volumes themselves are preserved over HUPs, we now
check if the contents of these volumes is preserved.

Resolves https://github.com/balena-os/meta-balena/issues/2428

---

Took the chance for some refactoring on the code I was changing. So, in a second commit:

Our tests perform two HUPs (into and out of the release under test), and
the code for both of these HUPs were duplicated. This commit factors
this code out to a common function.
