### PR TITLE
tests: os: engine-socket - wait for response before continuing test

### DIFF
--- a/tests/suites/os/tests/engine-socket/index.js
+++ b/tests/suites/os/tests/engine-socket/index.js
@@ -43,12 +43,21 @@ module.exports = {
 				}, false);
 				test.comment(`Verify engine socket is exposed`)
 
-				await test.doesNotThrow(
-						docker.info(function (err, info) {
-							if (err) {
-								throw new Error(`Docker info failed: ${err}`);
-							}
-						}),
+				await test.resolves(
+					this.utils.waitUntil(async () => {
+						await new Promise((resolve, reject) => {
+							docker.info(function (err, info) {
+								if (err){
+									reject(`Docker info failed: ${err}`);
+								} else {
+									console.log('got response, resolving!')
+									resolve(info)
+								}
+							})
+						})
+						
+						return true
+					}, false, 5, 500),
 					"Engine socket should be exposed in development images"
 				);
 			},


### PR DESCRIPTION
During the engine-socket test, there was a race condition that developed because the test would progress with a `#todo` instead of waiting for the response from the DUT engine. This meant that in some cases (mainly with the pi3-64 DUT) the test would progress, the DUT put into prod mode, which would make the previous request to the engine fail, killing the test run

resolves https://github.com/balena-os/balena-raspberrypi/issues/895

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
