### PR TITLE
common: kernel-devsrc: fix pseudo abort

### DIFF
--- a/meta-balena-common/recipes-kernel/linux/kernel-devsrc.bbappend
+++ b/meta-balena-common/recipes-kernel/linux/kernel-devsrc.bbappend
@@ -4,7 +4,6 @@ do_install:append() {
 
 do_deploy() {
     cp ${WORKDIR}/kernel_source.tar.gz ${DEPLOYDIR}/
-    rm ${WORKDIR}/kernel_source.tar.gz
 }
 inherit deploy
 addtask do_deploy before do_package after do_install


### PR DESCRIPTION
Yocto builds will abort due to inconsistencies between the pseudo database and files modified outside of the pseudo context [0].

This will occasionally cause builds to fail in the do_deploy step of the kernel-devsrc recipe. [1]

Fix this by not removing the kernel_source tarball in the do_deploy step.

Fixes: https://github.com/balena-os/meta-balena/issues/2806

[0] https://wiki.yoctoproject.org/wiki/Pseudo_Abort
[1] https://github.com/balena-os/meta-balena/issues/2806

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
