### PR TITLE
tests: hup: handle exception when unwrapping non-flasher image

### DIFF
--- a/tests/suites/hup/suite.js
+++ b/tests/suites/hup/suite.js
@@ -279,17 +279,25 @@ module.exports = {
 			this.suite.deviceType.data.storage.internal &&
 			this.workerContract.workerType === `qemu`
 		) {
-			const RAW_IMAGE_PATH = `/opt/balena-image-${this.suite.deviceType.slug}.balenaos-img`;
-			const OUTPUT_IMG_PATH = '/data/downloads/unwrapped.img';
-			console.log(`Unwrapping flasher image ${path}`);
-			await imagefs.interact(path, 2, async (fsImg) => {
-				await pipeline(
-					fsImg.createReadStream(RAW_IMAGE_PATH),
-					fs.createWriteStream(OUTPUT_IMG_PATH),
-				);
-			});
-			path = OUTPUT_IMG_PATH;
-			console.log(`Unwrapped flasher image!`);
+			try {
+				const RAW_IMAGE_PATH = `/opt/balena-image-${this.suite.deviceType.slug}.balenaos-img`;
+				const OUTPUT_IMG_PATH = '/data/downloads/unwrapped.img';
+				console.log(`Unwrapping flasher image ${path}`);
+				await imagefs.interact(path, 2, async (fsImg) => {
+					await pipeline(
+						fsImg.createReadStream(RAW_IMAGE_PATH),
+						fs.createWriteStream(OUTPUT_IMG_PATH),
+					);
+				});
+				path = OUTPUT_IMG_PATH;
+				console.log(`Unwrapped flasher image!`);
+			} catch (e) {
+				if (e.code === 'ENOENT') {
+					console.log('Not a flasher image, skipping unwrap');
+				} else {
+					throw e;
+				}
+			}
 		}
 
 		this.suite.context.set({


### PR DESCRIPTION
Handle ENOENT ErrnoException when attempting to unwrap a non-flasher image in HUP tests. This mirrors a similar change made in ce2d33ad8.

Fixes: https://github.com/balena-os/balena-generic/issues/148

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
