### PR TITLE
balena-persistent-logs: Unbind the logs on shutdown

### DIFF
--- a/meta-balena-common/recipes-support/balena-persistent-logs/balena-persistent-logs.bb
+++ b/meta-balena-common/recipes-support/balena-persistent-logs/balena-persistent-logs.bb
@@ -8,7 +8,7 @@ SRC_URI = " \
     "
 S = "${WORKDIR}"
 
-inherit allarch systemd
+inherit allarch systemd balena-configurable
 
 SYSTEMD_SERVICE:${PN} = "balena-persistent-logs.service"
 

--- a/meta-balena-common/recipes-support/balena-persistent-logs/balena-persistent-logs/balena-persistent-logs
+++ b/meta-balena-common/recipes-support/balena-persistent-logs/balena-persistent-logs/balena-persistent-logs
@@ -5,19 +5,33 @@
 
 set -e
 
+# Parse arguments
+if [ $# -gt 0 ]; then
+    cmd=$1
+    shift
+fi
+
 . /usr/libexec/os-helpers-logging
 . /usr/sbin/balena-config-vars
 
-if [ "$PERSISTENT_LOGGING" = "true" ] && [ ! -d /var/log/journal ]; then
-    mkdir -p /var/log/journal
-    systemctl start bind-var-log-journal.service
-    journalctl --flush
-    info "Persistent logging activated."
-elif [ "$PERSISTENT_LOGGING" = "true" ] && [ -d /var/log/journal ]; then
-    info "Persistent logging already activated."
-    journalctl --flush
-elif [ "$PERSISTENT_LOGGING" = "false" ] && [ -d /var/log/journal ]; then
-    info "Persistent logging was deactivated but system reboot is needed."
+if [ "${cmd}" = "start" ]; then
+    if [ "$PERSISTENT_LOGGING" = "true" ]; then
+        mkdir -p /var/log/journal
+        systemctl start bind-var-log-journal.service
+        journalctl --flush
+        info "Persistent logging activated."
+    elif [ "$PERSISTENT_LOGGING" = "false" ]; then
+        info "Persistent logging was deactivated."
+        journalctl --sync
+        systemctl stop systemd-journald.service
+        systemctl stop bind-var-log-journal.service
+        systemctl start systemd-journald.service
+    fi
+elif [ "${cmd}" = "stop" ]; then
+    if [ "$PERSISTENT_LOGGING" = "true" ]; then
+        journalctl --sync
+        systemctl stop bind-var-log-journal.service
+    fi
 else
-    info "Persistent logging deactivated."
+    error "Unknown command."
 fi

--- a/meta-balena-common/recipes-support/balena-persistent-logs/balena-persistent-logs/balena-persistent-logs.service
+++ b/meta-balena-common/recipes-support/balena-persistent-logs/balena-persistent-logs/balena-persistent-logs.service
@@ -6,7 +6,9 @@ After=resin-boot.service resin-state.service systemd-journald.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=@BINDIR@/balena-persistent-logs
+ExecStart=@BINDIR@/balena-persistent-logs start
+ExecStop=@BINDIR@/balena-persistent-logs stop
+RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-balena-common/recipes-support/balena-units-conf/balena-units-conf/unit-conf.json
+++ b/meta-balena-common/recipes-support/balena-units-conf/balena-units-conf/unit-conf.json
@@ -14,7 +14,7 @@
 				"balena-supervisor": {
 					"description": "The balena supervisor",
 					"comment": "Although apiTimeout and mixpanelToken are also used by the supervisor, they do not require a restart",
-					"configuration": "listenPort balenaRootCA"
+					"configuration": "listenPort balenaRootCA persistentLogging"
 				},
 				"development-features": {
 					"description": "Enable / disable development mode",
@@ -56,6 +56,10 @@
 				"prepare-openvpn": {
 					"description": "Setup VPN authentication",
 					"configuration": "apiKey"
+				},
+				"balena-persistent-logs": {
+					"description": "Enable/Disable persistent logging",
+					"configuration": "persistentLogging"
 				}
 			}
 		}


### PR DESCRIPTION
This avoids keeping the mount busy and other services failing to unmount at shutdown.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
