### PR TITLE
tests/connectivity: Run the proxy tests with the actual redsocks uid …

### DIFF
--- a/tests/suites/os/tests/connectivity/docker-compose.yml
+++ b/tests/suites/os/tests/connectivity/docker-compose.yml
@@ -5,4 +5,4 @@ services:
     network_mode: host
     restart: on-failure
     command: -verbose -listen :8123
-    user: "995" # run as redsocks user to avoid loop
+    user: REDSOCKS_UID


### PR DESCRIPTION
…of the DUT

Not all the boards we support have the redsocks uid as 995 in their rootfs so let's fetch the actual redsocks uid from the DUT before running the proxy tests and update that in the docker-compose.yml. We do so because the REDSOCKS_UID value isn't substituted in the compose file, even if it is passed trough the cli.

Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>

Tested locally on the Beaglebone DUT:

```
leviathan-client-1  | [2022-12-07T14:36:09.238Z][df30d27-os]         # Subtest: Proxy tests
leviathan-client-1  | [2022-12-07T14:36:09.238Z][df30d27-os]             # Subtest: Socks5 test
leviathan-client-1  |                 # Running proxy in container
leviathan-client-1  | [2022-12-07T14:36:20.255Z][df30d27-os]                 # Updated docker-compose.yml with redsocks uid 996
leviathan-client-1  | [2022-12-07T14:36:20.255Z][df30d27-os] Waiting for supervisor to be reachable before local push...
leviathan-client-1  | [2022-12-07T14:36:26.189Z][df30d27-os] Pushing container to DUT...
leviathan-client-1  | [2022-12-07T14:36:26.605Z][df30d27-os] [debug] new argv=[/usr/app/balena-cli/balena,/snapshot/versioned-source/bin/balena,push,127.0.0.1,--source,/data/suite/tests/connectivity,--nolive,--detached] length=8
leviathan-client-1  | [2022-12-07T14:36:26.609Z][df30d27-os] [debug] Deprecation check: 0.04943 days since last npm registry query for next major version release date.
leviathan-client-1  | [debug] Will not query the registry again until at least 7 days have passed.
leviathan-client-1  | [2022-12-07T14:36:26.636Z][df30d27-os] [Debug]   Using build source directory: /data/suite/tests/connectivity
leviathan-client-1  | [2022-12-07T14:36:26.690Z][df30d27-os] [Debug]   Pushing to local device: 127.0.0.1
leviathan-client-1  | [2022-12-07T14:36:27.066Z][df30d27-os] [Debug]   Checking we can access device
leviathan-client-1  | [Debug]   Sending request to http://127.0.0.1:48484/ping
leviathan-client-1  | [2022-12-07T14:36:38.524Z][df30d27-os] [Debug]   Checking device supervisor version: 14.4.4
leviathan-client-1  | [2022-12-07T14:36:38.525Z][df30d27-os] [Info]    Starting build on device 127.0.0.1
leviathan-client-1  | [2022-12-07T14:36:38.527Z][df30d27-os] [Debug]   Loading project...
leviathan-client-1  | [2022-12-07T14:36:38.527Z][df30d27-os] [Debug]   Resolving project...
leviathan-client-1  | [2022-12-07T14:36:38.527Z][df30d27-os] [Debug]   docker-compose.yml file found at "/data/suite/tests/connectivity"
leviathan-client-1  | [2022-12-07T14:36:38.528Z][df30d27-os] [Debug]   Creating project...
leviathan-client-1  | [2022-12-07T14:36:38.571Z][df30d27-os] [Debug]   Tarring all non-ignored files...
leviathan-client-1  | [2022-12-07T14:36:38.579Z][df30d27-os] [Debug]   Tarring complete in 8 ms
leviathan-client-1  | [Debug]   Fetching device information...
leviathan-client-1  | [Debug]   Sending request to http://127.0.0.1:48484/v2/local/device-info
leviathan-client-1  | [2022-12-07T14:36:44.094Z][df30d27-os] [Debug]   Found build tasks:
leviathan-client-1  | [2022-12-07T14:36:44.095Z][df30d27-os] [Debug]       proxy: build [.]
leviathan-client-1  | [Debug]   Resolving services with [beaglebone-black|armv7hf]
leviathan-client-1  | [2022-12-07T14:36:44.101Z][df30d27-os] [Debug]   Found project types:
leviathan-client-1  | [2022-12-07T14:36:44.101Z][df30d27-os] [Debug]       proxy: Architecture-specific Dockerfile
leviathan-client-1  | [Debug]   Probing remote daemon for cache images
leviathan-client-1  | [2022-12-07T14:36:49.996Z][df30d27-os] [Debug]   Using 1 on-device images for cache...
leviathan-client-1  | [2022-12-07T14:36:49.996Z][df30d27-os] [Debug]   Starting builds...
leviathan-client-1  | [2022-12-07T14:37:20.707Z][df30d27-os] [Build]   [proxy] Step 1/3 : FROM nadoo/glider@sha256:0ff0cfd93e73dc9ccd50fca848ef8823fd6f93c1369fe8ed008ea30cd76e1ef8
leviathan-client-1  | [2022-12-07T14:37:51.412Z][df30d27-os] [Build]   [proxy]  ---> 91e0418c11c9
leviathan-client-1  | [2022-12-07T14:37:51.412Z][df30d27-os] [Build]   [proxy] Step 2/3 : LABEL io.resin.local.image=1
leviathan-client-1  | [2022-12-07T14:37:51.664Z][df30d27-os] [Build]   [proxy]  ---> Running in 4b50cf0b875c
leviathan-client-1  | [2022-12-07T14:37:52.548Z][df30d27-os] [Build]   [proxy] Removing intermediate container 4b50cf0b875c
leviathan-client-1  | [2022-12-07T14:37:52.549Z][df30d27-os] [Build]   [proxy]  ---> 20b420335788
leviathan-client-1  | [Build]   [proxy] Step 3/3 : LABEL io.resin.local.service=proxy
leviathan-client-1  | [2022-12-07T14:37:52.855Z][df30d27-os] [Build]   [proxy]  ---> Running in fcd03f8a1591
leviathan-client-1  | [2022-12-07T14:37:53.982Z][df30d27-os] [Build]   [proxy] Removing intermediate container fcd03f8a1591
leviathan-client-1  | [2022-12-07T14:37:53.982Z][df30d27-os] [Build]   [proxy]  ---> e4e6ed3ee0bc
leviathan-client-1  | [2022-12-07T14:37:54.002Z][df30d27-os] [Build]   [proxy] Successfully built e4e6ed3ee0bc
leviathan-client-1  | [2022-12-07T14:37:54.058Z][df30d27-os] [Build]   [proxy] Successfully tagged local_proxy:latest
leviathan-client-1  | [2022-12-07T14:37:54.062Z][df30d27-os] 
leviathan-client-1  | [2022-12-07T14:37:54.063Z][df30d27-os] [Debug]   Setting device state...
leviathan-client-1  | [Debug]   Sending request to http://127.0.0.1:48484/v2/local/target-state
leviathan-client-1  | [2022-12-07T14:38:00.433Z][df30d27-os] [Debug]   Sending target state: {"local":{"name":"local","config":{"SUPERVISOR_POLL_INTERVAL":"900000","SUPERVISOR_INSTANT_UPDATE_TRIGGER":"true","SUPERVISOR_LOCAL_MODE":"true","SUPERVISOR_CONNECTIVITY_CHECK":"true","SUPERVISOR_LOG_CONTROL":"true","SUPERVISOR_DELTA":"false","SUPERVISOR_DELTA_REQUEST_TIMEOUT":"59000","SUPERVISOR_DELTA_APPLY_TIMEOUT":"0","SUPERVISOR_DELTA_RETRY_COUNT":"30","SUPERVISOR_DELTA_RETRY_INTERVAL":"10000","SUPERVISOR_DELTA_VERSION":"2","SUPERVISOR_OVERRIDE_LOCK":"false","SUPERVISOR_PERSISTENT_LOGGING":"true","HOST_FIREWALL_MODE":"","HOST_DISCOVERABILITY":"true","SUPERVISOR_HARDWARE_METRICS":"true","SUPERVISOR_VPN_CONTROL":"true"},"apps":{"1":{"name":"localapp","commit":"localrelease","releaseId":"1","services":{"1":{"environment":{},"labels":{},"network_mode":"host","restart":"on-failure","command":"-verbose -listen :8123","user":"996","imageId":1,"serviceName":"proxy","serviceId":1,"image":"local_proxy","running":true}},"volumes":{},"networks":{}}}},"dependent":{"apps":[],"devices":[]}}
leviathan-client-1  | [2022-12-07T14:38:00.434Z][df30d27-os] [Debug]   Sending request to http://127.0.0.1:48484/v2/local/target-state
leviathan-client-1  | [2022-12-07T14:38:07.309Z][df30d27-os] waiting for container to be available...
leviathan-client-1  | [2022-12-07T14:38:16.513Z][df30d27-os]                 # {
leviathan-client-1  | [2022-12-07T14:38:16.513Z][df30d27-os]                 #   status: 'success',
leviathan-client-1  | [2022-12-07T14:38:16.513Z][df30d27-os]                 #   services: {
leviathan-client-1  | [2022-12-07T14:38:16.513Z][df30d27-os]                 #     proxy: 'ab3793b77812d8e3492cf918fdd0eebba0436aee26007bfa95e7dcf1f497c8cf'
leviathan-client-1  | [2022-12-07T14:38:16.513Z][df30d27-os]                 #   }
leviathan-client-1  | [2022-12-07T14:38:16.514Z][df30d27-os]                 # }
leviathan-client-1  | [2022-12-07T14:38:26.229Z][df30d27-os]                 # Creating redsocks.conf for socks5...
leviathan-client-1  | [2022-12-07T14:38:35.762Z][df30d27-os]                 # Manually restarting services...
leviathan-client-1  | [2022-12-07T14:38:58.310Z][df30d27-os]                 ok 1 - Redsocks proxy service should be active
leviathan-client-1  | [2022-12-07T14:39:30.550Z][df30d27-os]                 # Getting proxy container logs...
leviathan-client-1  |                 # Looking for socks5 connection logs...
leviathan-client-1  | [2022-12-07T14:39:30.551Z][df30d27-os]                 ok 2 - ipv4.google.com responded over socks5 proxy
leviathan-client-1  | [2022-12-07T14:39:52.235Z][df30d27-os]                 # Removing redsocks.conf...
leviathan-client-1  |                 # Manually restarting services...
leviathan-client-1  | [2022-12-07T14:39:52.235Z][df30d27-os]                 1..2
leviathan-client-1  | [2022-12-07T14:39:52.235Z][df30d27-os]             ok 1 - Socks5 test # time=235171.93ms

```
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
