### PR TITLE
resolvconf: Add upstream 1.91 recipe for kirkstone

### DIFF
--- a/meta-balena-kirkstone/conf/distro/include/balena-os-yocto-version.inc
+++ b/meta-balena-kirkstone/conf/distro/include/balena-os-yocto-version.inc
@@ -1,0 +1,1 @@
+PREFERRED_VERSION_resolvconf = "1.91"

--- a/meta-balena-kirkstone/recipes-connectivity/resolvconf/resolvconf/0001-avoid-using-m-option-for-readlink.patch
+++ b/meta-balena-kirkstone/recipes-connectivity/resolvconf/resolvconf/0001-avoid-using-m-option-for-readlink.patch
@@ -1,0 +1,37 @@
+From 6bf2bb136a0b3961339369bc08e58b661fba0edb Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Thu, 17 Nov 2022 17:26:30 +0800
+Subject: [PATCH] avoid using -m option for readlink
+
+Use a more widely used option '-f' instead of '-m' here to
+avoid dependency on coreutils.
+
+Looking at the git history of the resolvconf repo, the '-m'
+is deliberately used. And it wants to depend on coreutils.
+But in case of OE, the existence of /etc is ensured, and busybox
+readlink provides '-f' option, so we can just use '-f'. In this
+way, the coreutils dependency is not necessary any more.
+
+Upstream-Status: Inappropriate [OE Specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ etc/resolvconf/update.d/libc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/etc/resolvconf/update.d/libc b/etc/resolvconf/update.d/libc
+index 1c4f6bc..f75d22c 100755
+--- a/etc/resolvconf/update.d/libc
++++ b/etc/resolvconf/update.d/libc
+@@ -57,7 +57,7 @@ fi
+ report_warning() { echo "$0: Warning: $*" >&2 ; }
+ 
+ resolv_conf_is_symlinked_to_dynamic_file() {
+-	[ -L ${ETC}/resolv.conf ] && [ "$(readlink -m ${ETC}/resolv.conf)" = "$DYNAMICRSLVCNFFILE" ]
++	[ -L ${ETC}/resolv.conf ] && [ "$(readlink -f ${ETC}/resolv.conf)" = "$DYNAMICRSLVCNFFILE" ]
+ }
+ 
+ if ! resolv_conf_is_symlinked_to_dynamic_file ; then
+-- 
+2.17.1
+

--- a/meta-balena-kirkstone/recipes-connectivity/resolvconf/resolvconf/99_resolvconf
+++ b/meta-balena-kirkstone/recipes-connectivity/resolvconf/resolvconf/99_resolvconf
@@ -1,0 +1,4 @@
+d root root 0755 /var/run/resolvconf/interface none
+f root root 0644 /etc/resolvconf/run/resolv.conf none
+f root root 0644 /etc/resolvconf/run/enable-updates none
+l root root 0644 /etc/resolv.conf /etc/resolvconf/run/resolv.conf

--- a/meta-balena-kirkstone/recipes-connectivity/resolvconf/resolvconf_1.91.bb
+++ b/meta-balena-kirkstone/recipes-connectivity/resolvconf/resolvconf_1.91.bb
@@ -1,0 +1,68 @@
+SUMMARY = "name server information handler"
+DESCRIPTION = "Resolvconf is a framework for keeping track of the system's \
+information about currently available nameservers. It sets \
+itself up as the intermediary between programs that supply \
+nameserver information and programs that need nameserver \
+information."
+SECTION = "console/network"
+LICENSE = "GPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=c93c0550bd3173f4504b2cbd8991e50b"
+AUTHOR = "Thomas Hood"
+HOMEPAGE = "http://packages.debian.org/resolvconf"
+RDEPENDS:${PN} = "bash sed util-linux-flock"
+
+SRC_URI = "git://salsa.debian.org/debian/resolvconf.git;protocol=https;branch=unstable \
+           file://99_resolvconf \
+           file://0001-avoid-using-m-option-for-readlink.patch \
+           "
+
+SRCREV = "859209d573e7aec0e95d812c6b52444591a628d1"
+
+S = "${WORKDIR}/git"
+
+# the package is taken from snapshots.debian.org; that source is static and goes stale
+# so we check the latest upstream from a directory that does get updated
+UPSTREAM_CHECK_URI = "${DEBIAN_MIRROR}/main/r/resolvconf/"
+
+do_compile () {
+	:
+}
+
+do_install () {
+	install -d ${D}${sysconfdir}/default/volatiles
+	install -m 0644 ${WORKDIR}/99_resolvconf ${D}${sysconfdir}/default/volatiles
+	if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+		install -d ${D}${sysconfdir}/tmpfiles.d
+		echo "d /run/${BPN}/interface - - - -" \
+		     > ${D}${sysconfdir}/tmpfiles.d/resolvconf.conf
+	fi
+	install -d ${D}${base_libdir}/${BPN}
+	install -d ${D}${sysconfdir}/${BPN}
+	install -d ${D}${nonarch_base_libdir}/${BPN}
+	ln -snf ${localstatedir}/run/${BPN} ${D}${sysconfdir}/${BPN}/run
+	install -d ${D}${sysconfdir} ${D}${base_sbindir}
+	install -d ${D}${mandir}/man8 ${D}${docdir}/${P}
+	cp -pPR etc/resolvconf ${D}${sysconfdir}/
+	chown -R root:root ${D}${sysconfdir}/
+	install -m 0755 bin/resolvconf ${D}${base_sbindir}/
+	install -m 0755 bin/normalize-resolvconf ${D}${nonarch_base_libdir}/${BPN}
+	install -m 0755 bin/list-records ${D}${base_libdir}/${BPN}
+	install -d ${D}/${sysconfdir}/network/if-up.d
+	install -m 0755 debian/resolvconf.000resolvconf.if-up ${D}/${sysconfdir}/network/if-up.d/000resolvconf
+	install -d ${D}/${sysconfdir}/network/if-down.d
+	install -m 0755 debian/resolvconf.resolvconf.if-down ${D}/${sysconfdir}/network/if-down.d/resolvconf
+	install -m 0644 README ${D}${docdir}/${P}/
+	install -m 0644 man/resolvconf.8 ${D}${mandir}/man8/
+}
+
+pkg_postinst:${PN} () {
+	if [ -z "$D" ]; then
+		if command -v systemd-tmpfiles >/dev/null; then
+			systemd-tmpfiles --create ${sysconfdir}/tmpfiles.d/resolvconf.conf
+		elif [ -e ${sysconfdir}/init.d/populate-volatile.sh ]; then
+			${sysconfdir}/init.d/populate-volatile.sh update
+		fi
+	fi
+}
+
+FILES:${PN} += "${base_libdir}/${BPN} ${nonarch_base_libdir}/${BPN}"


### PR DESCRIPTION
Current resolvconf version is broken for kirkstone, which is fixed upstream, so we reuse the fixed version from upstream.

The symptom is that DNS servers provided by DHCP are not being used.

Closes #2907

Change-type: patch
Changelog-entry: Add upstream resolvconf 1.91 recipe for kirkstone
Signed-off-by: Zahari Petkov <zahari@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
