### PR TITLE
test: ssh-auth: fix test cases using custom keys

### DIFF
--- a/tests/suites/cloud/tests/ssh-auth/index.js
+++ b/tests/suites/cloud/tests/ssh-auth/index.js
@@ -131,14 +131,27 @@ module.exports = {
 					});
 				}).then(async () => {
 					let result;
+					let ip = await this.worker.getDutIp(this.link);
+					let config = {}
+					config = {
+						host: ip,
+						port: '22222',
+						username: 'root',
+						privateKeyPath: `${sshPath}`
+					};
 					await this.utils.waitUntil(
 						async () => {
-							result = await this.worker.executeCommandInHostOS('echo -n pass',
-								this.link);
+							try {
+								result = await this.utils.executeCommandOverSSH('echo -n pass',
+								config);
+							} catch (err) {
+								console.error(err.message);
+								throw new Error(err);
+							}
 							return result
 						}, false, 10, 5 * 1000);
 					return test.equals(
-						result,
+						result.stdout,
 						"pass",
 						"Local SSH authentication with custom keys is allowed in production mode"
 					);
@@ -237,14 +250,27 @@ module.exports = {
 						});
 				}).then(async () => {
 					let result;
+					let ip = await this.worker.getDutIp(this.link);
+					let config = {}
+					config = {
+						host: ip,
+						port: '22222',
+						username: 'root',
+						privateKeyPath: `${sshPath}`
+					};
 					await this.utils.waitUntil(
 						async () => {
-							result = await this.worker.executeCommandInHostOS('echo -n pass',
-								this.link);
+							try {
+								result = await this.utils.executeCommandOverSSH('echo -n pass',
+								config);
+							} catch (err) {
+								console.error(err.message);
+								throw new Error(err);
+							}
 							return result
 						}, false, 10, 5 * 1000);
 					return test.equals(
-						result,
+						result.stdout,
 						"pass",
 						"Local SSH authentication with custom keys is allowed in development mode"
 					)


### PR DESCRIPTION
There are two sets of keys used in this test, one stored in `/root/id` which is created by the cloud suite to SSH via the proxy server, and a custom key stored in `/root/test_id` used in some of the subtests.

Fix the test cases using the custom key to use the correct private key.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
