### PR TITLE
tests: os: fsck: make compatible with old yocto releaes

### DIFF
--- a/tests/suites/os/package-lock.json
+++ b/tests/suites/os/package-lock.json
@@ -465,6 +465,14 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
+		"lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"requires": {
+				"yallist": "^4.0.0"
+			}
+		},
 		"mbr": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/mbr/-/mbr-1.1.3.tgz",
@@ -648,6 +656,14 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"semver": {
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"requires": {
+				"lru-cache": "^6.0.0"
+			}
 		},
 		"split-ca": {
 			"version": "1.0.1",
@@ -866,6 +882,11 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
 			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		}
 	}
 }

--- a/tests/suites/os/package.json
+++ b/tests/suites/os/package.json
@@ -10,6 +10,7 @@
 		"mz": "^2.7.0",
 		"request": "^2.88.0",
 		"request-promise": "^4.2.4",
+		"semver": "^7.3.8",
 		"tar-stream": "^2.1.0"
 	}
 }


### PR DESCRIPTION
This test fails with images built with older yocto releases (warrior)

This is because it uses the `-E force_fsck` argument for `tune2fs` to force a filesystem check of each partition on a reboot.
However this feature was only added to `tune2fs` version > 1.45.0, and images build with older yocto releases might not have a version of `tune2fs` that satisfies this. An example is the `etcher-pro` device type.

One solution suggested was to use `tune2fs -c 1` to force the `fsck` on the partition after a single reboot. However I tried this, and it did not work for the root partitions.


Instead, I've added a check to the test, that will skip it if `tune2fs` doesn't satisfy the version requirement on the DUT. 

This will unblock the tests for some device types - I'm not against refactoring this test more however in the future


Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
