### PR TITLE
patch: Add default debug object to test config

### DIFF
--- a/tests/suites/config.js
+++ b/tests/suites/config.js
@@ -11,6 +11,16 @@ module.exports = [
 		organization: process.env.BALENACLOUD_ORG
 	},
 	image: `${__dirname}/balena-image.docker`,
+	debug: {
+		// Exit the ongoing test suite if a test fails
+		failFast: true,
+		// Exit the ongoing test run if a test fails
+		globalFailFast: false,
+		// Persist downloadeded artifacts
+		preserveDownloads: false,
+		// Mark unstable tests to be skipped
+		unstable: ['']
+	},
 	workers: process.env.WORKER_TYPE === 'qemu' ? ['http://worker'] : {
 		balenaApplication: process.env.BALENACLOUD_APP_NAME,
 		apiKey: process.env.BALENACLOUD_API_KEY,
@@ -27,6 +37,16 @@ module.exports = [
 		organization: process.env.BALENACLOUD_ORG
 	},
 	image: `${__dirname}/balena.img.gz`,
+	debug: {
+		// Exit the ongoing test suite if a test fails
+		failFast: true,
+		// Exit the ongoing test run if a test fails
+		globalFailFast: false,
+		// Persist downloadeded artifacts
+		preserveDownloads: false,
+		// Mark unstable tests to be skipped
+		unstable: ['']
+	},
 	workers: process.env.WORKER_TYPE === 'qemu' ? ['http://worker'] : {
 		balenaApplication: process.env.BALENACLOUD_APP_NAME,
 		apiKey: process.env.BALENACLOUD_API_KEY,
@@ -43,6 +63,16 @@ module.exports = [
 		organization: process.env.BALENACLOUD_ORG
 	},
 	image: `${__dirname}/balena.img.gz`,
+	debug: {
+		// Exit the ongoing test suite if a test fails
+		failFast: true,
+		// Exit the ongoing test run if a test fails
+		globalFailFast: false,
+		// Persist downloadeded artifacts
+		preserveDownloads: false,
+		// Mark unstable tests to be skipped
+		unstable: ['']
+	},
 	workers: process.env.WORKER_TYPE === 'qemu' ? ['http://worker'] : {
 		balenaApplication: process.env.BALENACLOUD_APP_NAME,
 		apiKey: process.env.BALENACLOUD_API_KEY,


### PR DESCRIPTION
Following the conversation from https://balena.zulipchat.com/#narrow/stream/345889-loop.2Fbalena-os/topic/skipping.20tests.20on.20leviathan, I am adding a default debug object as a way to debug tests on production more easily. I will follow this up with parameters in Jenkins that can be modified as needed to derive more information out of a run. 

Additionally, this will also unblock PRs that are failing because there is no unstable object present in the config. 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
