### PR TITLE
resin-partition-mounter: resin-data-override support

### DIFF
--- a/meta-balena-common/recipes-support/resin-mounts/resin-mounts/resin-partition-mounter
+++ b/meta-balena-common/recipes-support/resin-mounts/resin-mounts/resin-partition-mounter
@@ -108,8 +108,8 @@ fi
 if [ "$target" = "resin-data" ]; then
     overwriting_target_path="$(get_state_path_from_label "resin-data-override")"
     if [ -z $overwriting_target_path ]; then
-        target = "resin-data-override"
-        target_path = overwriting_target_path
+        target="resin-data-override"
+        target_path=$overwriting_target_path
     fi
 fi
 

--- a/meta-balena-common/recipes-support/resin-mounts/resin-mounts/resin-partition-mounter
+++ b/meta-balena-common/recipes-support/resin-mounts/resin-mounts/resin-partition-mounter
@@ -103,6 +103,16 @@ if [ ! -d "$target_mountpoint" ]; then
     echo "ERROR: Target mountpoint $target_mountpoint not found."
     exit 1
 fi
+
+# Use resin-data-override instead of resin-data it available
+if [ "$target" = "resin-data" ]; then
+    overwriting_target_path="$(get_state_path_from_label "resin-data-override")"
+    if [ -z $overwriting_target_path ]; then
+        target = "resin-data-override"
+        target_path = overwriting_target_path
+    fi
+fi
+
 if ! wait4file "$target_path" "$TIMEOUT_LOOPS"; then
     echo "ERROR: Timeout while waiting for $target_path to come up."
     exit 1


### PR DESCRIPTION
This PR adds the feature described [here](https://forums.balena.io/t/method-for-mounting-external-storage-to-multiple-containers/53248/8).

It adds the rule to the resin-partition-mounter script that instead of the `resin-data` the `resin-data-override` partition is used as data partition, if available.

As this partition may live on another drive, this allows the use of non-boot media as primary storage.
This also lifts the limitation that that external storage can only be made partition to a single container. 

Next I will test this feature manually with a jetson nano emmc and an nvme ssd. Maybe someone with more insight in how to do so could also write a test suite.

Signed-off-by: Tom Julux <42802270+Tom-Julux@users.noreply.github.com>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->

- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [X] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
