### PR TITLE
tests: cloud: supervisor: use minimal app image

### DIFF
--- a/tests/suites/cloud/app/Dockerfile.aarch64
+++ b/tests/suites/cloud/app/Dockerfile.aarch64
@@ -1,0 +1,4 @@
+FROM alpine@sha256:c3c58223e2af75154c4a7852d6924b4cc51a00c821553bbd9b3319481131b2e0
+
+COPY entry.sh .
+CMD ./entry.sh

--- a/tests/suites/cloud/app/Dockerfile.amd64
+++ b/tests/suites/cloud/app/Dockerfile.amd64
@@ -1,0 +1,4 @@
+FROM alpine@sha256:4ff3ca91275773af45cb4b0834e12b7eb47d1c18f770a0b151381cd227f4c253
+
+COPY entry.sh .
+CMD ./entry.sh

--- a/tests/suites/cloud/app/Dockerfile.armv7hf
+++ b/tests/suites/cloud/app/Dockerfile.armv7hf
@@ -1,0 +1,4 @@
+FROM alpine@sha256:0615cdd745d0b78e7e6ac3a7b1f02e4daefa664eae0324120955f4e4c91bea3f
+
+COPY entry.sh .
+CMD ./entry.sh

--- a/tests/suites/cloud/app/docker-compose.yml
+++ b/tests/suites/cloud/app/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "2"
+
+services:
+  balena-hello-world:
+    build: .
+    ports:
+      - "80:80"

--- a/tests/suites/cloud/app/entry.sh
+++ b/tests/suites/cloud/app/entry.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+# https://funprojects.blog/2021/04/11/a-web-server-in-1-line-of-bash/
+run_server() {
+	while true; do { \
+		printf "HTTP/1.0 200 OK\r\nContent-Length: %s\r\n\r\n%s" \
+			"$(printf "%s" "$1" | wc -c)" "$1"; \
+		} | nc -l -p 80; \
+	done
+}
+
+# https://raw.githubusercontent.com/balena-io-examples/balena-nodejs-hello-world/master/views/index.html
+doc=$(cat <<'EOF'
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Welcome to balena!</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" type="text/css" media="screen" href="public/bootstrap.min.css" />
+    <link rel="stylesheet" type="text/css" media="screen" href="public/main.css" />
+  </head>
+  <body>
+    <div class="header">
+      <nav class="navbar">
+        <div class="container d-flex justify-content-center">
+          <a href="http://balena.io/" target="_blank">
+            <img style="width: 6rem; height: auto;" src="public/logo.svg">
+          </a>
+        </div>
+      </nav>
+    </div>
+
+    <div class="container mt-5 mb-5 p-0 pb-5">
+
+      <div class="row d-flex flex-column align-items-center">
+        <h1>Welcome to balena!</h1>
+        <p class="text-center pl-5 pr-5 pt-0 pb-0">Now that you've deployed code to your device,<br /> explore the resources below to continue on your journey!</p>
+      </div>
+
+      <div class="row d-flex justify-content-center">
+        <div class="box">
+          <h5 class="title">Read our documentation</h5>
+          <ul>
+            <li>Learn how balena works behind the scenes</li>
+            <li>Run multiple containers in your application</li>
+            <li>Fast development with local development mode</li>
+            <li>Deploy device configurations across your fleet</li>
+            <li>And much more!</li>
+          </ul>
+          <br />
+          <a class="button" href="https://www.balena.io/docs">Explore the balena documentation</a>
+        </div>
+
+        <div class="box">
+          <h5 class="title">Discover more balena project ideas</h5>
+
+          <p>Find inspiration for what to build next, deploy another cool project,<br /> or join your device to an open fleet!</p>
+          <a class="button" href="https://hub.balena.io/">View projects on hub.balena.io</a>
+          <br />
+          <a href="https://github.com/balena-io-examples">balena example projects</a>
+          <span class="separator">|</span>
+          <a href="https://github.com/balenalabs">Projects by balena</a>
+          <span class="separator">|</span>
+          <a href="https://forums.balena.io/c/projects">Projects in our forums</a>
+        </div>
+
+        <div class="box">
+          <h5 class="title">Get additional help</h5>
+          <p>Need to ask a question or get product support?</p>
+          <a class="button" href="https://forums.balena.io/">Visit our forums</a>
+          <br />
+          <a href="https://www.balena.io/contact-sales/">Contact sales</a>
+          <span class="separator">|</span>
+          <a href="https://www.balena.io/support/">Learn about balena support</a>
+        </div>
+
+      </div>
+
+    </div>
+    <canvas id="canvas"></canvas>
+    <script src="public/confetti.js"></script>
+  </body>
+</html>
+EOF
+)
+
+run_server "$doc"

--- a/tests/suites/cloud/multicontainer-app/Dockerfile.aarch64
+++ b/tests/suites/cloud/multicontainer-app/Dockerfile.aarch64
@@ -1,0 +1,1 @@
+../app/Dockerfile.aarch64

--- a/tests/suites/cloud/multicontainer-app/Dockerfile.amd64
+++ b/tests/suites/cloud/multicontainer-app/Dockerfile.amd64
@@ -1,0 +1,1 @@
+../app/Dockerfile.amd64

--- a/tests/suites/cloud/multicontainer-app/Dockerfile.armv7hf
+++ b/tests/suites/cloud/multicontainer-app/Dockerfile.armv7hf
@@ -1,0 +1,1 @@
+../app/Dockerfile.armv7hf

--- a/tests/suites/cloud/multicontainer-app/docker-compose.yml
+++ b/tests/suites/cloud/multicontainer-app/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "2"
+
+services:
+  foo:
+    build: .
+    expose:
+      - "80"
+  bar:
+    build: .
+    command: "sleep infinity"
+  baz:
+    build: .
+    command: "sleep infinity"

--- a/tests/suites/cloud/multicontainer-app/entry.sh
+++ b/tests/suites/cloud/multicontainer-app/entry.sh
@@ -1,0 +1,1 @@
+../app/entry.sh

--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -158,17 +158,15 @@ module.exports = {
       }
     });
 
+    const appSource = `${__dirname}/app`;
     // Push a single container application
     this.log(`Cloning getting started repo...`);
     this.suite.context.set({
-      appPath: `${__dirname}/app`,
+      appPath: appSource,
       appServiceName: `balena-hello-world`
     })
-    await exec(
-      `git clone https://github.com/balena-io-examples/balena-node-hello-world.git ${this.appPath}`
-    );
     this.log(`Pushing release to app...`);
-    const initialCommit = await this.cloud.pushReleaseToApp(this.balena.application, `${__dirname}/app`)
+    const initialCommit = await this.cloud.pushReleaseToApp(this.balena.application, appSource)
     this.suite.context.set({
       balena: {
         initialCommit: initialCommit

--- a/tests/suites/cloud/tests/multicontainer/index.js
+++ b/tests/suites/cloud/tests/multicontainer/index.js
@@ -64,13 +64,8 @@ module.exports = {
     });
 
     // push multicontainer app release to new app
-    test.comment(`Cloning repo...`);
-    await exec(
-      `git clone https://github.com/balena-io-examples/multicontainer-getting-started.git ${__dirname}/app`
-    );
-
     test.comment(`Pushing release...`);
-    const initialCommit = await this.cloud.pushReleaseToApp(moveApplicationName, `${__dirname}/app`)
+    const initialCommit = await this.cloud.pushReleaseToApp(moveApplicationName, `${__dirname}/../../multicontainer-app`);
     this.suite.context.set({
       multicontainer: {
         initialCommit: initialCommit
@@ -90,7 +85,7 @@ module.exports = {
         await waitUntilServicesRunning(
           this,
           this.balena.uuid, 
-          [`frontend`, `proxy`, `data`], 
+          [`foo`, `bar`, `baz`],
           this.multicontainer.initialCommit,
           test
         )
@@ -112,11 +107,11 @@ module.exports = {
           );
 
         // Check that device env variable is present in each service
-        let services  = [`frontend`, `proxy`, `data`]
+        let services  = [`foo`, `bar`, `baz`];
         await this.utils.waitUntil(async () => {
           let results = {}
           for (let service of services){
-            let env = await this.cloud.executeCommandInContainer(`env`, service, this.balena.uuid)
+            let env = await this.cloud.executeCommandInContainer(`env`, service, this.balena.uuid);
             if (env.includes(`${key}=${value}\n`)){
               results[service] = true
             } else {
@@ -141,10 +136,10 @@ module.exports = {
             this.balena.uuid
           );
 
-        // set device service variable for frontend service
+        // set device service variable for 'foo' service
         await this.cloud.balena.models.device.serviceVar.set(
             this.balena.uuid,
-            services.current_services.frontend[0].service_id,
+            services.current_services.foo[0].service_id,
             key,
             value
           );
@@ -152,7 +147,7 @@ module.exports = {
         // Check to see if variable is present in front end service
         await this.utils.waitUntil(async () => {
           test.comment("Checking to see if variables are visible...");
-          let env = await this.cloud.executeCommandInContainer(`env`, `frontend`, this.balena.uuid)
+          let env = await this.cloud.executeCommandInContainer(`env`, `foo`, this.balena.uuid);
 
           return env.includes(`${key}=${value}\n`);
         }, false, 60, 5 * 1000);

--- a/tests/suites/cloud/tests/multicontainer/index.js
+++ b/tests/suites/cloud/tests/multicontainer/index.js
@@ -187,7 +187,7 @@ module.exports = {
             this.balena.uuid
           )
           return deviceHash === commit
-        })
+        }, false, 60, 5 * 1000);
 
         test.ok(
           true,

--- a/tests/suites/cloud/tests/preload/index.js
+++ b/tests/suites/cloud/tests/preload/index.js
@@ -64,6 +64,6 @@ module.exports = {
       return await this.cloud.balena.models.device.isTrackingApplicationRelease(
         this.balena.uuid
       );
-    }, false);
+    }, false, 60, 5 * 1000);
   },
 };

--- a/tests/suites/cloud/tests/preload/index.js
+++ b/tests/suites/cloud/tests/preload/index.js
@@ -61,7 +61,7 @@ module.exports = {
 
     await this.utils.waitUntil(async () => {
       console.log('Waiting for device to be running latest release...');
-      return await this.cloud.balena.models.device.isTrackingApplicationRelease(
+      return this.cloud.balena.models.device.isTrackingApplicationRelease(
         this.balena.uuid
       );
     }, false, 60, 5 * 1000);


### PR DESCRIPTION
Several supervisor tests in the managed cloud suite depend on the
balena-nodejs-hello-world app, which builds a ~225 MB image for testing.
Building, pushing, and pulling this image is time consuming. Switch to a
minimal image that accomplishes much the same thing.

This cuts approximately a minute from the supervisor tests.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
