### PR TITLE
tests: cloud: Wait for random triggers to be updated

### DIFF
--- a/tests/suites/cloud/tests/os-config/index.js
+++ b/tests/suites/cloud/tests/os-config/index.js
@@ -26,14 +26,29 @@ module.exports = {
 				let samples = 0
 				do {
 					nextTriggers.push( await this.cloud.executeCommandInHostOS(
-					`date -s "1 day" > /dev/null && sleep 2 && systemctl status os-config.timer | grep "Trigger:" | cut -d ';' -f2`,
-					this.balena.uuid))
-					samples = samples + 1
+						`date -s "1 day" > /dev/null`,
+						this.balena.uuid
+					  ).then(async () => {
+						let trigger;
+						await this.utils.waitUntil(async () => {
+						  // on slower hardware this command can return an empty string so don't proceed
+						  // until we have a value for trigger
+						  trigger = await this.cloud.executeCommandInHostOS(
+							`systemctl status os-config.timer | grep "Trigger:" | awk '{print $4}'`,
+							this.balena.uuid
+						  );
+						  return trigger !== "";
+						}, false, 20, 500)
+						return trigger;
+					  })
+					);
+					samples = samples + 1;
 				} while (samples < 3);
-				test.notOk (
-					nextTriggers.every( (v, i, a) => v === a[0] ),
-					'Service configuration has been fetched on a randomized timer'
-				)
+				test.ok (
+					// check that all results are unique
+					(new Set(nextTriggers)).size === nextTriggers.length,
+					'Service configuration will be fetched on a randomized timer'
+				  )
 				/* Restore current time */
 				await this.cloud.executeCommandInHostOS(
 					`chronyc -a 'burst 4/4'`,


### PR DESCRIPTION
This prevents a race condition on slower hardware where
the systemd unit does not have a value for Trigger immediately
after skewing the clock.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/balena-os/balena-generic/issues/74
Resolves: https://github.com/balena-os/balena-raspberrypi/issues/852
Resolves: https://github.com/balena-os/balena-beaglebone/issues/351

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
