### PR TITLE
tests: cloud: reduce waitUntil interval

### DIFF
--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -304,7 +304,7 @@ module.exports = {
     await this.utils.waitUntil(async() => {
       console.log("Waiting for device to be online...");
       return await this.cloud.balena.models.device.isOnline(this.balena.uuid);
-    }, false);
+    }, false, 60, 5 * 1000);
 
     this.log("Device is online and provisioned successfully");
     
@@ -314,7 +314,7 @@ module.exports = {
         "cat /etc/hostname",
         this.balena.uuid
       ) === this.balena.uuid.slice(0, 7);
-    }, false);
+    }, false, 60, 5 * 1000);
 
     // create tunnels
     this.log('Creating SSH tunnels to DUT');
@@ -332,7 +332,7 @@ module.exports = {
           `${this.balena.uuid.slice(0, 7)}.local`
         )
       return (hostname === `${this.balena.uuid.slice(0, 7)}`)
-    }, true);
+    }, true, 60, 5 * 1000);
 
     this.log("Unpinning device from release");
     await this.cloud.balena.models.device.trackApplicationRelease(
@@ -344,7 +344,7 @@ module.exports = {
       return await this.cloud.balena.models.device.isTrackingApplicationRelease(
         this.balena.uuid
       );
-    }, false);
+    }, false, 60, 5 * 1000);
 
     // wait until the service is running before continuing
     await this.cloud.waitUntilServicesRunning(

--- a/tests/suites/cloud/tests/multicontainer/index.js
+++ b/tests/suites/cloud/tests/multicontainer/index.js
@@ -28,7 +28,7 @@ const waitUntilServicesRunning = async(that, uuid, services, commit, test) => {
       return (deviceServices.current_services[service][0].status === "Running") && (deviceServices.current_services[service][0].commit === commit)
     })
     return running;
-  }, false, 50)
+  }, false, 60, 5 * 1000)
 }
 
 module.exports = {
@@ -126,7 +126,7 @@ module.exports = {
           return services.every((service) => {
             return results[service] === true
           })
-        }, false, 30);
+        }, false, 60, 5 * 1000);
 
         test.ok(true, `Should see device env variable`);
       },
@@ -155,7 +155,7 @@ module.exports = {
           let env = await this.cloud.executeCommandInContainer(`env`, `frontend`, this.balena.uuid)
 
           return env.includes(`${key}=${value}\n`);
-        }, false, 30);
+        }, false, 60, 5 * 1000);
         test.ok(true, `Should service env var in service it was set for`);
       },
     },

--- a/tests/suites/cloud/tests/preload/index.js
+++ b/tests/suites/cloud/tests/preload/index.js
@@ -5,7 +5,7 @@ module.exports = {
     // make sure DUT is online
     await this.utils.waitUntil(() => {
       return this.cloud.balena.models.device.isOnline(this.balena.uuid);
-    }, false);
+    }, false, 60, 5 * 1000);
 
     // wait until the service is running
     await this.cloud.waitUntilServicesRunning(

--- a/tests/suites/cloud/tests/ssh-auth/index.js
+++ b/tests/suites/cloud/tests/ssh-auth/index.js
@@ -111,7 +111,7 @@ module.exports = {
 										result = await this.worker.executeCommandInHostOS('echo -n pass',
 											`${this.balena.uuid.slice(0, 7)}.local`);
 										return result
-									})
+									}, false, 60, 5 * 1000);
 							test.equals(
 								result,
 								"pass",
@@ -197,7 +197,7 @@ module.exports = {
 							result = await this.worker.executeCommandInHostOS('echo -n pass',
 								`${this.balena.uuid.slice(0, 7)}.local`);
 							return result
-						})
+						}, false, 60, 5 * 1000);
 					test.equals(
 						result,
 						"pass",
@@ -249,7 +249,7 @@ module.exports = {
 							result = await this.worker.executeCommandInHostOS('echo -n pass',
 								`${this.balena.uuid.slice(0, 7)}.local`);
 							return result
-						})
+						}, false, 60, 5 * 1000);
 					test.equals(
 						result,
 						"pass",

--- a/tests/suites/cloud/tests/supervisor/index.js
+++ b/tests/suites/cloud/tests/supervisor/index.js
@@ -13,7 +13,7 @@ const waitUntilServicesRunning = async(that, uuid, services, commit, test) => {
       return (deviceServices.current_services[service][0].status === "Running") && (deviceServices.current_services[service][0].commit === commit)
     })
     return running;
-  }, false, 50)
+  }, false, 60, 5 * 1000);
 }
 
 module.exports = {
@@ -114,7 +114,7 @@ module.exports = {
             }
           });
           return downloaded && originalRunning;
-        }, false, 50);
+        }, false, 60, 5 * 1000);
 
         test.ok(
           true,
@@ -129,7 +129,7 @@ module.exports = {
           );
 
           return updatesLocked === true
-        })
+        }, false, 60, 5 * 1000);
 
         test.ok(updatesLocked, `Update lock message should appear in logs`)
 


### PR DESCRIPTION
When the promise called in waitUntil fails, the function defaults to a
30s interval before trying again. Reduce this to a 5s interval w/
maximum 5m retry window in the cloud suite.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
