### PR TITLE
balena-supervisor: Set the supervisor package version

### DIFF
--- a/meta-balena-common/recipes-containers/balena-supervisor/balena-supervisor.bb
+++ b/meta-balena-common/recipes-containers/balena-supervisor/balena-supervisor.bb
@@ -7,6 +7,8 @@ require recipes-containers/balena-supervisor/balena-supervisor.inc
 
 LED_FILE ?= "/dev/null"
 
+PV = "${@d.getVar('SUPERVISOR_VERSION').replace('v', '')}"
+
 SRC_URI += " \
 	file://resin-data.mount \
 	file://start-balena-supervisor \


### PR DESCRIPTION
This will reflect the included supervisor version in the hostapp manifest.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>

old manifest:
```
balena-supervisor armv7vet2hf-neon 1.0-r0
```

new manifest:
```
balena-supervisor armv7vet2hf-neon 14.4.9-r0
```

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
