### PR TITLE
ntp: Remove race condition from directory creation

### DIFF
--- a/meta-balena-common/recipes-connectivity/balena-ntp-config/balena-ntp-config/balena-ntp-config
+++ b/meta-balena-common/recipes-connectivity/balena-ntp-config/balena-ntp-config/balena-ntp-config
@@ -18,8 +18,7 @@ else
 fi
 
 if [ ! -d "$SERVER_DIR" ]; then
-	mkdir -p $SERVER_DIR
-	chmod 750 $SERVER_DIR
+	mkdir -p $SERVER_DIR -m 770
 fi
 
 # Always remove the old server file before we refresh the list.

--- a/meta-balena-common/recipes-connectivity/networkmanager/balena-files/98dhcp_ntp
+++ b/meta-balena-common/recipes-connectivity/networkmanager/balena-files/98dhcp_ntp
@@ -11,8 +11,7 @@ SERVER_DIR=/run/chrony/
 SERVER_FILE=${SERVER_DIR}/added_dhcp_${INTERFACE}.sources
 
 if [ ! -d "$SERVER_DIR" ]; then
-	mkdir -p $SERVER_DIR
-	chmod 750 $SERVER_DIR
+	mkdir -p $SERVER_DIR -m 770
 fi
 
 case "$ACTION" in


### PR DESCRIPTION
Chronyd checks that the directory specified as `sourcedir` in `chrony.conf` (in this case `/var/chrony`) is not world accessible if it exists (chrony will create it correctly if it does not exist), and does not start if that's the case.

The way that the `/var/chrony` is created when it does not exist opens the possibility of the directory existing with the wrong permissions and hitting this problem.

This commit creates the directory with the correct permissions from the start to avoid the race condition.

Change-type@ patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
