### PR TITLE
kernel-balena: Kernel version check should include provided version

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -90,6 +90,7 @@ def get_kernel_version(d):
             kernelversion = kernelversion + '.' + m.group(1)
     return kernelversion
 
+# Return passed value if the kernel version is equal or above the one provided
 def configure_from_version(version, passvalue, failvalue, d):
     kv = get_kernel_version(d)
     if kv is None:
@@ -101,7 +102,7 @@ def configure_from_version(version, passvalue, failvalue, d):
     if int(kv_major) > int(major):
         return passvalue
     elif int(kv_major) == int(major):
-        if int(kv_minor) > int(minor):
+        if int(kv_minor) >= int(minor):
             return passvalue
     return failvalue
 


### PR DESCRIPTION
When adding a kernel configuration conditional in a provided kernel version, make the check include the provided kernel version as that is the intuitive way to understand it.

The two places that use this function already used it in this way.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
