### PR TITLE
tests: ssh-auth: Rework to prevent race conditions

### DIFF
--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -265,7 +265,7 @@ module.exports = {
     config.deviceApiKey = deviceRegInfo.api_key;
     config.deviceId = deviceRegInfo.id;
     config.persistentLogging = true;
-    config.developmentMode= true;
+    config.developmentMode = true;
 
     // get ready to populate DUT image config.json with the attributes we just generated
     this.os.addCloudConfig(config);
@@ -310,7 +310,6 @@ module.exports = {
     await this.worker.flash(this.os.image.path);
     await this.worker.on();
 
-
     // create tunnels
     this.log('Creating SSH tunnels to DUT');
     await this.worker.createSSHTunnels(
@@ -331,7 +330,7 @@ module.exports = {
 
     // Retrieving journalctl logs: register teardown after device is reachable
     this.suite.teardown.register(async () => {
-      await this.worker.archiveLogs(this.id, this.link);
+      await this.worker.archiveLogs(this.id, this.balena.uuid);
     });
 
   },


### PR DESCRIPTION
Use a common function to apply settings in config.json to avoid
code duplication. It also provides timed results so we know
how long it took to apply a setting.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/balena-os/balena-generic/issues/118
Resolves: https://github.com/balena-os/meta-balena/issues/2726
Resolves: https://github.com/balena-os/meta-balena/issues/2679
Resolves: https://github.com/balena-os/balena-beaglebone/issues/335

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
