### PR TITLE
kernel-balena: enable zstd compression

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -150,6 +150,7 @@ BALENA_CONFIGS ?= " \
     no_gcc_plugins \
     ${FIRMWARE_COMPRESS} \
     ${WIREGUARD} \
+    ${KERNEL_ZSTD} \
     "
 
 #
@@ -222,6 +223,11 @@ BALENA_CONFIGS[firmware_compress] = " \
 WIREGUARD = "${@configure_from_version("5.10", "wireguard", "", d)}"
 BALENA_CONFIGS[wireguard] = " \
     CONFIG_WIREGUARD=m \
+"
+
+KERNEL_ZSTD = "${@configure_from_version("5.9", "kernel_zstd", "", d)}"
+BALENA_CONFIGS[kernel_zstd] = " \
+    CONFIG_KERNEL_ZSTD=y \
 "
 
 BALENA_CONFIGS[aufs] = " \


### PR DESCRIPTION
Enabling CONFIG_KERNEL_ZSTD=y improves the compression ratio compared to gzip while being faster to decompress. With kernel 5.15 in balenaOS v2.105, we see the 24 MB kernel compress to approximately 19 MB.

Zstd support was added in commit 48f7ddf, first introduced in kernel v5.9. Enable this config unconditionally in supported kernels.

Note that not every architecture and device support this option, but in those cases, Kconfig will automatically disable it as HAVE_ZSTD is also missing.

Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
