### PR TITLE
tests/cloud: fix ssh prod test for physical duts

### DIFF
--- a/tests/suites/cloud/tests/ssh-auth/index.js
+++ b/tests/suites/cloud/tests/ssh-auth/index.js
@@ -20,7 +20,7 @@ const exec = Bluebird.promisify(require('child_process').exec);
 const { join, dirname } = require("path");
 const { homedir } = require("os");
 const fse = require("fs-extra");
-const sshPath = join(homedir(), "test_id");
+const sshPath = join(homedir(), "id");
 
 const setConfig = async (test, that, target, key, value) => {
 
@@ -117,7 +117,7 @@ module.exports = {
 					}).catch((err) => {
 						return test.match(
 							err.message,
-							/All configured authentication methods failed/,
+							/All configured authentication methods failed|Connection lost before handshake/,
 							"Local SSH authentication without custom keys is not allowed in production mode"
 						);
 					});
@@ -136,7 +136,7 @@ module.exports = {
 							result = await this.worker.executeCommandInHostOS('echo -n pass',
 								this.link);
 							return result
-						}, false, 60, 5 * 1000);
+						}, false, 10, 5 * 1000);
 					return test.equals(
 						result,
 						"pass",
@@ -173,7 +173,7 @@ module.exports = {
 							result = await this.worker.executeCommandInHostOS('echo -n pass',
 								this.link);
 							return result
-						}, false, 60, 5 * 1000);
+						}, false, 10, 5 * 1000);
 					return test.equals(
 						result,
 						"pass",
@@ -214,7 +214,7 @@ module.exports = {
 							result = await this.worker.executeCommandInHostOS('echo -n pass',
 								this.link);
 							return result
-						}, false, 60, 5 * 1000);
+						}, false, 10, 5 * 1000);
 					return test.equals(
 						result,
 						"pass",


### PR DESCRIPTION
fixes 2 errors with the ssh keys test in the cloud suite:
1. When using the testbot setup, the error message that is returned on the expected failed ssh (no keys set up) is different to the qemu setup - fixed the check to check for both
2. the newly generated ssh keys were being sent to the wrong location on the testbot - fixed

I also reduced the timouts in the waituntils as they were multiple hours long

tested on pi4 and pi3

resolves:  https://github.com/balena-os/meta-balena/issues/2744

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
