### PR TITLE
openvpn: do not stop os-config if active

### DIFF
--- a/meta-balena-common/recipes-connectivity/openvpn/files/openvpn.service
+++ b/meta-balena-common/recipes-connectivity/openvpn/files/openvpn.service
@@ -11,7 +11,7 @@ RestartSec=10s
 #Adjust OOMscore to -1000 to disable OOM killing for openvpn
 OOMScoreAdjust=-1000
 PIDFile=/run/openvpn/openvpn.pid
-ExecStartPre=-/bin/systemctl restart os-config
+ExecStartPre=-@BASE_BINDIR@/sh -c "@BASE_BINDIR@/systemctl is-active --quiet os-config || @BASE_BINDIR@/systemctl start os-config"
 ExecStart=/usr/sbin/openvpn --writepid /run/openvpn/openvpn.pid --cd /etc/openvpn/ --config /etc/openvpn/openvpn.conf --connect-retry 5 120
 
 [Install]

--- a/meta-balena-common/recipes-connectivity/openvpn/openvpn_%.bbappend
+++ b/meta-balena-common/recipes-connectivity/openvpn/openvpn_%.bbappend
@@ -31,4 +31,10 @@ do_install:append() {
 		${WORKDIR}/prepare-openvpn.service \
 		${WORKDIR}/openvpn.service \
 		${D}${systemd_unitdir}/system
+
+    sed -i -e 's,@BASE_BINDIR@,${base_bindir},g' \
+        -e 's,@SBINDIR@,${sbindir},g' \
+        -e 's,@BINDIR@,${bindir},g' \
+        -e 's,@BALENA_STATE_MP@,${BALENA_STATE_MOUNT_POINT},g' \
+        ${D}${systemd_unitdir}/system/*.service
 }


### PR DESCRIPTION
The `os-config` application stops the supervisor before fetching openvpn configuration and starting the `openvpn` service unit.

As the `openvpn` service units stops `os-config`, it might not get to restart the supervisor.

This commit checks that `os-config` is not already active before starting it.

Fixes #2855

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
