### PR TITLE
image_types_balena: fix inconsistency with flasher image partition na…

### DIFF
--- a/meta-balena-common/classes/image_types_balena.bbclass
+++ b/meta-balena-common/classes/image_types_balena.bbclass
@@ -233,7 +233,7 @@ IMAGE_CMD:balenaos-img () {
             OPTS="primary fat16"
         fi
     elif [ "${PARTITION_TABLE_TYPE}" = "gpt" ]; then
-        OPTS="resin-boot"
+        OPTS="${BALENA_BOOT_FS_LABEL}"
     fi
     START=${DEVICE_SPECIFIC_SPACE}
     END=$(expr ${START} \+ ${BALENA_BOOT_SIZE_ALIGNED})
@@ -245,7 +245,7 @@ IMAGE_CMD:balenaos-img () {
     if [ "${PARTITION_TABLE_TYPE}" = "msdos" ]; then
         OPTS="primary"
     elif [ "${PARTITION_TABLE_TYPE}" = "gpt" ]; then
-        OPTS="resin-rootA"
+        OPTS="${BALENA_ROOTA_FS_LABEL}"
     fi
     START=${END}
     END=$(expr ${START} \+ ${BALENA_ROOTA_SIZE_ALIGNED})
@@ -255,7 +255,7 @@ IMAGE_CMD:balenaos-img () {
     if [ "${PARTITION_TABLE_TYPE}" = "msdos" ]; then
         OPTS="primary"
     elif [ "${PARTITION_TABLE_TYPE}" = "gpt" ]; then
-        OPTS="resin-rootB"
+        OPTS="${BALENA_ROOTB_FS_LABEL}"
     fi
     START=${END}
     END=$(expr ${START} \+ ${BALENA_ROOTB_SIZE_ALIGNED})
@@ -273,7 +273,7 @@ IMAGE_CMD:balenaos-img () {
     if [ "${PARTITION_TABLE_TYPE}" = "msdos" ]; then
         OPTS="logical"
     elif [ "${PARTITION_TABLE_TYPE}" = "gpt" ]; then
-        OPTS="resin-state"
+        OPTS="${BALENA_STATE_FS_LABEL}"
     fi
     START=${END}
     END=$(expr ${START} \+ ${BALENA_STATE_SIZE_ALIGNED})
@@ -285,7 +285,7 @@ IMAGE_CMD:balenaos-img () {
         OPTS="logical"
         START=$(expr ${END} \+ ${BALENA_IMAGE_ALIGNMENT})
     elif [ "${PARTITION_TABLE_TYPE}" = "gpt" ]; then
-        OPTS="resin-data"
+        OPTS="${BALENA_DATA_FS_LABEL}"
         START=${END}
     fi
     parted -s ${BALENA_RAW_IMG} -- unit KiB mkpart ${OPTS} ${START} 100%


### PR DESCRIPTION
…ming

Partitions in flasher images are being created with different LABEL and PARTLABEL, for example:
```
/dev/sdd2: LABEL="flash-rootA" UUID="5585296a-c183-4b10-89ae-20607e5604be" TYPE="ext4" PARTLABEL="resin-rootA" PARTUUID="582478f2-be4b-4279-9124-536385c9551d"
```

This commit fixes the inconsistency as the PARTLABEL is used as a fallback method to identify devices.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
