### PR TITLE
tests: Increase delay when testing randomized timers

### DIFF
--- a/tests/suites/cloud/tests/os-config/index.js
+++ b/tests/suites/cloud/tests/os-config/index.js
@@ -23,15 +23,13 @@ module.exports = {
 			title: 'os-config service randomized timer',
 			run: async function(test) {
 				const nextTriggers = []
-				nextTriggers.push( await this.cloud.executeCommandInHostOS(
-							`date -s "1 day" > /dev/null && sleep 0.5 && systemctl status os-config.timer | grep "Trigger:" | cut -d ';' -f2`,
-							this.balena.uuid))
-				nextTriggers.push( await this.cloud.executeCommandInHostOS(
-							`date -s "1 day" > /dev/null && sleep 0.5 && systemctl status os-config.timer | grep "Trigger:" | cut -d ';' -f2`,
-							this.balena.uuid))
-				nextTriggers.push( await this.cloud.executeCommandInHostOS(
-							`date -s "1 day" > /dev/null && sleep 0.5 && systemctl status os-config.timer | grep "Trigger:" | cut -d ';' -f2`,
-							this.balena.uuid))
+				let samples = 0
+				do {
+					nextTriggers.push( await this.cloud.executeCommandInHostOS(
+					`date -s "1 day" > /dev/null && sleep 2 && systemctl status os-config.timer | grep "Trigger:" | cut -d ';' -f2`,
+					this.balena.uuid))
+					samples = samples + 1
+				} while (samples < 3);
 				test.notOk (
 					nextTriggers.every( (v, i, a) => v === a[0] ),
 					'Service configuration has been fetched on a randomized timer'

--- a/tests/suites/cloud/tests/supervisor/index.js
+++ b/tests/suites/cloud/tests/supervisor/index.js
@@ -172,7 +172,7 @@ module.exports = {
           let samples = 0
           do {
               nextTriggers.push( await this.cloud.executeCommandInHostOS(
-              `date -s "+2 hours" > /dev/null && sleep 0.5 && systemctl status update-balena-supervisor.timer | grep "Trigger:" | cut -d ';' -f2`,
+              `date -s "+2 hours" > /dev/null && sleep 2 && systemctl status update-balena-supervisor.timer | grep "Trigger:" | cut -d ';' -f2`,
               this.balena.uuid))
               samples = samples + 1
           } while (samples < 3);


### PR DESCRIPTION
This should prevent failed tests on slower devices.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/balena-os/balena-generic/issues/74

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
