### PR TITLE
balena-config-vars: Set permissions for cache file

### DIFF
--- a/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/balena-config-vars
+++ b/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/balena-config-vars
@@ -112,6 +112,7 @@ else
             if [ -n "${BALENA_CONFIG_VARS_CACHE}" ]; then
                 tmpfile=$(mktemp)
                 echo "${CONFIG_PARAMS}" | sed -e 's/^[[:space:]]*//' > "${tmpfile}"
+                chmod a+rx "${tmpfile}"
                 mv "${tmpfile}" "${BALENA_CONFIG_VARS_CACHE}"
             fi
             eval "$CONFIG_PARAMS"

--- a/tests/suites/cloud/tests/ssh-auth/index.js
+++ b/tests/suites/cloud/tests/ssh-auth/index.js
@@ -142,8 +142,36 @@ module.exports = {
 						"pass",
 						"Local SSH authentication with custom keys is allowed in production mode"
 					);
-				}).then(async () => {
-					return setConfig(test, this, this.balena.uuid, 'os.sshKeys');
+			  }).then(async () => {
+					await setConfig(test, this, this.balena.uuid, 'os.sshKeys');
+			  }).then(async () => {
+					let result;
+					let ip = await this.worker.getDutIp(this.link);
+					let config = {}
+					await this.cloud.balena.models.key.create(this.suite.options.id, customKey.pubKey);
+					config = {
+						host: ip,
+						port: '22222',
+						username: this.worker.username,
+						privateKeyPath: `${sshPath}`
+					};
+					await this.utils.waitUntil(
+						async () => {
+							try {
+								result = await this.utils.executeCommandOverSSH('echo -n pass',
+								config);
+							} catch (err) {
+								console.error(err.message);
+								throw new Error(err);
+							}
+							return result
+						}, false, 10, 5 * 1000);
+					return test.equals(
+						result.stdout,
+						"pass",
+						"Local SSH authentication with balenaCloud registered keys is allowed in production mode"
+					)
+					await this.cloud.balena.removeSSHKey(this.suite.options.id);
 				});
 			},
 		},
@@ -222,6 +250,34 @@ module.exports = {
 					)
 				}).then(async () => {
 					return setConfig(test, this, this.balena.uuid, 'os.sshKeys');
+				}).then(async () => {
+					let result;
+					let ip = await this.worker.getDutIp(this.link);
+					let config = {}
+					await this.cloud.balena.models.key.create(this.suite.options.id, customKey.pubKey);
+					config = {
+						host: ip,
+						port: '22222',
+						username: this.worker.username,
+						privateKeyPath: `${sshPath}`
+					};
+					await this.utils.waitUntil(
+						async () => {
+							try {
+								result = await this.utils.executeCommandOverSSH('echo -n pass',
+									config);
+							} catch (err) {
+								console.error(err.message);
+								throw new Error(err);
+							}
+							return result
+						}, false, 10, 5 * 1000);
+					return test.equals(
+						result.stdout,
+						"pass",
+						"Local SSH authentication with balenaCloud registered keys is allowed in development mode"
+					)
+					await this.cloud.balena.removeSSHKey(this.suite.options.id);
 				});
 			},
 		},

--- a/tests/suites/cloud/tests/ssh-auth/index.js
+++ b/tests/suites/cloud/tests/ssh-auth/index.js
@@ -24,7 +24,7 @@ const sshPath = join(homedir(), "test_id");
 
 const setConfig = async (test, that, target, key, value) => {
 
-	test.test(`Update or delete ${key} in config.json`, t =>
+	return test.test(`Update or delete ${key} in config.json`, t =>
 		t.resolves(
 			that.waitForServiceState(
 				'config-json.service',

--- a/tests/suites/cloud/tests/ssh-auth/index.js
+++ b/tests/suites/cloud/tests/ssh-auth/index.js
@@ -20,7 +20,7 @@ const exec = Bluebird.promisify(require('child_process').exec);
 const { join, dirname } = require("path");
 const { homedir } = require("os");
 const fse = require("fs-extra");
-const sshPath = join(homedir(), "id");
+const sshPath = join(homedir(), "test_id");
 
 const setConfig = async (test, that, target, key, value) => {
 


### PR DESCRIPTION
The sshd daemon is configured to fetch keys from the API for local user connections. The script that fetches the keys, cloud-public-sshkeys, sources balena-config-vars and is run as am exclusive non-root user.

Let's set the correct permissions for this file to allow not to break the above.

Fixes #2785

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
