### PR TITLE
Enable back connectivity check in NetworkManager

### DIFF
--- a/meta-balena-common/recipes-connectivity/networkmanager/networkmanager_1.40.4.bbappend
+++ b/meta-balena-common/recipes-connectivity/networkmanager/networkmanager_1.40.4.bbappend
@@ -31,7 +31,7 @@ EXTRA_OEMESON += " \
     -Dresolvconf=/sbin/resolvconf \
     -Dovs=false \
     "
-PACKAGECONFIG:append = " modemmanager ppp resolvconf"
+PACKAGECONFIG:append = " modemmanager ppp resolvconf concheck"
 
 # The external DHCP client doesn't work well with our `ipv4.dhcp-timeout`
 # configuration. Switch to the internal one.


### PR DESCRIPTION
In v2.108.0 we did a major NetworkManager upgrade as we started using
meson as a build system. The connectivity check feature was left
disabled, which is a regression and it produces fake results.

This commit enables it back.

Fixes #2964.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
