### PR TITLE
openssh: allow RSA signatures with SHA1 algorithms

### DIFF
--- a/meta-balena-common/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-balena-common/recipes-connectivity/openssh/openssh_%.bbappend
@@ -39,6 +39,8 @@ do_install:append () {
     echo "# Get public SSH keys from the API when available" >> ${D}${sysconfdir}/ssh/sshd_config_readonly
     echo "AuthorizedKeysCommand ${libexecdir}/${BPN}/cloud-public-sshkeys %u" >> ${D}${sysconfdir}/ssh/sshd_config_readonly
     echo "AuthorizedKeysCommandUser sshd-authcommands" >> ${D}${sysconfdir}/ssh/sshd_config_readonly
+    # Allow RSA signatures using SHA1 algorithm for backwards compatibility
+    echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> ${D}${sysconfdir}/ssh/sshd_config_readonly
 
     install -D -m 0755 ${WORKDIR}/cloud-public-sshkeys ${D}${libexecdir}/${BPN}/cloud-public-sshkeys
 


### PR DESCRIPTION
Openssh v8.8 removes this support by default but the backend still needs to be updated to drop these.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
