### PR TITLE
mobynit: allow compile task to use network

### DIFF
--- a/meta-balena-common/recipes-containers/mobynit/mobynit_git.bb
+++ b/meta-balena-common/recipes-containers/mobynit/mobynit_git.bb
@@ -14,6 +14,7 @@ SRCREV="0423d69ee52970bb8eeae46da8f1d5cf7a8c948c"
 
 S = "${WORKDIR}/${BPN}/src/${GO_IMPORT}"
 
+do_compile[network] = "1"
 do_compile() {
     cd ${S}
     unset GO_LDFLAGS


### PR DESCRIPTION
Mobynit requires network access to fetch dependencies.

Signed-off-by: Joseph Kogut <joseph@balena.io>
Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
