### PR TITLE
common: update openvpn conf w/ cloudlink URL

### DIFF
--- a/meta-balena-common/recipes-connectivity/openvpn/openvpn/resin.conf
+++ b/meta-balena-common/recipes-connectivity/openvpn/openvpn/resin.conf
@@ -1,5 +1,5 @@
 client
-remote vpn.balena-cloud.com 443
+remote cloudlink.balena-cloud.com 443
 resolv-retry infinite
 
 remote-cert-tls server


### PR DESCRIPTION
As the expiration of the TLS certificate for vpn.balena-cloud.com drew
near, we setup an additional OpenVPN endpoint at
cloudlink.balena-cloud.com with a renewed certificate and a different
name, to clarify the purpose of the connection as a tunnel from balena
cloud to devices.

https://www.balena.io/blog/sunsetting-vpn-balenacloud-and-introducing-cloudlink/

That endpoint is the new preferred URL to connect to, though devices may
still successfully connect with the old URL until the certificate
expires, and os-config should update them to point to the new URL
anyway.

However, newly provisioned devices may fail to authenticate with the
cloudlink endpoint when first provisioned, and that unauthorized
response can be cached by the API, leading to an extended period where
the device appears offline on the dashboard.

Update the URL for cloudlink to improve the provisioning time for new
devices.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
