### PR TITLE
Devmode extra args

### DIFF
--- a/meta-balena-common/conf/distro/include/balena-os.inc
+++ b/meta-balena-common/conf/distro/include/balena-os.inc
@@ -27,20 +27,15 @@ python () {
 }
 
 def set_default_kernel_cmdline(d):
-    cmdline = 'console=null quiet splash vt.global_cursor_default=0 consoleblank=0'
-    if d.getVar('OS_DEVELOPMENT', True) is '1':
-        cmdline = ""
-        for serial_console in d.getVar('SERIAL_CONSOLES', True).split():
-            try:
-                baudrate,port = serial_console.split(';')
-                console = "console=" + port + "," + baudrate + "n8"
-                if len(cmdline) is 0:
-                    cmdline = console
-                else:
-                    cmdline = cmdline + " " + console
-            except:
-                return
-    return cmdline
+    prod_cmdline = 'console=null quiet splash vt.global_cursor_default=0 consoleblank=0'
+    serial_consoles = d.getVar('SERIAL_CONSOLES', True).split()
+    devmode_cmdline = ' '.join([
+        'console={},{}s8'.format(port, baudrate)
+        for (baudrate,port) in (console.split(';') for console in serial_consoles)
+    ])
+    return (devmode_cmdline
+        if d.getVar('OS_DEVELOPMENT', True) == '1'
+        else prod_cmdline)
 
 MAINTAINER = "Balena <hello@balena.io>"
 

--- a/meta-balena-common/conf/distro/include/balena-os.inc
+++ b/meta-balena-common/conf/distro/include/balena-os.inc
@@ -29,10 +29,11 @@ python () {
 def set_default_kernel_cmdline(d):
     prod_cmdline = 'console=null quiet splash vt.global_cursor_default=0 consoleblank=0'
     serial_consoles = d.getVar('SERIAL_CONSOLES', True).split()
+    devmode_extra_args = ['verbose=true', 'debug=true']
     devmode_cmdline = ' '.join([
         'console={},{}s8'.format(port, baudrate)
         for (baudrate,port) in (console.split(';') for console in serial_consoles)
-    ])
+    ] + devmode_extra_args)
     return (devmode_cmdline
         if d.getVar('OS_DEVELOPMENT', True) == '1'
         else prod_cmdline)


### PR DESCRIPTION
Add the verbose and debug flags to the kernel cmdline when OS
development is enabled. This makes the init script in the initramfs
print more information about the boot process, and aids in debugging.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
