### PR TITLE
prepare-openvpn: do not use cached configuration

### DIFF
--- a/meta-balena-common/recipes-connectivity/openvpn/files/prepare-openvpn
+++ b/meta-balena-common/recipes-connectivity/openvpn/files/prepare-openvpn
@@ -2,7 +2,7 @@
 
 set -e
 
-. /usr/sbin/balena-config-vars
+. /usr/sbin/balena-config-vars --no-cache
 
 generate_vpn_authfile() {
 	local _user


### PR DESCRIPTION
This script needs to update the VPN authentication with the currently configured keys so do not use cached values.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
