### PR TITLE
tests:cloud: Register teardown only when DUT is reachable

### DIFF
--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -297,10 +297,6 @@ module.exports = {
     await this.worker.flash(this.os.image.path);
     await this.worker.on();
 
-    this.suite.teardown.register(async () => {
-      await this.worker.archiveLogs(this.id, `${this.balena.uuid.slice(0, 7)}.local`,);
-    });
-
     await this.utils.waitUntil(async() => {
       console.log("Waiting for device to be online...");
       return await this.cloud.balena.models.device.isOnline(this.balena.uuid);
@@ -333,6 +329,11 @@ module.exports = {
         )
       return (hostname === `${this.balena.uuid.slice(0, 7)}`)
     }, true, 60, 5 * 1000);
+
+    // Retrieving journalctl logs: register teardown after device is reachable
+    this.suite.teardown.register(async () => {
+      await this.worker.archiveLogs(this.id, `${this.balena.uuid.slice(0, 7)}.local`,);
+    });
 
     this.log("Unpinning device from release");
     await this.cloud.balena.models.device.trackApplicationRelease(


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
