### PR TITLE
tests: os: fix modem test teardown

### DIFF
--- a/tests/suites/os/tests/modem/index.js
+++ b/tests/suites/os/tests/modem/index.js
@@ -227,6 +227,11 @@ module.exports = {
                             `mmcli -m ${targetAddress} --simple-disconnect && mmcli -m ${targetAddress} --disable`,
                             this.link,
                         );
+                            
+                        await this.worker.executeCommandInHostOS(
+                            `route del -net default netmask 0.0.0.0 dev ${iface}`,
+                            this.link,
+                        );
                     });
                 }),
             );


### PR DESCRIPTION
There were issues in this PR: https://github.com/balena-os/balena-raspberrypi/pull/900 with the modem test

- after the modem test, the DUT had no internet connection
- this led to chrony not being able to sync with ntp servers
- eventually this led to the `config.hson` `ntpServers` test failing
- The reason why, it seemed, was that during the modem test, we set up a route, with a metric of 200, to make the modem interface the "default" interface. At the end of the modem test, we disconnect the modem, but to not delete this route - the OS seemed to try to use this route still
- As a "fix" I now remove this route in the teardown

However, I'd like to know if this is just covering up a legitimate problem. Why does this only fail now with the kirkstone PR?

Context: https://balena.zulipchat.com/#narrow/stream/345889-loop.2Fbalena-os/topic/.5Bos-testing.5D.20balena-raspberrypi.20failures

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
