### PR TITLE
flasher: disable development-features

### DIFF
--- a/meta-balena-common/recipes-core/systemd/systemd-serialgetty/development-features.conf
+++ b/meta-balena-common/recipes-core/systemd/systemd-serialgetty/development-features.conf
@@ -2,3 +2,6 @@
 ConditionPathExists=/var/volatile/development-features
 After=development-features.service
 Requires=development-features.service
+
+[Service]
+ExecCondition=/bin/bash -c '/usr/bin/systemctl is-active --quiet resin-init-flasher && exit 1 || exit 0'

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher.service
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher.service
@@ -2,6 +2,7 @@
 Description=Resin init flasher service
 Requires=mnt-boot.mount
 Wants=resin-device-register.service
+Before=development-features.service
 After=mnt-boot.mount resin-device-register.service
 
 [Service]


### PR DESCRIPTION
resin-init-flasher was modified to output to ttyS0 in commit 131893e for improved visibility and debugging

In development mode, a getty is started on this terminal, which kills the flasher and inhibits debugging. Add an ExecCondition to the serial-getty unit that exits early when the flasher is running.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
