### PR TITLE
resindataexpander: Move get_part_table_type to os-helpers-fs

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/resindataexpander
+++ b/meta-balena-common/recipes-core/initrdscripts/files/resindataexpander
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# shellcheck disable=SC1091
+. /usr/libexec/os-helpers-fs
+
 FREESPACE_LIMIT=10
 datapart=$(get_state_path_from_label "resin-data")
 dataparttype=$(lsblk "${datapart}" -nlo type)
@@ -14,11 +17,6 @@ if [ "${dataparttype}" = "crypt" ]; then
     datapartdev=$(ls "/sys/class/block/${datapartdev}/slaves")
 fi
 datadev=$(lsblk "/dev/${datapartdev}" -d -n -o PKNAME)
-
-get_part_table_type() {
-    parted -s "$1" print | grep "Partition Table" | tr -d " " |cut -d ":" -f2
-}
-
 pttype=$(get_part_table_type "/dev/${datadev}")
 
 resindataexpander_enabled() {

--- a/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -52,7 +52,7 @@ RDEPENDS:initramfs-module-machineid = "${PN}-base initramfs-module-udev"
 FILES:initramfs-module-machineid = "/init.d/91-machineid"
 
 SUMMARY:initramfs-module-resindataexpander = "Expand the data partition to the end of device"
-RDEPENDS:initramfs-module-resindataexpander = "${PN}-base initramfs-module-udev busybox parted util-linux-lsblk e2fsprogs-resize2fs"
+RDEPENDS:initramfs-module-resindataexpander = "${PN}-base initramfs-module-udev busybox parted util-linux-lsblk e2fsprogs-resize2fs os-helpers-fs"
 FILES:initramfs-module-resindataexpander = "/init.d/88-resindataexpander"
 
 SUMMARY:initramfs-module-rorootfs = "Mount our rootfs"

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
@@ -214,3 +214,10 @@ function get_part_start_by_number {
 
     parted "/dev/${DEVICE}" unit B print | grep "^[ \t]*${PART_NUMBER}[ \t][ \t]*" | awk '{print $2}' | sed -e "s,B$,,"
 }
+
+# Find the partition table type of the given block device
+# Arguments:
+#    1 - Block device
+get_part_table_type() {
+    parted -s "$1" print | grep "Partition Table" | tr -d " " | cut -d ":" -f2
+}


### PR DESCRIPTION
This is useful outside of the expander script, specifically in the init-board
script in device repos.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
