### PR TITLE
meta-balena-thud: Enable GOCACHE

### DIFF
--- a/meta-balena-thud/recipes-containers/balena/balena_git.bbappend
+++ b/meta-balena-thud/recipes-containers/balena/balena_git.bbappend
@@ -1,3 +1,7 @@
 # Since gcc 7.3.0, compiling mobynit with pie support fails at runtime. We
 # deactivate it until we figure out why that happens.
 MOBYNIT_EXTRA_LDFLAGS_append = " -no-pie"
+
+do_compile_prepend() {
+	export GOCACHE="${B}/.cache"
+}


### PR DESCRIPTION
Versions above 1.12 require GOCACHE to be used.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>

Required to unblock:

https://github.com/balena-os/balena-nanopc-t4/pull/44
https://github.com/balena-os/balena-tci/pull/24
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
