### PR TITLE
grub-efi: disable shim_lock when in secure boot mode

### DIFF
--- a/meta-balena-common/recipes-bsp/grub/grub-efi_%.bbappend
+++ b/meta-balena-common/recipes-bsp/grub/grub-efi_%.bbappend
@@ -35,7 +35,7 @@ do_mkimage() {
     cd ${B}
 
     if [ -f "${DEPLOY_DIR_IMAGE}/balena-keys/grub.gpg" ]; then
-        GRUB_PUBKEY_ARG="--pubkey ${DEPLOY_DIR_IMAGE}/balena-keys/grub.gpg"
+        GRUB_PUBKEY_ARG="--pubkey ${DEPLOY_DIR_IMAGE}/balena-keys/grub.gpg --disable-shim-lock"
     fi
 
     # Search for the grub.cfg on the local boot media by using the


### PR DESCRIPTION
Recent versions of GRUB default to use shim_lock when in secure boot mode.
We do not use shim and do not build the shim_lock module into GRUB EFI binary
therefore this needs to be disabled.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
