### PR TITLE
tests: os: fingerprint: fix errant promise

### DIFF
--- a/tests/suites/os/tests/fingerprint/index.js
+++ b/tests/suites/os/tests/fingerprint/index.js
@@ -14,28 +14,23 @@
 
 'use strict';
 
-const Promise = require('bluebird');
-
 module.exports = {
 	title: 'OS corruption tests',
 	tests: [
 		{
-			title: 'resinos.fingerprint file test',
+			title: 'fingerprint file test',
 			run: async function(test) {
-				let p = Promise.any(
-					['/resinos.fingerprint', '/balenaos.fingerprint'].map(
-						async (fingerprint) => {
-							return this.worker.executeCommandInHostOS(
-								`md5sum --quiet -c ${fingerprint}`,
-								this.link,
-							);
-						}
-					)
-				);
-
 				return test.resolves(
-					p,
-					'resinos.fingerprint/balenaos.fingerprint file passed md5sum, no OS corruption detected.',
+					this.worker.executeCommandInHostOS(
+						'md5sum --quiet -c /balenaos.fingerprint',
+						this.link,
+					).catch(
+						() => this.worker.executeCommandInHostOS(
+							'md5sum --quiet -c /resinos.fingerprint',
+							this.link,
+						)
+					),
+					'resinos.fingerprint/balenaos.fingerprint file passed md5sum, no OS corruption detected.'
 				);
 			},
 		},


### PR DESCRIPTION
When parallelizing fingerprint checks with Promise.any(), the
unsuccessful command would continue retrying in the background, causing
spurious error messages.

With mDNS resolution memoization, this optimization no longer saves us
time, so remove it.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
