### PR TITLE
efitools: Package lock down EFI image into its own package

### DIFF
--- a/meta-balena-common/recipes-bsp/efitools/efitools_git.bb
+++ b/meta-balena-common/recipes-bsp/efitools/efitools_git.bb
@@ -43,3 +43,6 @@ addtask deploy after do_install before do_build
 
 PACKAGES =+ "${PN}-utils"
 FILES:${PN}-utils = "/usr/bin/efi-updatevar /usr/bin/efi-readvar"
+
+PACKAGES =+ "${PN}-lockdown"
+FILES:${PN}-lockdown = "/boot/efi/EFI/BOOT/LockDown.efi"


### PR DESCRIPTION
This EFI image contains the secure boot certificates and when executed it is supposed to load the keys into the respective secure boot slots.

We don't use this binary in our secure boot implementation, but currently the build breaks as the binary is installed but not packaged.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
