### PR TITLE
tests: os: modem: reduce time taken scanning for modems

### DIFF
--- a/tests/suites/os/tests/modem/index.js
+++ b/tests/suites/os/tests/modem/index.js
@@ -17,7 +17,7 @@
 const fsPromises = require('fs').promises;
 const CONFIG_FILE = `${__dirname}/modems.json`;
 
-const SCAN_ATTEMPTS = 10;
+const SCAN_ATTEMPTS = 5;
 const PING_ATTEMPTS = 3;
 
 module.exports = {
@@ -48,7 +48,7 @@ module.exports = {
         },
             false,
             SCAN_ATTEMPTS,
-            5000
+            1000
         )
             .catch(() => {
                 test.comment(`timeout after ${SCAN_ATTEMPTS} attempts`)


### PR DESCRIPTION
Reduce the interval between scans as well as the maximum number of scans
for modems, reducing the time spent waiting when no modem is present
from ~50s to ~5s.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
