### PR TITLE
common: fix race w/ balena-supervisor startup

### DIFF
--- a/meta-balena-common/recipes-support/ca-certificates/ca-certificates/extract-balena-ca.service
+++ b/meta-balena-common/recipes-support/ca-certificates/ca-certificates/extract-balena-ca.service
@@ -5,6 +5,7 @@ Requires=bind-usr-share-ca-certificates-balena.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/bin/extract-balena-ca
 
 [Install]


### PR DESCRIPTION
On startup, extract-balena-ca.service exits, and being a oneshot service, its status changes to inactive/dead instead of active.

Meanwhile, balena-supervisor.service depends on
extract-balena-ca.service, so this can effectively halt the supervisor from ever starting.

Add RemainAfterExit=yes to extract-balena-ca.service to report as active after successfully exiting, which fixes the startup race with balena-supervisor. This appears to only manifest as a problem on Kirkstone, so it may be related to a systemd update.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
