### PR TITLE
balena-engine: Update to 20.10.17

### DIFF
--- a/meta-balena-common/recipes-containers/balena/balena_git.bb
+++ b/meta-balena-common/recipes-containers/balena/balena_git.bb
@@ -15,10 +15,10 @@ inherit goarch
 inherit pkgconfig
 inherit useradd
 
-BALENA_VERSION = "20.10.16"
+BALENA_VERSION = "20.10.17"
 BALENA_BRANCH= "master"
 
-SRCREV = "7ec512b1301592bd5ed1588b9bc5ee19471906b1"
+SRCREV = "13db38c82bdb056f013f5497b0662ad34ffb98f7"
 # NOTE: update patches when bumping major versions
 # [0] will have up-to-date versions, make sure poky version matches what
 # meta-balena uses


### PR DESCRIPTION
Update balena-engine from 20.10.16 to 20.10.17

Contains the fix to https://github.com/balena-os/balena-engine/issues/263

Fixes #2642