### PR TITLE
tests: Add 243390 unmanged Wifi HATs tests from testLodge

### DIFF
--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -336,6 +336,7 @@ module.exports = {
   },
   tests: [
     "./tests/preload",
+    "./tests/device-specific-tests/hostapd",
     "./tests/supervisor",
     "./tests/multicontainer",
     "./tests/ssh-auth",

--- a/tests/suites/cloud/tests/device-specific-tests/hostapd/index.js
+++ b/tests/suites/cloud/tests/device-specific-tests/hostapd/index.js
@@ -1,0 +1,185 @@
+/* Copyright 2019 balena
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+const waitUntilServicesRunning = async (that, uuid, services, commit, test) => {
+	await that.utils.waitUntil(
+		async () => {
+			test.comment(
+				`Waiting for device: ${uuid} to run services: ${services} at commit: ${commit}`,
+			);
+			let deviceServices = await that.cloud.balena.models.device.getWithServiceDetails(
+				uuid,
+			);
+			let running = false;
+			running = services.every(service => {
+				return (
+					deviceServices.current_services[service][0].status === 'Running' &&
+					deviceServices.current_services[service][0].commit === commit
+				);
+			});
+			return running;
+		},
+		false,
+		60,
+		5 * 1000,
+	);
+};
+
+const waitUntilHotspotCreated = async (that, uuid, test) => {
+	let result = false;
+	await that.utils.waitUntil(
+		async () => {
+			test.comment(
+				`Waiting for device: ${uuid} to create hotspot in container`,
+			);
+			let output = await that.cloud.executeCommandInHostOS(
+				`if [[ -n "$(nmcli dev wifi list ifname wlan0 | grep -i test_eus)" ]]; then echo "PASSED"; else echo "FAILED"; fi`,
+				uuid,
+			);
+			result = output === 'PASSED';
+
+			return result;
+		},
+		true,
+		10,
+		5 * 1000,
+	);
+	return result;
+};
+
+module.exports = {
+	deviceType: {
+		type: 'object',
+		required: ['slug'],
+		properties: {
+			slug: {
+				type: 'string',
+				const: '243390-rpi3',
+			},
+		},
+	},
+	title: 'Hostapd access-point test for EUS chipset',
+	run: async function(test) {
+		const hostapdAppName = `${this.balena.application}_Hostapd`;
+
+		// create new application
+		await this.cloud.balena.models.application.create({
+			name: `${this.balena.name}_Hostapd`,
+			deviceType: this.os.deviceType,
+			organization: this.balena.organization,
+		});
+
+		this.context.set({
+			moveApp: hostapdAppName,
+		});
+
+		this.suite.context.set({
+			moveApp: hostapdAppName,
+		});
+
+		// Remove this app at the end of the test suite
+		this.suite.teardown.register(() => {
+			this.log(`Removing application ${hostapdAppName}`);
+			try {
+				return this.cloud.balena.models.application.remove(hostapdAppName);
+			} catch (e) {
+				this.log(`Error while removing application...`);
+			}
+		});
+
+		// push hostapd app release to new app
+		test.comment(`Cloning repo...`);
+		await exec(
+			`git clone https://github.com/balena-io-playground/hostapd_rtl8188eu.git ${__dirname}/app`,
+		);
+
+		test.comment(`Pushing release...`);
+		const initialCommit = await this.cloud.pushReleaseToApp(
+			hostapdAppName,
+			`${__dirname}/app`,
+		);
+		this.suite.context.set({
+			hostapd: {
+				initialCommit: initialCommit,
+			},
+		});
+		test.comment(`Release pushed succesfully...`);
+	},
+	tests: [
+		{
+			title: 'Move device to hostapd test App',
+			run: async function(test) {
+				await this.cloud.balena.models.device.move(
+					this.balena.uuid,
+					this.moveApp,
+				);
+
+				await waitUntilServicesRunning(
+					this,
+					this.balena.uuid,
+					[`main`],
+					this.hostapd.initialCommit,
+					test,
+				);
+
+				let hotspotCreated = await waitUntilHotspotCreated(
+					this,
+					this.balena.uuid,
+					test,
+				);
+
+				test.is(
+					hotspotCreated,
+					true,
+					'hostapd access point created successfuly',
+				);
+			},
+		},
+		{
+			title: 'Move device back to original app',
+			run: async function(test) {
+				test.comment(
+					`Will move device back to original app ${this.balena.application} `,
+				);
+				// move device back to original app
+				await this.cloud.balena.models.device.move(
+					this.balena.uuid,
+					this.balena.application,
+				);
+				test.comment(
+					`Moved device back to original app ${this.balena.application}, will now get commit`,
+				);
+				let commit = await this.cloud.balena.models.application.getTargetReleaseHash(
+					this.balena.application,
+				);
+				await waitUntilServicesRunning(
+					this,
+					this.balena.uuid,
+					[this.appServiceName],
+					commit,
+					test,
+				);
+				test.ok(
+					true,
+					`Device ${this.balena.application} is running its service`,
+				);
+			},
+		},
+	],
+};

--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -281,6 +281,7 @@ module.exports = {
 	},
 	tests: [
 		'./tests/device-specific-tests/beaglebone-black',
+		'./tests/device-specific-tests/243390-rpi3',
 		'./tests/fingerprint',
 		'./tests/fsck',
 		'./tests/os-release',

--- a/tests/suites/os/tests/device-specific-tests/243390-rpi3/assets/helpers.sh
+++ b/tests/suites/os/tests/device-specific-tests/243390-rpi3/assets/helpers.sh
@@ -1,0 +1,129 @@
+#!/bin/sh
+
+nm_cus_connection="
+[connection]
+id=hotspot
+uuid=60e385b1-6b4f-49be-9fcf-7548b3f4949b
+type=wifi
+interface-name=wlan1
+permissions=
+
+[wifi]
+mac-address-blacklist=
+mode=ap
+ssid=test_cus
+
+[wifi-security]
+group=ccmp;
+key-mgmt=wpa-psk
+pairwise=ccmp;
+proto=rsn;
+psk=test1234
+
+[ipv4]
+dns-search=
+method=shared
+
+[ipv6]
+addr-gen-mode=stable-privacy
+dns-search=
+method=ignore
+"
+
+nm_eus_connection="
+[connection]
+id=hotspot
+uuid=5169a8ec-2bae-490b-b091-d7163c10e30f
+type=wifi
+interface-name=wlan1
+permissions=
+
+[wifi]
+band=bg
+channel=6
+driver=nl80211
+beacon_int=100
+cloned-mac-address=permanent
+powersave=2
+mac-address-randomization=1
+mac-address-blacklist=
+mode=ap
+ssid=test_eus
+
+[wifi-security]
+auth-alg=open
+group=ccmp;
+key-mgmt=wpa-psk
+pairwise=ccmp;
+proto=rsn
+psk=Test123456
+
+[ipv4]
+address1=10.11.0.1/24,10.11.0.1
+dns-search=
+method=manual
+
+[ipv6]
+addr-gen-mode=stable-privacy
+dns-search=
+method=ignore
+"
+
+CUS_ADAPTER="0bda:8176"
+EUS_ADAPTER="0bda:8179"
+get_adapter() {
+	if lsusb | grep -q "${CUS_ADAPTER}" ; then
+		echo "cus"
+	elif lsusb | grep -q "${EUS_ADAPTER}" ; then
+		echo "eus";
+	else
+		echo "unknown";
+	fi;
+}
+
+wifi_adapter=$(get_adapter)
+
+cleanup_hotspot_connections() {
+	rm -rf /mnt/boot/system-connections/*hotspot* || true
+	rm -rf /etc/NetworkManager/system-connections/*hotspot* || true
+}
+
+add_hotspot_connection() {
+	cleanup_hotspot_connections
+
+	connection_file="/mnt/boot/system-connections/nm-${wifi_adapter}-hotspot.conf"
+	declare -n connection_contents="nm_${wifi_adapter}_connection"
+	echo "$connection_contents" > ${connection_file}
+	if [[ -f "${connection_file}" ]]; then echo "added"; else echo "failed"; fi;
+}
+
+test_hotspot() {
+	case ${wifi_adapter} in
+		eus)
+			;&
+		cus)
+			if nmcli dev wifi list ifname wlan0 | grep -q "test_${wifi_adapter}" ; then echo "passed"; else echo "failed"; fi
+			;;
+		*)
+			echo "unsupported or no adapter connected - failed"
+	esac
+}
+
+# wlan0 should always correspond to the internal wifi, while
+# wlan1 should always correspond to the usb adapter.
+test_interface_naming() {
+	if udevadm info -a /sys/class/net/wlan0 | grep -q brcmfmac ; then
+		case ${wifi_adapter} in
+			cus)
+				if udevadm info -a /sys/class/net/wlan1 | grep -q rtl8192 ; then echo "passed"; else echo "failed"; fi
+				;;
+			eus)
+				if udevadm info -a /sys/class/net/wlan1 | grep -q rtl8188 ; then echo "passed"; else echo "failed"; fi
+				;;
+			*)
+				echo "unsupported or no adapter connected - failed"
+		esac
+	else
+		echo "failed"
+	fi;
+}

--- a/tests/suites/os/tests/device-specific-tests/243390-rpi3/index.js
+++ b/tests/suites/os/tests/device-specific-tests/243390-rpi3/index.js
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require('fs');
+
+module.exports = {
+	deviceType: {
+		type: 'object',
+		required: ['slug'],
+		properties: {
+			slug: {
+				type: 'string',
+				const: '243390-rpi3',
+			},
+		},
+	},
+	title: '243390-rpi3 - CUS/EUS chipsets test',
+	run: async function(test) {
+		const testHelpers = fs
+			.readFileSync(`${__dirname}/assets/helpers.sh`)
+			.toString();
+
+		/* TC55, TC56 */
+		let output = await this.context
+			.get()
+			.worker.executeCommandInHostOS(
+				`${testHelpers} test_interface_naming`,
+				this.link,
+			);
+
+		test.is(
+			output.includes('passed'),
+			true,
+			'Wireless interfaces are named correctly',
+		);
+
+		/* TC50, TC51, TC52, TC53 */
+		output = await this.context
+			.get()
+			.worker.executeCommandInHostOS(
+				`${testHelpers} add_hotspot_connection`,
+				this.link,
+			);
+
+		test.is(
+			output.includes('added'),
+			true,
+			'NetworkManager hotspot connection added',
+		);
+
+		await this.worker.rebootDut(this.link);
+
+		await this.utils.waitUntil(
+			async () => {
+				output = await this.context.get().worker.executeCommandInHostOS(`${testHelpers} test_hotspot`, this.link);
+				return output.includes('passed');
+			},
+			true,
+			10,
+			5 * 1000
+		);
+
+		test.is(output.includes('passed'), true, 'Wifi hotspot is active');
+	},
+};


### PR DESCRIPTION
This covers the unmanaged part of the tests for the CUS
and EUS wifi chipsets on this DT.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Implements https://github.com/balena-os/meta-balena/issues/2541


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
