### PR TITLE
tests: cloud: check preloaded app starts w/o api

### DIFF
--- a/tests/suites/cloud/tests/preload/index.js
+++ b/tests/suites/cloud/tests/preload/index.js
@@ -1,8 +1,35 @@
 "use strict";
+
+const request = require('request-promise');
+
 module.exports = {
   title: "Image preload test",
   run: async function (test) {
+
+    // if test is being done on physical DUT via the testbot, check that the preloaded application is working
+    if(this.workerContract.workerType !== `qemu`){
+      // we should be able to see the app starting.
+      const ip = await this.worker.ip(this.link);
+      
+      // create tunnel to DUT port 80
+      console.log(`Creating tunnel to DUT port 80...`)
+      await this.worker.createTunneltoDUT(this.link, 80, 8899);
+      await this.utils.waitUntil(async () => {
+        console.log(`Checking preloaded app is running... `)
+        let page = await request({
+          method: 'GET',
+          uri: `http://${ip}:80`,
+        })
+        return page.includes("Welcome to balena!"); 
+      }, false);
+
+      test.ok(true, `Web page should be exposed on port 80 of DUT`)
+      // When we confirm the app has started, then re-enable internet access to DUT
+      await this.worker.executeCommandInWorker('sh -c "echo 1 > /proc/sys/net/ipv4/ip_forward"');
+    }
+
     // make sure DUT is online
+    console.log(`Waiting for DUT to be online in dashboard`)
     await this.utils.waitUntil(() => {
       return this.cloud.balena.models.device.isOnline(this.balena.uuid);
     }, false, 60, 5 * 1000);
@@ -26,5 +53,17 @@ module.exports = {
     );
 
     test.ok(!downloadedLog, `Device should run application without downloading`);
+
+    this.log("Unpinning device from release");
+    await this.cloud.balena.models.device.trackApplicationRelease(
+      this.balena.uuid
+    );
+
+    await this.utils.waitUntil(async () => {
+      console.log('Waiting for device to be running latest release...');
+      return await this.cloud.balena.models.device.isTrackingApplicationRelease(
+        this.balena.uuid
+      );
+    }, false);
   },
 };


### PR DESCRIPTION
Resolves: https://github.com/balena-os/meta-balena/issues/2634

Bring preload test more in line with testlodge case - make sure on physical devices (not qemu), to check preloaded app starts without api connectivity. This is achieved by disabling the internet connected to the DUT. 

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
