### PR TITLE
tests: os: add ep fan block test

### DIFF
--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -373,6 +373,7 @@ module.exports = {
 		'./tests/device-tree',
 		'./tests/purge-data',
 		'./tests/device-specific-tests/revpi-core-3',
+		'./tests/device-specific-tests/etcher-pro',
 		'./tests/swap',
 	],
 };

--- a/tests/suites/os/tests/device-specific-tests/etcher-pro/docker-compose.yml
+++ b/tests/suites/os/tests/device-specific-tests/etcher-pro/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2'
+services:
+  fan-control:
+      image: bh.cr/balena/fan_control_arm
+      privileged: true
+      restart: always
+      labels:
+         io.balena.features.sysfs: 1
+      environment:
+         - 'THERMAL_ZONE=1'
+         - 'REFRESH_DELAY=10'
+         - 'PWM="1,0"'
+         - 'PWM_TEMPS="0,40,50,70"'
+         - 'PWM_DUTY="0,100,1000,40000"'

--- a/tests/suites/os/tests/device-specific-tests/etcher-pro/index.js
+++ b/tests/suites/os/tests/device-specific-tests/etcher-pro/index.js
@@ -1,0 +1,33 @@
+const { delay } = require('bluebird');
+
+module.exports = {
+	deviceType: {
+		type: 'object',
+		required: ['slug'],
+		properties: {
+			slug: {
+				type: 'string',
+				const: 'etcher-pro',
+			},
+		},
+	},
+	title: 'Etcher pro fan block test',
+	run: async function(test) {
+        // push fan control block to DUT
+        const ip = await this.worker.ip(this.link);
+
+		await this.context
+			.get()
+			.worker.pushContainerToDUT(ip, __dirname, 'fan-control');
+
+        // wait for 5 seconds to ensure no crashlooping
+        await delay(5000);
+    
+        // execute command a container
+        const res = await this.context
+			.get()
+			.worker.executeCommandInContainer('echo Hello', 'fan-control', this.link);
+
+        test.ok(res, 'Hello', 'Should be able to run command inside fan-block');
+    }
+};


### PR DESCRIPTION
add device specific test for etcher pro, to test the fan block works, and by extension that the OS interfaces with it correctly

1. push fan block to the etcher pro DUT
2. wait 5 seconds
3. execute a command in the container and check the output is what is expected

If there is a problem with the fan block interfacing with the OS, then the container will crash loop - if we can execute the command in the container, then we know the container is no crashlooping

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
