### PR TITLE
initrdscripts: Only unlock LUKS partitions on the OS drive

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup
+++ b/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup
@@ -63,7 +63,9 @@ cryptsetup_run() {
         fail "Failed to unlock LUKS passphrase using the TPM"
     fi
 
-    for LUKS_UUID in $(lsblk -nlo uuid,fstype | grep crypto_LUKS | cut -d " " -f 1); do
+    BOOT_DEVICE=$(lsblk -nlo pkname "${EFI_DEV}")
+
+    for LUKS_UUID in $(lsblk -nlo uuid,fstype "/dev/${BOOT_DEVICE}" | grep crypto_LUKS | cut -d " " -f 1); do
         cryptsetup luksOpen --key-file $PASSPHRASE_FILE UUID="${LUKS_UUID}" luks-"${LUKS_UUID}"
     done
 


### PR DESCRIPTION
In the current state the cryptsetup initrd script tries to unlock all LUKS volumes in the system using the TPM. This includes user-defined LUKS volumes that, if present, fail to unlock and make the system unbootable. We should also not touch user-defined volumes in the first place.

This patch modifies the cryptsetup script to only unlock LUKS volumes that are on the OS drive (same block device as the EFI partition).

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
