### PR TITLE
tests: cloud: ssh-auth: multiple bugfixes

### DIFF
--- a/tests/suites/cloud/tests/ssh-auth/index.js
+++ b/tests/suites/cloud/tests/ssh-auth/index.js
@@ -35,7 +35,7 @@ const setConfig = async (test, that, target, key, value) => {
 		).then(() => {
 			if (value == null) {
 				return t.resolves(
-					that.worker.executeCommandInHostOS(
+					that.cloud.executeCommandInHostOS(
 						[
 							`tmp=$(mktemp)`,
 							`&&`, `jq`, `"del(.${key})"`, `/mnt/boot/config.json`,
@@ -52,7 +52,7 @@ const setConfig = async (test, that, target, key, value) => {
 				}
 
 				return t.resolves(
-					that.worker.executeCommandInHostOS(
+					that.cloud.executeCommandInHostOS(
 						[
 							`tmp=$(mktemp)`,
 							`&&`, `jq`, `'.${key}=${value}'`, `/mnt/boot/config.json`,
@@ -65,7 +65,7 @@ const setConfig = async (test, that, target, key, value) => {
 		}).then(() => {
 			// avoid hitting 'start request repeated too quickly'
 			return t.resolves(
-				that.worker.executeCommandInHostOS(
+				that.cloud.executeCommandInHostOS(
 					'systemctl reset-failed config-json.service',
 					target
 				), `Should reset start counter of config-json.service`

--- a/tests/suites/cloud/tests/ssh-auth/index.js
+++ b/tests/suites/cloud/tests/ssh-auth/index.js
@@ -117,7 +117,7 @@ module.exports = {
 					}).catch((err) => {
 						return test.match(
 							err.message,
-							/All configured authentication methods failed|Connection lost before handshake/,
+							/All configured authentication methods failed|Connection lost before handshake|Timed out while waiting for handshake/,
 							"Local SSH authentication without custom keys is not allowed in production mode"
 						);
 					});


### PR DESCRIPTION
2 fixes:

1. use cloud ssh auth to avoid race condition in `setConfig`. This function is used to set a device to production mode - it then however tries to run one more command over the local ssh connection - there's a chance that the device would have toggled to prod mode before that command can be completed, which will cause it to fail
2. After toggling to prod mode we check that the local ssh auth fails - depending on the timing, you might get several messages - so I added another possible message to the ones we check for

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
