### PR TITLE
balena-image.bb: Include bits for LUKS when FDE is enabled

### DIFF
--- a/meta-balena-common/recipes-core/images/balena-image.bb
+++ b/meta-balena-common/recipes-core/images/balena-image.bb
@@ -37,6 +37,9 @@ IMAGE_INSTALL = " \
     packagegroup-resin \
     "
 
+# add packages for LUKS operations if necessary
+IMAGE_INSTALL:append = "${@oe.utils.conditional('SIGN_API','','',' cryptsetup lvm2-udevrules tpm2-tools libtss2-tcti-device',d)}"
+
 generate_rootfs_fingerprints () {
     # Generate fingerprints file for root filesystem
     # We exclude some entries that are bind mounted to state partition
@@ -66,6 +69,9 @@ BALENA_BOOT_PARTITION_FILES:append = " \
 
 # add the secure boot keys if needed
 BALENA_BOOT_PARTITION_FILES:append = "${@oe.utils.conditional('SIGN_API','','','balena-keys:/balena-keys/',d)}"
+
+# add the LUKS variant of GRUB config if needed
+BALENA_BOOT_PARTITION_FILES:append = "${@oe.utils.conditional('SIGN_API','','',' grub.cfg_internal_luks:/EFI/BOOT/grub-luks.cfg',d)}"
 
 # add the generated <machine-name>.json to the resin-boot partition, renamed as device-type.json
 BALENA_BOOT_PARTITION_FILES:append = " ${BALENA_COREBASE}/../../../${MACHINE}.json:/device-type.json"


### PR DESCRIPTION
We want meta-balena to pull in these packages automatically when FDE is enabled rather than relying on device types to have them.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
