### PR TITLE
redsocks: Increase maximum number of open files

### DIFF
--- a/meta-balena-common/recipes-connectivity/balena-proxy-config/balena-proxy-config/redsocks.service
+++ b/meta-balena-common/recipes-connectivity/balena-proxy-config/balena-proxy-config/redsocks.service
@@ -9,6 +9,7 @@ User=redsocks
 ExecStart=@BINDIR@/redsocks -c /mnt/boot/system-proxy/redsocks.conf
 Restart=on-failure
 RestartSec=10s
+LimitNOFILE=16384
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This increases the number of open connections that redsocks can support to a new maximum of 2048.

See https://github.com/darkk/redsocks/blob/19b822e345f6a291f6cff6b168f1cfdfeeb2cd7d/base.c#L419

It is motivated by a customer request to increase the number of maximum connections of the redsocks proxy:
https://jel.ly.fish/support-thread-1-0-0-front-cnv-dhcbthp

Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
