### PR TITLE
tests: os: make apiKey an optional parameter

### DIFF
--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -76,7 +76,8 @@ module.exports = {
 			this.suite.options.balena.organization, 
 			join(homedir(), 'id')
 		);
-		const cloud = new Balena(this.suite.options.balena.apiUrl, this.getLogger());
+
+		const cloud = new Balena(this.suite.options?.balena?.apiUrl, this.getLogger());
 
 		await fse.ensureDir(this.suite.options.tmpdir);
 
@@ -227,25 +228,21 @@ module.exports = {
 			await enableSerialConsole(this.os.image.path);
 		}
 
-
-		this.log("Logging into balena with balenaSDK");
-		await this.context
-		  .get()
-		  .cloud.balena.auth.loginWithToken(this.suite.options.balena.apiKey);
-		await this.context
-		.get()
-		.cloud.balena.models.key.create(
-			this.sshKeyLabel,
-			keys.pubKey
-		);
-		this.suite.teardown.register(() => {
-			return Promise.resolve(
-				this.context
-				.get()
-				.cloud.removeSSHKey(this.sshKeyLabel)
+		if (this.suite.options?.balena?.apiKey) {
+			this.log("Logging into balena with balenaSDK");
+			await this.cloud.balena.auth.loginWithToken(
+				this.suite.options.balena.apiKey
 			);
-		});
-
+			await this.cloud.balena.models.key.create(
+				this.sshKeyLabel,
+				keys.pubKey
+			);
+			this.suite.teardown.register(() => {
+				return Promise.resolve(
+					this.cloud.removeSSHKey(this.sshKeyLabel)
+				);
+			});
+		}
 
 		// Configure OS image
 		await this.os.configure();


### PR DESCRIPTION
When accessing a test device as part of a fleet, a cloud API key is
required in order to generate an SSH key and access the device through
the VPN. However, when accessing a device locally, such as a QEMU
instance running on the workstation itself, we have a direct path, and
no VPN is necessary.

Make the apiKey optional, and don't login when it's not specified. This
allows direct connections to work without it.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
