### PR TITLE
test: os: fix search for active interface

### DIFF
--- a/tests/suites/os/tests/connectivity/index.js
+++ b/tests/suites/os/tests/connectivity/index.js
@@ -41,15 +41,16 @@ module.exports = {
 						},
 					},
 					run: async function(test) {
-						let testIface = adaptor === 'wireless' ? 'wifi' : 'ethernet';
+						let connection = adaptor === 'wireless' ? 'balena-wifi' : 'Wired';
 						return this.worker.executeCommandInHostOS(
-							`nmcli d  | grep ' ${testIface} ' | grep connected | awk '{print $1}'`,
+							`nmcli d  | grep ' ${connection} ' | grep connected | awk '{print $1}'`,
 							this.link,
 						).then((iface) => {
 							if (iface === '') {
-								throw new Error(`No ${testIface} interface found.`);
+								throw new Error(`No ${connection} connection found.`);
 							}
 
+							test.comment(`Attempting to connect to ${URL_TEST} over interface ${iface}`)
 							return this.worker.executeCommandInHostOS(
 								`ping -c 10 -i 0.002 -I ${iface} ${URL_TEST}`,
 								this.link,
@@ -57,7 +58,7 @@ module.exports = {
 						}).then((ping) => {
 							test.ok(
 								ping.includes('10 packets transmitted, 10 packets received'),
-								`${URL_TEST} responded over ${testIface}`,
+								`${URL_TEST} should respond over ${connection}`,
 							);
 						});
 					},


### PR DESCRIPTION
The connectivity test fails when there are multiple active interfaces, like with the case of the alliance board. 

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
