### PR TITLE
connectivity: Add linux firmware for iwlwifi 9260

### DIFF
--- a/meta-balena-kirkstone/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
+++ b/meta-balena-kirkstone/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
@@ -16,6 +16,7 @@ CONNECTIVITY_FIRMWARES:append = " \
     linux-firmware-iwlwifi-7265d \
     linux-firmware-iwlwifi-8000c \
     linux-firmware-iwlwifi-8265 \
+    linux-firmware-iwlwifi-9260 \
     linux-firmware-rtl8188eu \
     linux-firmware-wl12xx \
     linux-firmware-wl18xx \


### PR DESCRIPTION
Some device types are being sold with this WiFi chipset so let's include the firmware.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
