### PR TITLE
Migration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,39 @@ The following example contains two custom udev rules that will create `/etc/udev
 }
 ```
 
+### installer
+
+An object that configures the behaviour of the balenaOS installer image.
+
+#### secureboot
+
+(boolean) Opt-in to installing a secure boot and encrypted disk system for
+supported device types.
+
+```json
+"installer": {
+  "secureboot": true
+}
+```
+
+#### migrator
+
+An object that configures the behaviour of the balenaOS installer migration
+module.
+
+##### migrator.force
+
+(boolean) Forces the migration to run. By default the migration only runs if
+the installer is booting in a single disk system.
+
+```json
+"installer": {
+  "migrator": {
+    "force": true
+  }
+}
+```
+
 ## Yocto version support
 
 The following Yocto versions are supported:

--- a/docs/initramfs.md
+++ b/docs/initramfs.md
@@ -20,3 +20,39 @@ can be used in the following ways:
     from a user application, so this can only be used as a local recovery
     mechanism, replacing the use of `shell` for devices with no accesible
     serial console.
+
+* Installer boot:
+
+  When a `flasher` command is found in the kernel command line, the initramfs
+  boots in installer mode.
+
+  Two types of installations are possible:
+
+  * Installation running from an external storage into internal storage (flasher).
+
+     * This is the traditional balenaOS flasher and allows to register with
+       balenaCloud and send progress reports, as well as allowing for remote
+       cloudlink connections to the running installer.
+
+     * This is the default if more than one storage disks are present.
+
+  * Installation running from initramfs into internal storage (migrator).
+
+     * This is the default if there is only one disk and we are booting from it,
+       or the installer is configured with `installer.migrate.force` by adding
+       the following section to `config.json`:
+
+       ```json
+       "installer": {
+         "migrate": {
+           "force": true
+         }
+       }
+       ```
+
+     * In this mode no registration with the cloud occurs, and remote connections
+       are not possible. Debugging problems with the migration can only be done
+       locally using the recovery mode explained above.
+
+     * When the installation finishes, the new system is booted into and a log
+       file from the migration can be found in the installed boot partition.

--- a/docs/initramfs.md
+++ b/docs/initramfs.md
@@ -9,3 +9,14 @@ can be used in the following ways:
   *  Expands the data partition if required
   *  Mounts the read-only hostapp
   *  Pivots root into it
+
+* Recovery boot:
+  * When a `recovery` command is found in the kernel command line, the
+    initramfs will spawn an `adbd` (android debug bridge) service on a timeout
+    and wait for it to exit before continuing.
+  * Note that secure boot implementations will not boot when the kernel command
+    line arguments are modified
+  * There is also no mechanism to remotely modify kernel command line arguments
+    from a user application, so this can only be used as a local recovery
+    mechanism, replacing the use of `shell` for devices with no accesible
+    serial console.

--- a/meta-balena-common/recipes-core/images/balena-image-initramfs.bb
+++ b/meta-balena-common/recipes-core/images/balena-image-initramfs.bb
@@ -15,6 +15,7 @@ PACKAGE_INSTALL = " \
     initramfs-module-fsck \
     initramfs-module-machineid \
     initramfs-module-recovery \
+    initramfs-module-migrate \
     initramfs-module-resindataexpander \
     initramfs-module-rorootfs \
     initramfs-module-udev \

--- a/meta-balena-common/recipes-core/images/balena-image-initramfs.bb
+++ b/meta-balena-common/recipes-core/images/balena-image-initramfs.bb
@@ -14,6 +14,7 @@ PACKAGE_INSTALL = " \
     initramfs-module-prepare \
     initramfs-module-fsck \
     initramfs-module-machineid \
+    initramfs-module-recovery \
     initramfs-module-resindataexpander \
     initramfs-module-rorootfs \
     initramfs-module-udev \

--- a/meta-balena-common/recipes-core/initrdscripts/files/finish
+++ b/meta-balena-common/recipes-core/initrdscripts/files/finish
@@ -3,6 +3,13 @@
 # Licensed on MIT
 
 finish_enabled() {
+    # shellcheck disable=SC2154
+    if [ "$bootparam_recovery" = "true" ]; then
+        if [ -n "${ADBD_PID}" ]; then
+            # adbd is not a child process so cannot wait
+            while kill -0  "${ADBD_PID}" 2>/dev/null; do sleep 1; done
+        fi
+    fi
     return 0
 }
 

--- a/meta-balena-common/recipes-core/initrdscripts/files/migrate
+++ b/meta-balena-common/recipes-core/initrdscripts/files/migrate
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+# Copyright 2022 Balena Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# OS migration
+#
+# Expects to find flash-boot and a mounted flash-rootA rootfs in the boot disk
+
+# shellcheck disable=SC1091
+. /usr/libexec/os-helpers-logging
+# shellcheck disable=SC1091
+. /usr/libexec/os-helpers-fs
+# shellcheck disable=SC1091
+. /usr/sbin/balena-config-defaults
+
+memory_check() {
+    _size="${1}"
+    sync && echo 3 > /proc/sys/vm/drop_caches
+    swapoff -a && swapon -a
+    _memfree=$(awk '/MemFree/{free=$2} END{print (free*1024)}' /proc/meminfo)
+    if [ "${_memfree}" -lt "${_size}" ]; then
+        relocate_log_mount
+        fail "Not enough memory: requested ${_size}, available ${_memfree}"
+    fi
+    return 0
+}
+
+relocate_log_mount() {
+    # Preserve log file in rootfs
+    # Move the /run mountpoint to the rootfs mountpoint
+    if [ -d "${ROOTFS_DIR}/run" ]; then
+        if mountpoint '/run' > /dev/null; then
+            mount -n -o move /run "${ROOTFS_DIR}/run"
+        fi
+    else
+        # Older releases do not create /run so use /tmp instead
+        if mountpoint '/run' > /dev/null; then
+            mount -n -o move /run "${ROOTFS_DIR}/tmp"
+        fi
+    fi
+    sync "${ROOTFS_DIR}/run" "${ROOTFS_DIR}/tmp" || true
+}
+
+# Enable module function
+migrate_enabled() {
+    # shellcheck disable=SC2154
+    if [ "$bootparam_flasher" = "true" ]; then
+        # flash-rootA has been identified as rootfs
+
+        _flash_file_name=$(basename "${FLASHER_FILEFLAG}")
+        if [ -f "${ROOTFS_DIR}/flash-boot/${_flash_file_name}" ]; then
+            # shellcheck disable=SC1090
+            . "${ROOTFS_DIR}/etc/resin-init-flasher.conf"
+
+            # Migration use cases are:
+            #
+            # * Booting with only one disk - migrate if this disk is the one
+            #   configured to program into
+            # * Booting with multiple disks - only migrate if explicitely
+            #   configured to do so as the user might want to install on
+            #   alternative disks
+            #
+            internal_dev=$(get_internal_device "${INTERNAL_DEVICE_KERNEL}")
+            FLASH_BOOT_DEVICE=$(get_dev_path_in_device_with_label "${internal_dev}" "flash-boot")
+            if [ -n "${FLASH_BOOT_DEVICE}" ]; then
+                FLASH_BOOT_MOUNT="/tmp/flash-boot"
+                mkdir -p "${FLASH_BOOT_MOUNT}"
+                mount "${FLASH_BOOT_DEVICE}" "${FLASH_BOOT_MOUNT}"
+                if jq -re '.installer.migrate.force' "${FLASH_BOOT_MOUNT}/config.json" > /dev/null; then
+                    _migrate=1
+                    info "Migration requested in configuration"
+                fi
+            else
+                relocate_log_mount
+                fail "Flash boot partition not found in ${internal_dev}"
+            fi
+
+            # Migrate if configured to do so or if there is only one disk
+            # (excluding RAM and swap devices)
+            if [[ ( -n "${_migrate}" && "${_migrate}" = "1" ) || $(lsblk -nde 251,1 | wc -l) -eq "1" ]]; then
+                # Check that we are booting from the same disk we want to program
+                device=$(findmnt --noheadings --canonicalize --output SOURCE "${ROOTFS_DIR}" | xargs lsblk -no pkname)
+                if [ "${internal_dev#/dev/}" = "${device}" ]; then
+                    info "Running migration on ${device}..."
+                    return 0
+                fi
+            fi
+        fi
+    fi
+    # Booting from external media - leave flashing after pivot-rooting
+    umount "${FLASH_BOOT_MOUNT}" > /dev/null || true
+    relocate_log_mount
+    return 1
+}
+
+# Main module function
+migrate_run() {
+    # Find the raw image in the rootfs partition
+    image=$(find "${ROOTFS_DIR}" -xdev -type f -name "${BALENA_IMAGE}")
+    kernel_images=$(find "${ROOTFS_DIR}" -xdev -type f -name "bzImage*")
+    if [ -n "${image}" ]; then
+        EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT="${BALENA_BOOT_MOUNTPOINT}"
+        if findmnt "${FLASH_BOOT_MOUNT}" > /dev/null; then
+            _image_size=$(wc -c "${image}" | awk '{print $1}')
+            _flash_boot_size=$(du -bs ${FLASH_BOOT_MOUNT} | awk '{print $1}')
+            # shellcheck disable=SC2086
+            _kernel_images_size=$(wc -c ${kernel_images} | awk '/total/{ print $1}')
+            _total_size=$(("$_image_size" + "$_flash_boot_size" + "$_kernel_images_size"))
+            memory_check "${_total_size}"
+        else
+            relocate_log_mount
+            fail "Flash boot partition not found in ${internal_dev}"
+        fi
+        # Copy the raw image to memory
+        cp "${image}" "/tmp"
+
+        # Copy the flasher boot partition into memory (contains configuration)
+        mkdir -p "${EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}"
+        cp -r "${FLASH_BOOT_MOUNT}"/* "${EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/"
+
+        # Copy the flasher kernel images to memory
+        # shellcheck disable=SC2086
+        cp -a ${kernel_images} "/tmp"
+
+        # Need to source this again to set CONFIG_PATH correctly
+        unset CONFIG_PATH
+        # shellcheck disable=SC1091
+        . /usr/sbin/balena-config-defaults
+
+        mkdir -p "$(dirname "${CONFIG_PATH}")"
+        _config_json_name=$(basename "${CONFIG_PATH}")
+        cp "${FLASH_BOOT_MOUNT}/${_config_json_name}" "${CONFIG_PATH}"
+
+        umount "${FLASH_BOOT_MOUNT}" > /dev/null || true
+        sync "${EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}"
+        # Unmount the rootfs as we are going to program over
+        umount "${ROOTFS_DIR}"
+        # Run flasher - should not return
+        /usr/bin/resin-init-flasher
+    else
+        relocate_log_mount
+        # If recovery mode, wait for adbd to exit
+        if [ -n "${ADBD_PID}" ]; then
+            # adbd is not a child process so cannot wait
+            while kill -0  "${ADBD_PID}" 2>/dev/null; do sleep 1; done
+        fi
+        fail "No ${BALENA_IMAGE} found in ${ROOTFS_DIR}"
+    fi
+}

--- a/meta-balena-common/recipes-core/initrdscripts/files/recovery
+++ b/meta-balena-common/recipes-core/initrdscripts/files/recovery
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# Copyright 2022 Balena Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Boots into a recovery shell
+#
+
+# shellcheck disable=SC1091
+. /usr/libexec/os-helpers-logging
+
+# Enable module function
+recovery_enabled() {
+    # shellcheck disable=SC2154
+    if [ "$bootparam_recovery" = "true" ]; then
+        return 0
+    fi
+    return 1
+}
+
+# Main module function
+recovery_run() {
+    if ! udhcpc -n; then
+        warn "DHCP request failed - network adb access won't be possible."
+    fi
+    mkdir /dev/pts
+    mount -t devpts devpts /dev/pts
+    ADBD_TIMEOUT="${bootparam_adbdtimeout:-10m}"
+    ADBD_KILLTIMEOUT="${bootparam_adbdkilltimeout:-15m}"
+    if [ "${ADBD_TIMEOUT}" -gt "${ADBD_KILLTIMEOUT}" ]; then
+        ADBD_KILLTIMEOUT="${ADBD_TIMEOUT}"
+    fi
+    info "Starting adbd daemon with a ${ADBD_TIMEOUT} timeout, sigkill in ${ADBD_KILLTIMEOUT}..."
+    timeout -k "${ADBD_KILLTIMEOUT}" "${ADBD_TIMEOUT}" adbd &
+    export ADBD_PID="$!"
+}

--- a/meta-balena-common/recipes-core/initrdscripts/files/rootfs
+++ b/meta-balena-common/recipes-core/initrdscripts/files/rootfs
@@ -76,13 +76,4 @@ rootfs_run() {
         sleep $delay
         C=$(( $C + 1 ))
     done
-
-    # Move the /run mountpoint to the rootfs mountpoint
-    if [ -d "${ROOTFS_DIR}/run" ]; then
-        mount -n -o move /run "${ROOTFS_DIR}/run"
-    else
-        # Older releases do not create /run so use /tmp instead
-        mount -n -o move /run "${ROOTFS_DIR}/tmp"
-    fi
-
 }

--- a/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -12,6 +12,7 @@ SRC_URI:append = " \
     file://cryptsetup \
     file://kexec \
     file://udevcleanup \
+    file://recovery \
     "
 
 do_install:append() {
@@ -27,6 +28,7 @@ do_install:append() {
     install -m 0755 ${WORKDIR}/udevcleanup ${D}/init.d/98-udevcleanup
     install -m 0755 ${WORKDIR}/cryptsetup ${D}/init.d/72-cryptsetup
     install -m 0755 ${WORKDIR}/kexec ${D}/init.d/92-kexec
+    install -m 0755 ${WORKDIR}/recovery ${D}/init.d/00-recovery
 }
 
 PACKAGES:append = " \
@@ -39,6 +41,7 @@ PACKAGES:append = " \
     initramfs-module-cryptsetup \
     initramfs-module-kexec \
     initramfs-module-udevcleanup \
+    initramfs-module-recovery \
     "
 
 RRECOMMENDS:${PN}-base += "initramfs-module-rootfs"
@@ -85,3 +88,7 @@ FILES:initramfs-module-kexec = "/init.d/92-kexec"
 SUMMARY:initramfs-module-udevcleanaup = "Cleanup the udev database before transitioning to the rootfs"
 RDEPENDS:initramfs-module-udevcleanaup = "${PN}-base"
 FILES:initramfs-module-udevcleanup = "/init.d/98-udevcleanup"
+
+SUMMARY:initramfs-module-recovery = "Boot into a recovery shell"
+RDEPENDS:initramfs-module-recovery = "${PN}-base android-tools-adbd"
+FILES:initramfs-module-recovery = "/init.d/00-recovery"

--- a/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -13,6 +13,7 @@ SRC_URI:append = " \
     file://kexec \
     file://udevcleanup \
     file://recovery \
+    file://migrate \
     "
 
 do_install:append() {
@@ -20,6 +21,7 @@ do_install:append() {
     install -m 0755 ${WORKDIR}/fsuuidsinit ${D}/init.d/75-fsuuidsinit
     install -m 0755 ${WORKDIR}/fsck ${D}/init.d/87-fsck
     install -m 0755 ${WORKDIR}/rootfs ${D}/init.d/90-rootfs
+    install -m 0755 ${WORKDIR}/migrate ${D}/init.d/92-migrate
     install -m 0755 ${WORKDIR}/finish ${D}/init.d/99-finish
 
     install -m 0755 ${WORKDIR}/machineid ${D}/init.d/91-machineid
@@ -42,6 +44,7 @@ PACKAGES:append = " \
     initramfs-module-kexec \
     initramfs-module-udevcleanup \
     initramfs-module-recovery \
+    initramfs-module-migrate \
     "
 
 RRECOMMENDS:${PN}-base += "initramfs-module-rootfs"
@@ -92,3 +95,13 @@ FILES:initramfs-module-udevcleanup = "/init.d/98-udevcleanup"
 SUMMARY:initramfs-module-recovery = "Boot into a recovery shell"
 RDEPENDS:initramfs-module-recovery = "${PN}-base android-tools-adbd"
 FILES:initramfs-module-recovery = "/init.d/00-recovery"
+
+SUMMARY:initramfs-module-migrate = "OS Migration"
+RDEPENDS:initramfs-module-migrate = " \
+    util-linux-findmnt \
+    util-linux-mountpoint \
+    resin-init-flasher \
+    bash \
+    balena-config-vars-config \
+    "
+FILES:initramfs-module-migrate = "/init.d/92-migrate"

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -580,6 +580,14 @@ fi
 
 report_progress 100 "Post-Provisioning"
 
-inform "Shutting down ..."
-shutdown -h now
-exit 0
+# After migration we want to reboot as the remote device might not be accesible otherwise
+# This is achieved because the shutdown command is not part of the initramfs
+if command -v shutdown; then
+    inform "Shutting down ..."
+    shutdown -h now
+elif command -v reboot; then
+    inform "Rebooting..."
+    reboot -f
+fi
+
+fail "Unable to shutdown or reboot"

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -572,8 +572,14 @@ if [ "$LUKS" = "1" ]; then
     done
 fi
 
+# If in initramfs recovery mode, wait for adbd to finish
+if [ -n "${ADBD_PID}" ]; then
+    # adbd is not a child process so cannot wait
+    while kill -0  "${ADBD_PID}" 2>/dev/null; do sleep 1; done
+fi
+
 report_progress 100 "Post-Provisioning"
+
 inform "Shutting down ..."
 shutdown -h now
-
 exit 0

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -47,6 +47,7 @@ EFIVARS_MOUNTDIR="/sys/firmware/efi/efivars"
 SECUREBOOT_ENABLED=0
 
 . /usr/libexec/os-helpers-fs
+. /usr/libexec/os-helpers-logging
 
 function clean {
     echo "[resin-init-flasher] Cleanup."
@@ -54,15 +55,7 @@ function clean {
     umount $INTERNAL_DEVICE_CONF_PART_MOUNTPOINT > /dev/null 2>&1 || true
 }
 
-function fail {
-    echo "[resin-init-flasher] ERROR: $1"
-    clean
-    exit 1
-}
-
-function inform {
-    echo "[resin-init-flasher] INFO: $1"
-}
+trap clean ERR
 
 function report_progress() {
     _ratio="${1}"
@@ -119,7 +112,7 @@ if [ "$EUID" -ne 0 ]; then
     fail "Please run as root."
 fi
 
-inform "Board specific initialization..."
+info "Board specific initialization..."
 /usr/bin/resin-init-board
 
 # Configuration file
@@ -128,7 +121,7 @@ if [ -f $FLASHER_CONF_FILE ]; then
 else
     fail "No configuration for resin-init-flasher."
 fi
-inform "resin-init-flasher configuration found."
+info "resin-init-flasher configuration found."
 
 # Find path to image
 _balena_image=$(find / -xdev -type f -name "${BALENA_IMAGE}")
@@ -144,7 +137,7 @@ if [ -f /usr/sbin/balena-config-vars ]; then
 else
     fail "No balena configuration found."
 fi
-inform "balena configuration found."
+info "balena configuration found."
 
 # BALENA_BOOT_MOUNTPOINT should exist
 if [ ! -d "$BALENA_BOOT_MOUNTPOINT" ]; then
@@ -166,7 +159,7 @@ if command -v "systemctl"; then
         if [ $((ENDTIME - STARTTIME)) -le $TIMEOUT ]; then
             sleep 1 && ENDTIME=$((ENDTIME + 1))
         else
-            inform "Timeout while waiting for openvpn to come alive. No network?"
+            info "Timeout while waiting for openvpn to come alive. No network?"
             break
         fi
     done
@@ -178,13 +171,13 @@ if [ -z "${INTERNAL_DEVICE_KERNEL}" ]; then
 fi
 
 # Flash Resin image on internal device
-inform "Flash internal device... will take around 5 minutes... "
+info "Flash internal device... will take around 5 minutes... "
 internal_dev=$(get_internal_device "${INTERNAL_DEVICE_KERNEL}")
 if [ -z "$internal_dev" ]; then
     report_progress 100 "Failed to find any block devices."
     fail "Failed to find any block devices in $INTERNAL_DEVICE_KERNEL."
 fi
-inform "$internal_dev will be used for flashing."
+info "$internal_dev will be used for flashing."
 
 IMAGE_FILE_SIZE=$(wc -c "$BALENA_IMAGE" | awk '{print $1}')
 
@@ -216,11 +209,11 @@ if [ -d /sys/firmware/efi ]; then
             fail "Secure boot is supported in firmware, but the image is not signed"
         fi
 
-        inform "Secure boot is enabled, proceeding with lockdown"
+        info "Secure boot is enabled, proceeding with lockdown"
         LUKS=1
 
         if [ "${SETUPMODE_VAR}" -eq "1" ]; then
-            inform "Secure boot setup mode detected - programming keys"
+            info "Secure boot setup mode detected - programming keys"
             # Enroll PK last, as it should disable setup mode
             for e in db KEK PK; do
                 # Remove immutable attribute
@@ -234,7 +227,7 @@ if [ -d /sys/firmware/efi ]; then
                 | awk 'NR==1, $1 == "Value:" {next}; NF {print $2}')
             if [ "${SETUPMODE_VAR}" -eq "1" ]; then
                 # Setting up keys hasn't disabled setup mode, try a reboot into flasher
-                inform "Rebooting flasher after secure mode setup to boot in secure boot mode."
+                info "Rebooting flasher after secure mode setup to boot in secure boot mode."
                 # Make sure to reboot into the installer
                 bootcurrent=$(efibootmgr | grep BootCurrent | awk '{print $2}')
                 efibootmgr -n "${bootcurrent}"
@@ -252,10 +245,10 @@ if [ "$LUKS" = "1" ]; then
     # Generate password and encrypt it using the TPM
     TPM="${TPM:-/dev/tpmrm0}"
     if [ -e "$TPM" ]; then
-        inform "$TPM will be used for LUKS operations"
+        info "$TPM will be used for LUKS operations"
         export TPM2TOOLS_TCTI="device:$TPM"
     else
-        inform "$TPM not found, falling back to autodetection"
+        info "$TPM not found, falling back to autodetection"
     fi
 
     # Generate a random passphrase
@@ -274,7 +267,7 @@ if [ "$LUKS" = "1" ]; then
 
     # Repartition the new drive
     report_progress 0 "Starting flashing balenaOS on internal media"
-    inform "Repartitioning $internal_dev for disk encryption"
+    info "Repartitioning $internal_dev for disk encryption"
 
     # Align partition sizes to multiples of 4MB
     PART_SIZE_ALIGN=$[4 * 1024 * 1024]
@@ -286,7 +279,7 @@ if [ "$LUKS" = "1" ]; then
     # and it is much harder to operate on due to the necessity of an extended partition
     parted "$internal_dev" mktable gpt
 
-    inform "Flashing boot partition"
+    info "Flashing boot partition"
     ORIGINAL_BOOT_PART_ID=$(get_part_number_by_label "$LOOP_DEVICE_NAME" resin-boot)
     ORIGINAL_BOOT_PART_SIZE=$(get_part_size_by_number "$LOOP_DEVICE_NAME" "$ORIGINAL_BOOT_PART_ID" "$PART_SIZE_ALIGN")
     ORIGINAL_BOOT_START=$(get_part_start_by_number "$LOOP_DEVICE_NAME" "$ORIGINAL_BOOT_PART_ID")
@@ -351,7 +344,7 @@ if [ "$LUKS" = "1" ]; then
         INTERNAL_PART_ID=$(get_part_number_by_label "${internal_dev#/dev/}" "$PART_NAME" partlabel)
 
         PART_DEV="$internal_dev$PART_PREFIX$INTERNAL_PART_ID"
-        inform "Encrypting $PART_DEV"
+        info "Encrypting $PART_DEV"
         cryptsetup -q luksFormat "$PART_DEV" "$PASSPHRASE_FILE"
         cryptsetup luksOpen "$PART_DEV" "$PART_NAME" --key-file "$PASSPHRASE_FILE"
         DM_DEV="/dev/mapper/$PART_NAME"
@@ -361,7 +354,7 @@ if [ "$LUKS" = "1" ]; then
             continue
         fi
 
-        inform "Flashing $PART_DEV"
+        info "Flashing $PART_DEV"
 
         dd_with_progress "${LOOP_DEVICE}p$LOOP_PART_ID" "$DM_DEV" "$FLASHED" "$IMAGE_FILE_SIZE"
 
@@ -392,28 +385,28 @@ udevadm settle
 if [ -n "$BOOTLOADER_FLASH_DEVICE" ]; then
     if [ -n "$BOOTLOADER_IMAGE" ] && [ -n "$BOOTLOADER_BLOCK_SIZE_OFFSET" ]; then
         dd if="${EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/${BOOTLOADER_IMAGE}" of="/dev/${BOOTLOADER_FLASH_DEVICE}" bs="${BOOTLOADER_BLOCK_SIZE_OFFSET}" seek="${BOOTLOADER_SKIP_OUTPUT_BLOCKS}"
-        inform "Flashed ${BOOTLOADER_IMAGE} to internal flash"
+        info "Flashed ${BOOTLOADER_IMAGE} to internal flash"
     else
         fail "BOOTLOADER_IMAGE and/or BOOTLOADER_BLOCK_SIZE_OFFSET are not set."
     fi
 else
-    inform "No need to flash first stage bootloader to a specific device."
+    info "No need to flash first stage bootloader to a specific device."
 fi
 
 if [ -n "$BOOTLOADER_FLASH_DEVICE_1" ]; then
     if [ -n "$BOOTLOADER_IMAGE_1" ] && [ -n "$BOOTLOADER_BLOCK_SIZE_OFFSET_1" ]; then
         dd if="${EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/${BOOTLOADER_IMAGE_1}" of="/dev/${BOOTLOADER_FLASH_DEVICE_1}" bs="${BOOTLOADER_BLOCK_SIZE_OFFSET_1}" seek="${BOOTLOADER_SKIP_OUTPUT_BLOCKS_1}"
-        inform "Flashed ${BOOTLOADER_IMAGE_1} to internal flash"
+        info "Flashed ${BOOTLOADER_IMAGE_1} to internal flash"
     else
         fail "BOOTLOADER_IMAGE_1 and/or BOOTLOADER_BLOCK_SIZE_OFFSET_1 are not set."
     fi
 else
-    inform "No need to flash second stage bootloader to a specific device."
+    info "No need to flash second stage bootloader to a specific device."
 fi
 
 # Mount internal device boot partition
 mkdir -p $INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT
-inform "Mounting internal device boot partition."
+info "Mounting internal device boot partition."
 
 # Wait for the devices to be detected for a while
 BOOT_MOUNT="/dev/disk/by-label/resin-boot"
@@ -472,20 +465,20 @@ fi
 # Copy Network Manager connection files
 _nm_config="${EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/${BALENA_NM_CONFIG}"
 if [ -d "${_nm_config}" ]; then
-    inform "Transferring system connections on the internal device."
+    info "Transferring system connections on the internal device."
     rm -rf "${INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/${BALENA_NM_CONFIG}/"
     cp -rvf "${_nm_config}" "${INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}"
 else
-    inform "No system connections found to transfer on the internal device."
+    info "No system connections found to transfer on the internal device."
 fi
 # Copy proxy configuration files
 _proxy_config="${EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/${BALENA_PROXY_CONFIG}"
 if [ -d "${_proxy_config}" ]; then
-    inform "Transferring proxy configuration on the internal device."
+    info "Transferring proxy configuration on the internal device."
     rm -rf "${INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/${BALENA_PROXY_CONFIG}"
     cp -rvf "${_proxy_config}" "${INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}"
 else
-    inform "No proxy configuration found to transfer on the internal device."
+    info "No proxy configuration found to transfer on the internal device."
 fi
 # Copy bootloader config file
 if [ -n "${INTERNAL_DEVICE_BOOTLOADER_CONFIG}" ] && [ -f "${EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/${INTERNAL_DEVICE_BOOTLOADER_CONFIG}" ]; then
@@ -518,7 +511,7 @@ if command -v "systemctl"; then
         if [ $((ENDTIME - STARTTIME)) -le $TIMEOUT ]; then
             sleep 1 && ENDTIME=$((ENDTIME + 1))
         else
-            inform "Timeout while waiting for register to finish. No network?"
+            info "Timeout while waiting for register to finish. No network?"
             break
         fi
     done
@@ -533,7 +526,7 @@ if [ "$LUKS" = "1" ]; then
     umount "$EFI_MOUNT_DIR"
 fi
 
-inform "Board specific flash procedure..."
+info "Board specific flash procedure..."
 /usr/bin/resin-init-flasher-board
 
 info "Log end"
@@ -589,10 +582,10 @@ report_progress 100 "Post-Provisioning"
 # After migration we want to reboot as the remote device might not be accesible otherwise
 # This is achieved because the shutdown command is not part of the initramfs
 if command -v shutdown; then
-    inform "Shutting down ..."
+    info "Shutting down ..."
     shutdown -h now
 elif command -v reboot; then
-    inform "Rebooting..."
+    info "Rebooting..."
     reboot -f
 fi
 

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -533,12 +533,18 @@ if [ "$LUKS" = "1" ]; then
     umount "$EFI_MOUNT_DIR"
 fi
 
+inform "Board specific flash procedure..."
+/usr/bin/resin-init-flasher-board
+
+info "Log end"
+# Preserve logs when running from initramfs
+if [ -n "${INITRAMFS_LOGFILE}" ] && [ -f "${INITRAMFS_LOGFILE}" ]; then
+    cp "${INITRAMFS_LOGFILE}" "${INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/migration_$(date +"%Y%m%dT%H%M")"
+fi
+
 umount $INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT
 
 sync
-
-inform "Board specific flash procedure..."
-/usr/bin/resin-init-flasher-board
 
 EFIPART_LABEL="resin-boot"
 LOADER_PATH="/EFI/BOOT/bootx64.efi"

--- a/meta-balena-dunfell/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-balena-dunfell/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -15,3 +15,4 @@ PACKAGES_append = " \
 SUMMARY_initramfs-module-console-null-workaround = "Workaround needed for when console=null is passed in kernel cmdline"
 RDEPENDS_initramfs-module-console-null-workaround = "${PN}-base"
 FILES_initramfs-module-console-null-workaround = "/init.d/000-console_null_workaround"
+RDEPENDS_initramfs-module-recovery = "${PN}-base android-tools"

--- a/meta-balena-thud/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-balena-thud/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -4,3 +4,4 @@ RDEPENDS_initramfs-module-kexec = " \
     kexec-tools \
     util-linux \
     "
+RDEPENDS_initramfs-module-recovery = "${PN}-base android-tools"

--- a/meta-balena-warrior/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-balena-warrior/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -15,3 +15,4 @@ PACKAGES_append = " \
 SUMMARY_initramfs-module-console-null-workaround = "Workaround needed for when console=null is passed in kernel cmdline"
 RDEPENDS_initramfs-module-console-null-workaround = "${PN}-base"
 FILES_initramfs-module-console-null-workaround = "/init.d/000-console_null_workaround"
+RDEPENDS_initramfs-module-recovery = "${PN}-base android-tools"

--- a/meta-resin-pyro/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-resin-pyro/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -4,3 +4,4 @@ RDEPENDS_initramfs-module-kexec = " \
     kexec-tools \
     util-linux \
     "
+RDEPENDS_initramfs-module-recovery = "${PN}-base android-tools"

--- a/meta-resin-rocko/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-resin-rocko/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -1,2 +1,3 @@
 # Pre warrior busybox didn't have bc
 RDEPENDS_initramfs-module-resindataexpander_append = " bc"
+RDEPENDS_initramfs-module-recovery = "${PN}-base android-tools"

--- a/meta-resin-sumo/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-resin-sumo/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -4,3 +4,4 @@ RDEPENDS_initramfs-module-kexec = " \
     kexec-tools \
     util-linux \
     "
+RDEPENDS_initramfs-module-recovery = "${PN}-base android-tools"


### PR DESCRIPTION
This patchset introduces a migrator module to the initramfs that is capable of programming the direct boot image into internal storage from memory.

Applications for this mode include OS migration and also secure boot and disk encryption installation on non-flasher device types.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
