### PR TITLE
tests/connectivity: Set actual redsocks username for the user propert…

### DIFF
--- a/tests/suites/os/tests/connectivity/docker-compose.yml
+++ b/tests/suites/os/tests/connectivity/docker-compose.yml
@@ -5,4 +5,4 @@ services:
     network_mode: host
     restart: on-failure
     command: -verbose -listen :8123
-    user: "995" # run as redsocks user to avoid loop
+    user: redsocks # run as redsocks user to avoid loop


### PR DESCRIPTION
…y in the compose file

Not all boards have the redsocks user with uid 995 so let's use the actual username instead

Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
