### PR TITLE
recipes-bsp/u-boot: Import extra uboot environment from scanned devices, add sample proxy files

### DIFF
--- a/meta-balena-common/recipes-bsp/u-boot/patches/env_resin.h
+++ b/meta-balena-common/recipes-bsp/u-boot/patches/env_resin.h
@@ -68,6 +68,13 @@
                "echo Import ${balena_extra_env_file} in environment;" \
                "env import -t ${resin_kernel_load_addr} ${filesize}\0" \
        \
+       "balena_import_scan_dev_extra_env_file=" \
+               "if fatload ${resin_scan_dev_type} ${resin_scan_dev_index}:${resin_boot_part} ${resin_kernel_load_addr} ${balena_extra_env_file}; then " \
+                   "run balena_import_extra_env_file; " \
+                   "echo Imported ${balena_extra_env_file} from scanned device ${resin_scan_dev_type}:${resin_scan_dev_index} in environment;" \
+               "else " \
+                   "echo File ${balena_extra_env_file} not found on scanned device ${resin_scan_dev_type}:${resin_scan_dev_index}; " \
+               "fi; \0" \
        "os_import_bootcount_file=" \
                "echo Import ${os_bc_file} in environment;" \
                "env import -t ${resin_kernel_load_addr} ${filesize}\0" \
@@ -98,6 +105,7 @@
                "echo Scanning ${resin_uboot_device_types} devices ${resin_uboot_devices}; " \
                "for resin_scan_dev_type in ${resin_uboot_device_types}; do " \
                        "for resin_scan_dev_index in ${resin_uboot_devices}; do " \
+                               "run balena_import_scan_dev_extra_env_file; " \
                                "if test ${resin_flasher_skip} = 0 && run resin_flasher_detect; then " \
                                        "setenv resin_flasher_dev_index ${resin_scan_dev_index}; " \
                                        "setenv resin_dev_type ${resin_scan_dev_type}; " \

--- a/meta-balena-common/recipes-connectivity/redsocks/balena-files/README.ignore
+++ b/meta-balena-common/recipes-connectivity/redsocks/balena-files/README.ignore
@@ -1,0 +1,6 @@
+
+# Sample redsocks proxy configuration files
+
+The redsocks.conf.ignore file contains a sample socks5 proxy configuration.
+If you wish to enable this configuration then replace <SERVER_IP> with
+your actual proxy server IP and remove the file's .ignore suffix.

--- a/meta-balena-common/recipes-connectivity/redsocks/balena-files/redsocks.conf.ignore
+++ b/meta-balena-common/recipes-connectivity/redsocks/balena-files/redsocks.conf.ignore
@@ -1,0 +1,15 @@
+base {
+  log_debug = off;
+  log_info = on;
+  log = stderr;
+  daemon = off;
+  redirector = iptables;
+}
+
+redsocks {
+  type = socks5;
+  ip = <SERVER_IP>;
+  port = 8123;
+  local_ip = 127.0.0.1;
+  local_port = 12345;
+}

--- a/meta-balena-common/recipes-connectivity/redsocks/redsocks_0.5.bb
+++ b/meta-balena-common/recipes-connectivity/redsocks/redsocks_0.5.bb
@@ -1,7 +1,11 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/balena-files:"
+
 DESCRIPTION = "redsocks - transparent socks redirector"
 SECTION = "net/misc"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM="file://README;beginline=74;endline=78;md5=edd3a93090d9025f47a1fdec44ace593"
+
+inherit deploy
 
 SRCREV = "27b17889a43e32b0c1162514d00967e6967d41bb"
 
@@ -11,6 +15,8 @@ SRC_URI = " \
 	file://0002-Add-dnsu2t-module-to-convert-DNS-UDP-to-DNS-TCP.patch \
 	file://0003-Add-OS-dependent-default-configuration-values.patch \
 	file://0004-dnsu2t.c-Fix-dns-relay-when-there-is-no-TFO-cookie-c.patch \
+	file://README.ignore \
+	file://redsocks.conf.ignore \
 "
 
 DEPENDS = "libevent"
@@ -21,3 +27,11 @@ do_install () {
     install -d ${D}${bindir}
     install -m 0775 ${S}/redsocks ${D}${bindir}/redsocks
 }
+
+do_deploy() {
+    mkdir -p "${DEPLOYDIR}/system-proxy/"
+    install -m 0600 "${WORKDIR}/redsocks.conf.ignore" "${DEPLOYDIR}/system-proxy/"
+    install -m 0600 "${WORKDIR}/README.ignore" "${DEPLOYDIR}/system-proxy/"
+}
+
+addtask deploy before do_package after do_install

--- a/meta-balena-common/recipes-core/images/balena-image-flasher.bb
+++ b/meta-balena-common/recipes-core/images/balena-image-flasher.bb
@@ -69,5 +69,11 @@ BALENA_BOOT_PARTITION_FILES:append = " \
     system-connections/README.ignore:/system-connections/README.ignore \
     "
 
+# example redsocks config file
+BALENA_BOOT_PARTITION_FILES:append = " \
+    system-proxy/redsocks.conf.ignore:/system-proxy/redsocks.conf.ignore \
+    system-proxy/README.ignore:/system-proxy/README.ignore \
+"
+
 # Resin flasher flag file
 BALENA_BOOT_PARTITION_FILES:append = " ${BALENA_FLASHER_FLAG_FILE}:/${BALENA_FLASHER_FLAG_FILE}"

--- a/meta-balena-common/recipes-core/images/balena-image.bb
+++ b/meta-balena-common/recipes-core/images/balena-image.bb
@@ -82,6 +82,12 @@ BALENA_BOOT_PARTITION_FILES:append = " \
     system-connections/README.ignore:/system-connections/README.ignore \
 "
 
+# example redsocks config file
+BALENA_BOOT_PARTITION_FILES:append = " \
+    system-proxy/redsocks.conf.ignore:/system-proxy/redsocks.conf.ignore \
+    system-proxy/README.ignore:/system-proxy/README.ignore \
+"
+
 BALENA_BOOT_PARTITION_FILES:append = "${@ ' extra_uEnv.txt:/extra_uEnv.txt ' if d.getVar('UBOOT_MACHINE') else ''}"
 
 # Resin image flag file


### PR DESCRIPTION
recipes-bsp/u-boot: Import extra uboot environment from scanned devices
    
    This allows for the testbot to set resin_flasher_skip=0
    in the extra_uEnv.txt file of the flasher image and
    bypass the boot switch detection mechanisms used for
    specific private device types.
    
    The boot pins would otherwise prevent the flasher
    from running if they were set to the eMMC position.
    
    The flasher extra_uEnv.txt file overrides any resin_flasher_skip
    value previously configured by the device integration layer.


Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Added this change as per the internal discussion: https://balena.zulipchat.com/#narrow/stream/360838-balena-os.2Fdevices/topic/XXX/312607356

This PR also adds sample proxy files in the boot partition, similar to the ones for NetworkManager, as per the internal thread https://balena.zulipchat.com/#narrow/stream/345749-loop.2FbalenaLabs/topic/Jetson.20Flash/near/321375620


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested - on private DT with boot switch detection that ignores flasher image if boot switch is in eMMC position by setting resin_flasher_skip=1
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
