### PR TITLE
Flasher Glob Expansion Fixes

### DIFF
--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -162,7 +162,7 @@ for device_pattern in ${INTERNAL_DEVICE_KERNEL}; do
     ! IFS=$'\n' read -rd '' -a devices <<< \
 	    "$(ls $(eval echo "/dev/${device_pattern}") 2>/dev/null)"
     for device in "${devices[@]}"; do
-        if [[ "${CURRENT_ROOT}" = "${device}" ]]; then
+        if [[ "/dev/${CURRENT_ROOT}" = "${device}" ]]; then
             inform "${device} is our install media, skip it..."
             continue
         fi

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -157,7 +157,11 @@ done
 inform "Flash internal device... will take around 5 minutes... "
 internal_dev=""
 for device_pattern in ${INTERNAL_DEVICE_KERNEL}; do
-    for device in /dev/${device_pattern}; do
+    inform "Searching for devices matching pattern /dev/${device_pattern}"
+    # shellcheck disable=SC2046
+    ! IFS=$'\n' read -rd '' -a devices <<< \
+	    "$(ls $(eval echo "/dev/${device_pattern}") 2>/dev/null)"
+    for device in "${devices[@]}"; do
         if [[ "${CURRENT_ROOT}" = "${device}" ]]; then
             inform "${device} is our install media, skip it..."
             continue
@@ -172,6 +176,8 @@ for device_pattern in ${INTERNAL_DEVICE_KERNEL}; do
 
             internal_dev="${device}"
             break 2
+	else
+		inform "$device is not a block device, skipping"
         fi
     done
 done

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -169,7 +169,8 @@ for device_pattern in ${INTERNAL_DEVICE_KERNEL}; do
         if test -b "$(readlink -f "${device}")"; then
             if ! [[ "${device_pattern}" = md/* ]]; then
                 if mdadm --examine "${device}" | grep -q Array; then
-                    inform "${device} is part of an existing RAID array that wasn't specified by name, skip it..."
+                    inform "${device} is part of an existing RAID array" \
+			    "that wasn't specified by name, skip it..."
                     continue
                 fi
             fi


### PR DESCRIPTION
This PR includes some fixes for glob expansion in the flasher script, as well as a fix for properly detecting and excluding the installation media from the target disk pool.

Tested with the standalone script below, as well as with the flasher, [targeting a RAID disk](https://github.com/balena-os/balena-generic/pull/151):
```bash
#!/bin/bash
set -e 

CURRENT_ROOT="$(findmnt --noheadings --canonicalize --output SOURCE / | xargs lsblk -no pkname)"
INTERNAL_DEVICE_KERNEL="$*"
echo "INTERNAL_DEVICE_KERNEL=\"${INTERNAL_DEVICE_KERNEL}\""

internal_dev=""
for device_pattern in ${INTERNAL_DEVICE_KERNEL}; do
        echo "Searching for devices matching pattern /dev/${device_pattern}"
        # shellcheck disable=SC2046
        ! IFS=$'\n' read -rd '' -a devices <<< \
                "$(ls $(eval echo "/dev/${device_pattern}") 2>/dev/null)"
        for device in "${devices[@]}"; do
                if [[ "/dev/${CURRENT_ROOT}" = "${device}" ]]; then
                        echo "${device} is our install media, skipping"
                        continue
                fi
                if test -b "$(readlink -f "${device}")"; then
                        if ! [[ "${device_pattern}" = md/* ]]; then
                                if mdadm --examine "${device}" | grep -q Array; then
                                        echo "${device} is part of an existing RAID array" \
                                                "that wasn't specified by name, skip it..."
                                        continue
                                fi
                        fi

                        internal_dev="${device}"
                        break 2 
                else
                        echo "$device is not a block device, skipping"
                fi
        done
done

echo "internal_dev: ${internal_dev}"
```

```
┌─[13:55:42]─[joseph@wash]
└──> balena-generic $ >> ./test.sh "md/balena{,_*} sd? hd? nvme?n? mmcblk?"
INTERNAL_DEVICE_KERNEL="md/balena{,_*} sd? hd? nvme?n? mmcblk?"
Searching for devices matching pattern /dev/md/balena{,_*}
internal_dev: /dev/md/balena
┌─[13:55:47]─[joseph@wash]
└──> balena-generic $ >> ./test.sh "sd? hd? nvme?n? mmcblk?"
INTERNAL_DEVICE_KERNEL="sd? hd? nvme?n? mmcblk?"
Searching for devices matching pattern /dev/sd?
Searching for devices matching pattern /dev/hd?
Searching for devices matching pattern /dev/nvme?n?
/dev/nvme0n1 is our install media, skipping
mdadm: No md superblock detected on /dev/nvme1n1.
internal_dev: /dev/nvme1n1
```