### PR TITLE
balena-config-vars: Do not use cache in flasher images

### DIFF
--- a/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/balena-config-defaults
+++ b/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/balena-config-defaults
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 # Default values
-BALENA_CONFIG_VARS_CACHE="/var/cache/balena-config-vars"
 BALENA_BOOT_MOUNTPOINT="/mnt/boot"
 # Do not use - left here for backwards compatibility - use BALENA_BOOT_MOUNTPOINT instead
 BOOT_MOUNTPOINT="${BALENA_BOOT_MOUNTPOINT}"
@@ -12,5 +11,6 @@ if [ -z "$CONFIG_PATH" ]; then
         CONFIG_PATH=/mnt/boottmp/config.json
     else
         CONFIG_PATH=$BALENA_BOOT_MOUNTPOINT/config.json
+        BALENA_CONFIG_VARS_CACHE="/var/cache/balena-config-vars"
     fi
 fi

--- a/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/balena-config-vars
+++ b/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/balena-config-vars
@@ -46,10 +46,10 @@ done
 # Source static defaults
 . /usr/sbin/balena-config-defaults
 
-if [ "${USE_CACHE}" -eq "1" ] && [ -f "${BALENA_CONFIG_VARS_CACHE}" ]; then
+if [ "${USE_CACHE}" -eq "1" ] && [ -n "${BALENA_CONFIG_VARS_CACHE}" ] && [ -f "${BALENA_CONFIG_VARS_CACHE}" ]; then
         . "${BALENA_CONFIG_VARS_CACHE}"
 else
-    rm -f "${BALENA_CONFIG_VARS_CACHE}"
+    [ -n "${BALENA_CONFIG_VARS_CACHE}" ] && [ -f "${BALENA_CONFIG_VARS_CACHE}" ] && rm -f "${BALENA_CONFIG_VARS_CACHE}"
 
     # If config.json provides redefinitions for our vars let us rewrite their
     # runtime value
@@ -83,9 +83,11 @@ else
             echo "[ERROR] $0: Failed to parse '$CONFIG_PATH'."
             exit 1
         else
-            tmpfile=$(mktemp)
-            echo "${CONFIG_PARAMS}" | sed -e 's/^[[:space:]]*//' > "${tmpfile}"
-            mv "${tmpfile}" "${BALENA_CONFIG_VARS_CACHE}"
+            if [ -n "${BALENA_CONFIG_VARS_CACHE}" ]; then
+                tmpfile=$(mktemp)
+                echo "${CONFIG_PARAMS}" | sed -e 's/^[[:space:]]*//' > "${tmpfile}"
+                mv "${tmpfile}" "${BALENA_CONFIG_VARS_CACHE}"
+            fi
             eval "$CONFIG_PARAMS"
         fi
     else


### PR DESCRIPTION
Flasher images use an alternative configuration storage so skip caching.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
