### PR TITLE
initrdscripts: Wait for udev processing to complete when unlocking LUKS devices

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup
+++ b/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup
@@ -7,6 +7,38 @@
 
 EFI_DEV=$(get_state_path_from_label "balena-efi")
 
+wait4udev() {
+    # Wait for udev processing of a DM device to finish
+    #
+    # After cryptsetup luksOpen returns to shell, udev events initializing
+    # the DM device are still being generated in the background.
+    # 95-dm-notify.rules will notify dmsetup when udev processing is finished
+    # but we found no way to hook to this from shell.
+    #
+    # This function waits for a particular udev env variable to be defined
+    # on the specified device. This is not the cleanest solution but it works
+    # for this use-case - it indicates the last necessary udev event is being
+    # processed and, if necessary from a shell, a subsequent settle will block
+    # until the processing finishes.
+    #
+    # The function will fail if the variable does not appear in a reasonable amount of time.
+
+    DM_DEVICE="$1"
+
+    I=0
+    # DM_UDEV_RULES_VSN is the last variable that 10-dm.rules defines for an active device
+    while ! udevadm info "${DM_DEVICE}" | grep -q "DM_UDEV_RULES_VSN=2"; do
+        if [ "${I}" -gt 4 ]; then
+            return 1
+        fi
+
+        sleep 1
+        I=$["${I}" + 1]
+    done
+
+    return 0
+}
+
 cryptsetup_enabled() {
     # Flasher should not try to unlock the partitions
     if [ "$bootparam_flasher" = "true" ]; then
@@ -65,8 +97,19 @@ cryptsetup_run() {
 
     BOOT_DEVICE=$(lsblk -nlo pkname "${EFI_DEV}")
 
+    # Unlock all the partitions - cryptsetup luksOpen does not wait for udev processing
+    # of the DM device to complete, it just kicks off the process and returns.
+    # Since this is async, we can perform all the luksOpens here, note the device names
+    # and wait for them in a separate loop later
+    LUKS_UNLOCKED=""
     for LUKS_UUID in $(lsblk -nlo uuid,fstype "/dev/${BOOT_DEVICE}" | grep crypto_LUKS | cut -d " " -f 1); do
         cryptsetup luksOpen --key-file $PASSPHRASE_FILE UUID="${LUKS_UUID}" luks-"${LUKS_UUID}"
+        LUKS_UNLOCKED="${LUKS_UNLOCKED} luks-${LUKS_UUID}"
+    done
+
+    # Wait for udev processing of each unlocked device
+    for DM_NAME in ${LUKS_UNLOCKED}; do
+        wait4udev "/dev/mapper/${DM_NAME}"
     done
 
     rm -f "$PASSPHRASE_FILE"

--- a/meta-balena-common/recipes-core/initrdscripts/files/udevcleanup
+++ b/meta-balena-common/recipes-core/initrdscripts/files/udevcleanup
@@ -10,6 +10,7 @@ udevcleanup_enabled() {
 }
 
 udevcleanup_run() {
+    udevadm settle
     info "Stopping udevd daemon"
     killall udevd
     info "Cleaning up udev database"


### PR DESCRIPTION
When unlocking LUKS devices, udev events initializing the DM devices are still generated in the background even after cryptsetup luksOpen returns. We need to wait for the udev processing to finish before killing udev and cleaning up the udev database to avoid having to deal with partially initialized devices or corrupted udev database in the target OS.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
