### PR TITLE
Revert "flasher: output logs to serial console"

### DIFF
--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher.service
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher.service
@@ -8,9 +8,6 @@ After=mnt-boot.mount resin-device-register.service
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=@BASE_BINDIR@/bash @BINDIR@/resin-init-flasher
-StandardOutput=tty
-StandardError=tty
-TTYPath=/dev/ttyS0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
In development mode, the flasher service is killed by getty. Revert this change to unbreak the flasher when OS development is enabled.

Change-type: patch
This reverts commit 131893e433ef64a1f3b05dfcd44b0e022f13646d.


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
