### PR TITLE
flasher: add conflict with serial-getty@ttyS0

### DIFF
--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher.service
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher.service
@@ -3,6 +3,8 @@ Description=Resin init flasher service
 Requires=mnt-boot.mount
 Wants=resin-device-register.service
 After=mnt-boot.mount resin-device-register.service
+Before=serial-getty@ttyS0.service
+Conflicts=serial-getty@ttyS0.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
resin-init-flasher was modified to output to ttyS0 in commit 131893e

In development mode, a getty is started on this terminal, which kills the flasher, and inhibits debugging. Add a conflict between serial-getty@ttyS0 and resin-init-flasher to prevent this getty from being started in flasher images.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
