### PR TITLE
chrony: disable reverse dns lookups in healthcheck

### DIFF
--- a/meta-balena-common/recipes-core/chrony/files/chrony-healthcheck
+++ b/meta-balena-common/recipes-core/chrony/files/chrony-healthcheck
@@ -5,7 +5,7 @@ set -o errexit
 . /usr/libexec/os-helpers-logging
 
 offline="true"
-sources=$(chronyc sources | tail -n +3 | awk '{ print $1 }')
+sources=$(chronyc -n sources | tail -n +3 | awk '{ print $1 }')
 for source in $sources; do
 	if [[ $source = *\** ]]; then
 		offline="false"


### PR DESCRIPTION
v2.99.0 added #2669, a healthcheck for chrony time synchronization. This check executes `chronyc sources` to verify chronyd has selected a source. By default this command performs a reverse DNS lookup for the host name of a source. For the healthcheck we don't care about the host name, so it's a waste of bandwidth and time especially when there is no name for the address. This PR disables these unnecessary lookups with an option on the chronyc command.

### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->
