### PR TITLE
Update balena.service

### DIFF
--- a/meta-balena-common/recipes-containers/balena/balena/balena.service
+++ b/meta-balena-common/recipes-containers/balena/balena/balena.service
@@ -42,6 +42,8 @@ WatchdogSec=360
 Restart=always
 KillMode=process
 TimeoutStartSec=infinity
+# Let balenaEngine (instead of systemd) manage the containers cgroups.
+Delegate=yes
 
 [Install]
 Alias=balena-engine.service

--- a/meta-balena-common/recipes-containers/balena/balena/balena.service
+++ b/meta-balena-common/recipes-containers/balena/balena/balena.service
@@ -36,7 +36,9 @@ OOMScoreAdjust=-900
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576
-LimitCORE=infinity
+# Don't generate core dumps. This way, user apps that are crashlooping will not
+# fill up all storage space.
+LimitCORE=0
 WatchdogSignal=SIGTERM
 WatchdogSec=360
 Restart=always


### PR DESCRIPTION
This PR has two separate commits, each with a different change to `balena.service`.

-----

Setting `LimitCORE=0` will avoid the creation of core dump files on
containers. This will avoid cases in which a crashlooping user app ends
up filling up the entire storage with dump files.

Users can re-enable core dumps in their services by manually setting the
`ulimits.core`. For example:

```
services:
  my-service:
    ulimits:
      core: -1
```

(Where -1 is used to mean "unlimited")

-----

Setting `Delegate=yes` ensures that systemd will not change anything on
the cgroups created for running the containers.

This setting is used upstream since this commit:
https://github.com/moby/moby/commit/d16737f971092767c1b9d28302a3f5aedbe2f576

And also is recommended by systemd: https://systemd.io/CGROUP_DELEGATION/

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
