### PR TITLE
chronyd: Add periodic time synchronization check

### DIFF
--- a/meta-balena-common/recipes-core/chrony/chrony_%.bbappend
+++ b/meta-balena-common/recipes-core/chrony/chrony_%.bbappend
@@ -4,10 +4,20 @@ SRC_URI:append = " \
     file://chrony.conf \
     file://chronyd.conf.systemd \
     file://chrony-helper \
+    file://chrony-sync-check.service \
+    file://chrony-sync-check.timer \
+    file://chronyd-sync-check.sh \
     "
-FILES:${PN} += "${libexecdir}/chrony-helper"
+FILES:${PN} += "\
+    ${libexecdir}/chrony-helper \
+    ${libexecdir}/chronyd-sync-check"
 
 RDEPENDS:${PN} = "bash"
+
+SYSTEMD_SERVICE:${PN} += "\
+    chrony-sync-check.service \
+    chrony-sync-check.timer \
+"
 
 do_install:append() {
     install -m 0644 ${WORKDIR}/chrony.conf ${D}/${sysconfdir}/chrony.conf
@@ -17,4 +27,10 @@ do_install:append() {
     install -m 0644 ${WORKDIR}/chronyd.conf.systemd ${D}${sysconfdir}/systemd/system/chronyd.service.d/chronyd.conf
     install -d ${D}${libexecdir}
     install -m 0775 ${WORKDIR}/chrony-helper ${D}${libexecdir}
+
+    install -d ${D}${systemd_unitdir}/system/
+    install -d ${D}${sysconfdir}/systemd/system/multi-user.target.wants/
+    install -c -m 0755 ${WORKDIR}/chronyd-sync-check.sh ${D}${libexecdir}/chronyd-sync-check
+    install -c -m 0644 ${WORKDIR}/chrony-sync-check.service ${D}${systemd_unitdir}/system
+    install -c -m 0644 ${WORKDIR}/chrony-sync-check.timer ${D}${systemd_unitdir}/system
 }

--- a/meta-balena-common/recipes-core/chrony/files/chrony-sync-check.service
+++ b/meta-balena-common/recipes-core/chrony/files/chrony-sync-check.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=NTP time synchronization check
+Requires=chronyd.service
+After=chronyd.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/chronyc waitsync 60 0.1 0.0 1
+ExecStopPost=/usr/libexec/chronyd-sync-check
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-balena-common/recipes-core/chrony/files/chrony-sync-check.timer
+++ b/meta-balena-common/recipes-core/chrony/files/chrony-sync-check.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Periodic check for NTP time synchronization
+
+[Timer]
+OnUnitInactiveSec=64s
+RandomizedDelaySec=1024
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-balena-common/recipes-core/chrony/files/chronyd-sync-check.sh
+++ b/meta-balena-common/recipes-core/chrony/files/chronyd-sync-check.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+. /usr/libexec/os-helpers-logging
+
+if [ "${EXIT_STATUS}" != "0" ]; then
+	info "NTP time lost synchonization - forcing synchronization"
+
+	if ! /usr/bin/chronyc 'burst 4/4' > /dev/null ||
+		 ! /usr/bin/chronyc makestep > /dev/null; then
+		error "Failed to trigger NTP sync"
+	fi
+fi


### PR DESCRIPTION
By default, chronyd is configured to poll every ~4h to minimize bandwidth
use. However, if the sync fails, it won't retry until the next poll time.

This means that time can get out of sync on unreliable networks.

This commit introduces a timer that checks chrony synchronization status
on a varying time range between 1m and 15m, roughly equivalent to the
chronyd minpoll and maxpoll defaults which are 64s and 1024s respectively.
It checks synchronization once every 10s for 10 minutes, and syncs time
if not synchronized.

Fixes #2314

Change-type: minor
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
