### PR TITLE
tests: hup: clean up inactive partition pre hup

### DIFF
--- a/tests/suites/hup/suite.js
+++ b/tests/suites/hup/suite.js
@@ -81,10 +81,21 @@ const enableSerialConsole = async (imagePath) => {
 const doHUP = async (that, test, mode, target) => {
 	const balenaHostTmpPath = "/mnt/sysroot/inactive/balena/tmp";
 	const hupLoadTmp = "/mnt/data/resin-data/tmp";
-	const inactiveStorage = "/mnt/sysroot/inactive/docker";
+	const inactiveStorage = "/mnt/sysroot/inactive/balena";
 
 	await that.worker.executeCommandInHostOS(
+		`systemctl stop balena-host`,
+		target,
+	);
+
+	test.comment(`Cleaning up inactive partition`);
+	await that.worker.executeCommandInHostOS(
 		`find "${inactiveStorage}" -mindepth 1 -maxdepth 1 -exec rm -r "{}" \\; || true`,
+		target,
+	)
+
+	await that.worker.executeCommandInHostOS(
+		`systemctl start balena-host`,
 		target,
 	);
 


### PR DESCRIPTION
resolves an issue where on some device types we would run out of space in the inactive partition during the hup

tested on beaglebone black DUT

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
