### PR TITLE
tests: cloud: simplify apps to speedup suite

### DIFF
--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -158,17 +158,12 @@ module.exports = {
       }
     });
 
-    // Push a single container application
-    this.log(`Cloning getting started repo...`);
     this.suite.context.set({
-      appPath: `${__dirname}/app`,
-      appServiceName: `balena-hello-world`
+      appPath: `${__dirname}/test-app`,
+      appServiceName: `containerA`
     })
-    await exec(
-      `git clone https://github.com/balena-io-examples/balena-node-hello-world.git ${this.appPath}`
-    );
     this.log(`Pushing release to app...`);
-    const initialCommit = await this.cloud.pushReleaseToApp(this.balena.application, `${__dirname}/app`)
+    const initialCommit = await this.cloud.pushReleaseToApp(this.balena.application, `${__dirname}/test-app`)
     this.suite.context.set({
       balena: {
         initialCommit: initialCommit

--- a/tests/suites/cloud/test-app/containerA/Dockerfile.template
+++ b/tests/suites/cloud/test-app/containerA/Dockerfile.template
@@ -1,0 +1,3 @@
+FROM balenalib/%%BALENA_ARCH%%-alpine:3.12-run
+
+CMD ["bash", "-c", "echo 'HELLO_WORLD'; bash"]

--- a/tests/suites/cloud/test-app/containerB/Dockerfile.template
+++ b/tests/suites/cloud/test-app/containerB/Dockerfile.template
@@ -1,0 +1,3 @@
+FROM balenalib/%%BALENA_ARCH%%-alpine
+
+CMD ["bash"]

--- a/tests/suites/cloud/test-app/docker-compose.yml
+++ b/tests/suites/cloud/test-app/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  containerA:
+    build: ./containerA
+  containerB:
+    build: ./containerB

--- a/tests/suites/cloud/tests/supervisor/index.js
+++ b/tests/suites/cloud/tests/supervisor/index.js
@@ -30,7 +30,7 @@ module.exports = {
           );
         
         // add a comment to the end of the server.js file, to trigger a delta when pushing
-        await exec(`echo "//comment" >> ${this.appPath}/server.js`);
+        await exec(`echo "#comment" >> ${this.appPath}/containerA/Dockerfile.template`);
         test.comment(`Pushing release...`);
 
         let secondCommit = await this.cloud.pushReleaseToApp(
@@ -80,12 +80,10 @@ module.exports = {
           this.appServiceName,
           this.balena.uuid)
 
-        // push release to application
-        await exec(`echo "//comment" >> ${this.appPath}/server.js`);
-        test.comment(`Pushing release...`);
-        let secondCommit = await this.cloud.pushReleaseToApp(
-          this.balena.application, 
-          `${this.appPath}` // push original release to application (node hello world)
+        //pin to a previous, different commit
+        await this.cloud.balena.models.device.pinToRelease(
+          this.balena.uuid, 
+          this.balena.initialCommit
         );
 
         // check original application is downloaded - shouldn't be installed
@@ -100,7 +98,7 @@ module.exports = {
           let originalRunning = false;
           services.current_services[this.appServiceName].forEach((service) => {
             if (
-              service.commit === secondCommit &&
+              service.commit === this.balena.initialCommit &&
               service.status === "Downloaded"
             ) {
               downloaded = true;
@@ -144,7 +142,7 @@ module.exports = {
           this,
           this.balena.uuid, 
           [this.appServiceName], 
-          secondCommit,
+          this.balena.initialCommit,
           test
         )
 

--- a/tests/suites/os/tests/container-healthcheck/Dockerfile.template
+++ b/tests/suites/os/tests/container-healthcheck/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_ARCH%%-alpine
+FROM balenalib/%%BALENA_ARCH%%-alpine:3.12-run
 
 HEALTHCHECK --interval=1s --retries=1 \
     CMD [ -f /tmp/health ] 


### PR DESCRIPTION
Current steps of cloud suite: 
```
    1. create an app
    2. push hello-world to that app
    3. preload image with that release
    4. flash DUT
    5. power on DUT
    6. check preloading worked

    7. disable deltas
    8. push a new release to the app
    9. wait for release to be downloaded, check it wasnt done via deltas
    10. create lockfile
    11. push another release
    12. wait until its downloaded - then check its not being installed due to lockfile

    13. create another app
    14. push multicontainer example
    15. move device to this new app
    16. wait until dowoaded and started (takes a good chunk of time, times out often with slow devices with 5 -10 minute timeout)
    17. check servcie / device env vars

    18. os config tests
    19. ssh keys tests ( flaky and kill test runs sometimes, but steps 1-17 have enough fat in them to try and cut imo)
```

To save a good chunk of time, I tried this:
- for step 2 - push a multi container app, included in the test suite (small, 2 empty alpine containers). This speeds up the initial push to the app
- remove step 11 - instead, pin the dut to the release from step 2 instead
- remove 13, 14, 15, 16 we already have a multicontainer app, and have moved the device between releases

This reduces pushes from 4 to 2, and stops the device having to download a large 3 container application. Haven't got exact numbers yet but speeds things up quite a bit - need to confirm coverage isn't lost, and need to test on hardware. 

Further gains could be made by creating this app for each arch, to avoid any pushes

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
