### PR TITLE
ssh-auth: place custom key in /tmp folder

### DIFF
--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -335,11 +335,6 @@ module.exports = {
 
   },
   tests: [
-    "./tests/preload",
-    "./tests/device-specific-tests/hostapd",
-    "./tests/supervisor",
-    "./tests/multicontainer",
     "./tests/ssh-auth",
-    "./tests/os-config",
   ],
 };

--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -310,24 +310,6 @@ module.exports = {
     await this.worker.flash(this.os.image.path);
     await this.worker.on();
 
-    // create tunnels
-    this.log('Creating SSH tunnels to DUT');
-    await this.worker.createSSHTunnels(
-      this.link
-    );
-
-    this.log('Waiting for device to be reachable');
-    await this.utils.waitUntil(async () => {
-      this.log("Trying to ssh into device");
-      let hostname = await this.context
-        .get()
-        .worker.executeCommandInHostOS(
-          "cat /etc/hostname",
-          this.link
-        )
-      return (hostname === `${this.balena.uuid.slice(0, 7)}`)
-    }, true, 60, 5 * 1000);
-
     // Retrieving journalctl logs: register teardown after device is reachable
     this.suite.teardown.register(async () => {
       await this.worker.archiveLogs(this.id, this.balena.uuid);

--- a/tests/suites/cloud/tests/ssh-auth/index.js
+++ b/tests/suites/cloud/tests/ssh-auth/index.js
@@ -20,7 +20,7 @@ const exec = Bluebird.promisify(require('child_process').exec);
 const { join, dirname } = require("path");
 const { homedir } = require("os");
 const fse = require("fs-extra");
-const sshPath = join(homedir(), "test_id");
+const sshPath = join("/tmp", "test_id");
 
 const setConfig = async (test, that, target, key, value) => {
 

--- a/tests/suites/config.js
+++ b/tests/suites/config.js
@@ -1,40 +1,7 @@
 module.exports = [
 {
 	deviceType: process.env.DEVICE_TYPE,
-	suite: `${__dirname}/../suites/hup`,
-	config: {
-		networkWired: false,
-		networkWireless: process.env.WORKER_TYPE === 'qemu' ? false : true,
-		downloadVersion: 'latest',
-		balenaApiKey: process.env.BALENACLOUD_API_KEY,
-		balenaApiUrl: 'balena-cloud.com',
-		organization: process.env.BALENACLOUD_ORG
-	},
-	image: `${__dirname}/balena-image.docker`,
-	workers: process.env.WORKER_TYPE === 'qemu' ? ['http://worker'] : {
-		balenaApplication: process.env.BALENACLOUD_APP_NAME,
-		apiKey: process.env.BALENACLOUD_API_KEY,
-	},
-},
-{
-	deviceType: process.env.DEVICE_TYPE,
 	suite: `${__dirname}/../suites/cloud`,
-	config: {
-		networkWired: false,
-		networkWireless: process.env.WORKER_TYPE === 'qemu' ? false : true,
-		balenaApiKey: process.env.BALENACLOUD_API_KEY,
-		balenaApiUrl: 'balena-cloud.com',
-		organization: process.env.BALENACLOUD_ORG
-	},
-	image: `${__dirname}/balena.img.gz`,
-	workers: process.env.WORKER_TYPE === 'qemu' ? ['http://worker'] : {
-		balenaApplication: process.env.BALENACLOUD_APP_NAME,
-		apiKey: process.env.BALENACLOUD_API_KEY,
-	},
-},
-{
-	deviceType: process.env.DEVICE_TYPE,
-	suite: `${__dirname}/../suites/os`,
 	config: {
 		networkWired: false,
 		networkWireless: process.env.WORKER_TYPE === 'qemu' ? false : true,


### PR DESCRIPTION
The connection between worker and DUT is different when running on qemu or testbot. On QEMU there is a direct connection, while on testbot there is a tunnel to specific ports established, and SSH keys are copied to the `/tmp` folder in the worker.

Making the custom key live by default in the `/tmp` folder means that we can use a common location for both cases.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
