### PR TITLE
tests: os: purge-data: reduce intervals in waitUntil

### DIFF
--- a/tests/suites/os/tests/purge-data/index.js
+++ b/tests/suites/os/tests/purge-data/index.js
@@ -26,7 +26,7 @@ async function waitUntilSupervisorActive(test, context){
 				uri: `http://${ip}:48484/ping`,
 			})) === 'OK'
 		);
-	}, false);
+	}, false, 2 * 60 * 4, 250);
 }
 
 module.exports = {
@@ -67,7 +67,7 @@ module.exports = {
 								this.link,
 							)) === 'active'
 					);
-				}, false);
+				}, false, 2 * 60 * 4, 250);
 
 				test.is(
 					await this.context
@@ -97,7 +97,7 @@ module.exports = {
 								this.link,
 							)) === 'active'
 					);
-				}, false);
+				}, false, 2 * 60 * 4, 250);
 
 				test.comment(`Waiting for supervisor service to be active...`);
 				await this.utils.waitUntil(async () => {
@@ -109,7 +109,7 @@ module.exports = {
 								this.link,
 							)) === 'active'
 					);
-				}, false);
+				}, false, 2 * 60 * 4, 250);
 
 				test.is(
 					await this.context
@@ -151,7 +151,7 @@ module.exports = {
 								this.link,
 							)) === 'active'
 					);
-				}, false);
+				}, false, 2 * 60 * 4, 250);
 
 				test.comment(`Waiting for supervisor service to be active...`);
 				await this.utils.waitUntil(async () => {
@@ -163,7 +163,7 @@ module.exports = {
 								this.link,
 							)) === 'active'
 					);
-				}, false);
+				}, false, 2 * 60 * 4, 250);
 
 				await waitUntilSupervisorActive(test, this.context.get());
 
@@ -203,7 +203,7 @@ module.exports = {
 								this.link,
 							)) === 'active'
 					);
-				}, false);
+				}, false, 2 * 60 * 4, 250);
 
 				test.comment(`Waiting for supervisor service to be active...`);
 				await this.utils.waitUntil(async () => {
@@ -215,7 +215,7 @@ module.exports = {
 								this.link,
 							)) === 'active'
 					);
-				}, false);
+				}, false, 2 * 60 * 4, 250);
 
 				test.comment(`Pruning all container images...`);
 				await this.context
@@ -235,7 +235,7 @@ module.exports = {
 								this.link,
 							)) === 'active'
 					);
-				}, false);
+				}, false, 2 * 60 * 4, 250);
 
 				await waitUntilSupervisorActive(test, this.context.get());
 


### PR DESCRIPTION
This reduces the time taken for the purge tests by approximately 30s

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
