### PR TITLE
Sparse images

### DIFF
--- a/meta-balena-common/classes/image_types_balena.bbclass
+++ b/meta-balena-common/classes/image_types_balena.bbclass
@@ -70,11 +70,13 @@ python() {
     if d.getVar('IMGDEPLOYDIR', True):
         d.setVar('BALENA_ROOT_FS', '${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${BALENA_ROOT_FSTYPE}')
         d.setVar('BALENA_RAW_IMG', '${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.balenaos-img')
+        d.setVar('BALENA_RAW_BMAP', '${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.bmap')
         d.setVar('BALENA_DOCKER_IMG', '${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.docker')
         d.setVar('BALENA_HOSTAPP_IMG', '${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.${BALENA_ROOT_FSTYPE}')
     else:
         d.setVar('BALENA_ROOT_FS', '${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.${BALENA_ROOT_FSTYPE}')
         d.setVar('BALENA_RAW_IMG', '${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.balenaos-img')
+        d.setVar('BALENA_RAW_BMAP', '${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.bmap')
         d.setVar('BALENA_DOCKER_IMG', '${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.docker')
         d.setVar('BALENA_HOSTAPP_IMG', '${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.${BALENA_ROOT_FSTYPE}')
 
@@ -134,6 +136,7 @@ do_image_balenaos_img[depends] = " \
     e2fsprogs-native:do_populate_sysroot \
     mtools-native:do_populate_sysroot \
     parted-native:do_populate_sysroot \
+    bmap-tools-native:do_populate_sysroot \
     virtual/kernel:do_deploy \
     ${BALENA_IMAGE_BOOTLOADER_DEPLOY_TASK} \
     "
@@ -357,6 +360,9 @@ IMAGE_CMD:balenaos-img () {
             dd if=${BALENA_DATA_FS} of=${BALENA_RAW_IMG} conv=notrunc,sparse seek=${offset} bs=1024
         fi
     fi
+
+    # create bmap to enable recreating sparse image after full allocation
+    bmaptool create ${BALENA_RAW_IMG} > ${BALENA_RAW_BMAP}
 
     # Optionally apply compression
     case "${BALENA_RAW_IMG_COMPRESSION}" in

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -71,7 +71,7 @@ function dd_with_progress {
     OFFSET=$3
     TOTAL_SIZE=$4
 
-    dd "if=$SRC" "of=$DEST" bs=4M 2> /tmp/dd_progress_log & DD_PID=$!
+    dd "if=$SRC" "of=$DEST" conv=sparse bs=4M 2> /tmp/dd_progress_log & DD_PID=$!
 
     if ! kill -0 $DD_PID; then
         # dd might have been too fast, let's check exit status if it is no longer running


### PR DESCRIPTION
Generates sparse images, which speeds up image generation, reduces writes to disk, and speeds up flashing.

```
┌─[17:32:07]─[joseph@wash]
└──> balena-generic $ >> du -sh balena-nosparse.img 
2.3G	balena-nosparse.img
┌─[17:32:11]─[joseph@wash]
└──> balena-generic $ >> bmaptool copy --bmap build/tmp/deploy/images/generic-amd64/balena-image-generic-amd64-20221130012101.rootfs.bmap balena-nosparse.img balena-sparse.img
bmaptool: info: block map format version 2.0
bmaptool: info: 580608 blocks of size 4096 (2.2 GiB), mapped 216093 blocks (844.1 MiB or 37.2%)
bmaptool: info: copying image 'balena-nosparse.img' to file 'balena-sparse.img' using bmap file 'balena-image-generic-amd64-20221130012101.rootfs.bmap'
bmaptool: info: 100% copied
bmaptool: info: synchronizing 'balena-sparse.img'
bmaptool: info: copying time: 0.9s, copying speed 931.9 MiB/sec
┌─[17:32:18]─[joseph@wash]
└──> balena-generic $ >> du -sh balena-sparse.img 
845M	balena-sparse.img
```

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
