### PR TITLE
meta-resin-sumo: libical: Fix build QA error

### DIFF
--- a/meta-resin-sumo/recipes-support/libical/libical_2.0.0.bbappend
+++ b/meta-resin-sumo/recipes-support/libical/libical_2.0.0.bbappend
@@ -1,0 +1,3 @@
+do_install_append() {
+	rm -rf "${D}/usr/lib/cmake/"
+}


### PR DESCRIPTION
Address the following build error:
```
ERROR: libical-2.0.0-r0 do_package: QA Issue: libical: Files/directories were installed but not shipped in any package:
/usr/lib/cmake
/usr/lib/cmake/LibIcal
/usr/lib/cmake/LibIcal/LibIcalTargets.cmake
/usr/lib/cmake/LibIcal/LibIcalConfig.cmake
/usr/lib/cmake/LibIcal/LibIcalConfigVersion.cmake
/usr/lib/cmake/LibIcal/LibIcalTargets-noconfig.cmake
```

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
