### PR TITLE
balena: remove kernel-module-nf-nat-native dependency for host build

### DIFF
--- a/meta-balena-common/recipes-containers/balena/balena_git.bb
+++ b/meta-balena-common/recipes-containers/balena/balena_git.bb
@@ -50,7 +50,7 @@ GROUPADD_PARAM:${PN} = "-r balena-engine"
 
 DEPENDS:append:class-target = " systemd"
 RDEPENDS:${PN}:class-target = "curl util-linux iptables tini systemd healthdog bash procps-ps"
-RRECOMMENDS:${PN} += "kernel-module-nf-nat"
+RRECOMMENDS:${PN}:class-target += "kernel-module-nf-nat"
 
 # oe-meta-go recipes try to build go-cross-native
 DEPENDS:remove:class-native = "go-cross-native"


### PR DESCRIPTION
This fixes the following error when building mkfs-hostapp-native with Honister for a Variscite iMX8MM which only has Hardknott support:

mkfs-hostapp-native-1.0-r0 do_prepare_recipe_sysroot:
  Manifest /work/build/tmp/sstate-control/manifest-x86_64_x86_64-nativesdk-linux-libc-headers.populate_sysroot not found
  in cortexa53 armv8a-crc armv8a aarch64 allarch x86_64_x86_64-nativesdk (variant '')?

Remove the module since it's not used by the build host anyway

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested in local yocto build
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
