### PR TITLE
classes: kernel-balena: add wireguard module

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -148,6 +148,7 @@ BALENA_CONFIGS ?= " \
     dmcrypt \
     no_gcc_plugins \
     ${FIRMWARE_COMPRESS} \
+    ${WIREGUARD} \
     "
 
 #
@@ -215,6 +216,11 @@ BALENA_CONFIGS[balena] ?= " \
 FIRMWARE_COMPRESS = "${@configure_from_version("5.3", "firmware_compress", "", d)}"
 BALENA_CONFIGS[firmware_compress] = " \
     CONFIG_FW_LOADER_COMPRESS=y \
+"
+
+WIREGUARD = "${@configure_from_version("5.10", "wireguard", "", d)}"
+BALENA_CONFIGS[wireguard] = " \
+    CONFIG_WIREGUARD=m \
 "
 
 BALENA_CONFIGS[aufs] = " \


### PR DESCRIPTION
Add the wireguard module by default so it is included in all device types. This is a frequently requested by customers and will avoid having to patch individual device repositories.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
