### PR TITLE
common: signing: improve debug output on failure

### DIFF
--- a/meta-balena-common/classes/sign-efi.bbclass
+++ b/meta-balena-common/classes/sign-efi.bbclass
@@ -21,7 +21,13 @@ do_sign_efi () {
         REQUEST_FILE=$(mktemp)
         RESPONSE_FILE=$(mktemp)
         echo "{\"key_id\": \"${SIGN_EFI_KEY_ID}\", \"payload\": \"$(base64 -w 0 ${SIGNING_ARTIFACT})\"}" > "${REQUEST_FILE}"
-        CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt" curl --fail "${SIGN_API}/secureboot/efi" -X POST -H "Content-Type: application/json" -H "X-API-Key: ${SIGN_API_KEY}" -d "@${REQUEST_FILE}" > "${RESPONSE_FILE}"
+        CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt" \
+            curl --fail "${SIGN_API}/secureboot/efi" \
+                 -X POST \
+                 -H "Content-Type: application/json" \
+                 -H "X-API-Key: ${SIGN_API_KEY}" \
+                 -d "@${REQUEST_FILE}" \
+                 -o "${RESPONSE_FILE}"
         jq -r ".signed" < "${RESPONSE_FILE}" | base64 -d > "${SIGNING_ARTIFACT}.signed"
         rm -f "${REQUEST_FILE}" "${RESPONSE_FILE}"
     done

--- a/meta-balena-common/classes/sign-gpg.bbclass
+++ b/meta-balena-common/classes/sign-gpg.bbclass
@@ -16,7 +16,13 @@ do_sign_gpg () {
         REQUEST_FILE=$(mktemp)
         RESPONSE_FILE=$(mktemp)
         echo "{\"key_id\": \"${SIGN_GRUB_KEY_ID}\", \"payload\": \"$(base64 -w 0 ${SIGNING_ARTIFACT})\"}" > "${REQUEST_FILE}"
-        CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt" curl --fail --silent "${SIGN_API}/gpg/sign" -X POST -H "Content-Type: application/json" -H "X-API-Key: ${SIGN_API_KEY}" -d "@${REQUEST_FILE}" > "${RESPONSE_FILE}"
+        CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt" \
+            curl --fail "${SIGN_API}/gpg/sign" \
+                 -X POST \
+                 -H "Content-Type: application/json" \
+                 -H "X-API-Key: ${SIGN_API_KEY}" \
+                 -d "@${REQUEST_FILE}" \
+                 -o "${RESPONSE_FILE}"
         jq -r ".signature" < "${RESPONSE_FILE}" | base64 -d > "${SIGNING_ARTIFACT}.sig"
         rm -f "${REQUEST_FILE}" "${RESPONSE_FILE}"
     done

--- a/meta-balena-common/recipes-support/balena-keys/balena-keys.bb
+++ b/meta-balena-common/recipes-support/balena-keys/balena-keys.bb
@@ -25,7 +25,7 @@ fetch_key() {
     mkdir -p "${DEST_DIR}"
     RESPONSE_FILE=$(mktemp)
     export CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt"
-    curl --fail --silent "${SIGN_API}/${1}" > "${RESPONSE_FILE}"
+    curl --fail "${SIGN_API}/${1}" -o "${RESPONSE_FILE}"
     if [ "${2}" = ".key" ]; then
         jq -r "${2}" < "${RESPONSE_FILE}" | gpg --dearmor > "${DEST_DIR}/${3}"
     else


### PR DESCRIPTION
If the signing server's response is anything other than successful, such as with an authentication failure or bad request, the HTTP status code and response are hidden due to the --silent flag passed to cURL.

Drop the stdio redirect to the output file along with the --silent flag, and instead use the -o parameter to output the response to the appropriate file on success. This allows the status code and response to be shown in the logs upon failure.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
