### PR TITLE
balena-efi.service: Mount if /mnt/boot/EFI is a symlink

### DIFF
--- a/meta-balena-common/recipes-support/resin-mounts/resin-mounts/balena-efi.service
+++ b/meta-balena-common/recipes-support/resin-mounts/resin-mounts/balena-efi.service
@@ -6,7 +6,7 @@ Requires=resin-boot.service
 Before=umount.target
 Conflicts=umount.target
 ConditionVirtualization=!docker
-ConditionPathExists=/dev/disk/by-state/balena-efi
+ConditionPathIsSymbolicLink=/mnt/boot/EFI
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This changes the condition in the unit file from checking whether
/dev/disk/by-state/balena-efi exists to checking whether /mnt/boot/EFI
is a symlink. The original approach has a race condition populating
the by-state symlink - it is depending on udev and if the link is
not present when the service is started (after the boot partition is mounted),
the service fails and the EFI partition is never mounted.

The new approach does the trick pretty well - /mnt/boot/EFI is a symlink
if the EFI partition is split and a regular directory in case there is a single
boot partition. That said the service is only started when necessary
and the waiting for udev is implemented as a part of the mount script.

Change-type: patch
Signed-off-by: Michal Toman <michalt@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
