### PR TITLE
tests: os: disable unwrapping

### DIFF
--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -261,39 +261,6 @@ module.exports = {
 		// Unpack OS image .gz
 		await this.os.fetch();
 
-		// If this is a flasher image, and we are using qemu, unwrap
-		if (
-			this.suite.deviceType.data.storage.internal &&
-			this.workerContract.workerType === `qemu`
-		) {
-			const RAW_IMAGE_PATH = `/opt/balena-image-${this.suite.deviceType.slug}.balenaos-img`;
-			const OUTPUT_IMG_PATH = '/data/downloads/unwrapped.img';
-			console.log(`Unwrapping file ${this.os.image.path}`);
-			console.log(`Looking for ${RAW_IMAGE_PATH}`);
-			try {
-				await imagefs.interact(
-					this.os.image.path,
-					2,
-					async (fsImg) => {
-						await pipeline(
-							fsImg.createReadStream(RAW_IMAGE_PATH),
-							fse.createWriteStream(OUTPUT_IMG_PATH),
-						);
-					},
-				);
-
-				this.os.image.path = OUTPUT_IMG_PATH;
-				console.log(`Unwrapped flasher image!`);
-			} catch (e) {
-				// If the outer image doesn't contain an image for installation, ignore the error
-				if (e.code === 'ENOENT') {
-					console.log('Not a flasher image, skipping unwrap');
-				} else {
-					throw e;
-				}
-			}
-		}
-
 		if (supportsBootConfig(this.suite.deviceType.slug)) {
 			await enableSerialConsole(this.os.image.path);
 		}


### PR DESCRIPTION
The QEMU leviathan-worker now simulates flashing from an external device, which tests both flasher images, as well as secure-boot/full-disk encryption setup.

Disable the ad-hoc unwrapping in the OS suite setup.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
