### PR TITLE
tests: fix connectivity test on rpi0 devices

### DIFF
--- a/tests/suites/os/tests/connectivity/Dockerfile.rpi
+++ b/tests/suites/os/tests/connectivity/Dockerfile.rpi
@@ -1,0 +1,1 @@
+FROM nadoo/glider@sha256:eaf262f11d9ac8cf8d2b2f74788a73232f73336b26288ac17f6851b786effab7

--- a/tests/suites/os/tests/connectivity/Dockerfile.template
+++ b/tests/suites/os/tests/connectivity/Dockerfile.template
@@ -1,5 +1,0 @@
-FROM balenalib/%%BALENA_ARCH%%-golang as build
-
-RUN go get -u github.com/nadoo/glider@v0.14.0
-
-ENTRYPOINT ["/go/bin/glider"]


### PR DESCRIPTION
The connectivity test fails on the raspberrypi 0 with the following error:

```
# Subtest: Proxy tests
            # Subtest: Socks5 test
                # Running proxy in container
                # Updated docker-compose.yml with redsocks uid 995
Waiting for supervisor to be reachable before local push...
Pushing container to DUT...
[debug] new argv=[/usr/app/balena-cli/balena,/snapshot/versioned-source/bin/balena,push,127.0.0.1,--source,/data/suite/tests/connectivity,--nolive,--detached] length=8
[Debug]   Using build source directory: /data/suite/tests/connectivity
[Debug]   Pushing to local device: 127.0.0.1
[Debug]   Checking we can access device
[Debug]   Sending request to http://127.0.0.1:48484/ping
[Debug]   Checking device supervisor version: 14.4.8
[Info]    Starting build on device 127.0.0.1
[Debug]   Loading project...
[Debug]   Resolving project...
[Debug]   docker-compose.yml file found at "/data/suite/tests/connectivity"
[Debug]   Creating project...
[Debug]   Tarring all non-ignored files...
[Debug]   Tarring complete in 5 ms
[Debug]   Fetching device information...
[Debug]   Sending request to http://127.0.0.1:48484/v2/local/device-info
[Debug]   Found build tasks:
[Debug]       proxy: build [.]
[Debug]   Resolving services with [raspberry-pi|rpi]
[Debug]   Found project types:
[Debug]       proxy: Dockerfile.template
[Debug]   Probing remote daemon for cache images
[Debug]   Using 11 on-device images for cache...
[Debug]   Starting builds...
[Build]   [proxy] Step 1/5 : FROM balenalib/rpi-golang as build
[Build]   [proxy]  ---> 57f0cbf91b90
[Build]   [proxy] Step 2/5 : RUN go get -u github.com/nadoo/glider@v0.14.0
[Build]   [proxy]  ---> Running in 4c9aa873bb07
[Build]   [proxy] [91mgo: go.mod file not found in current directory or any parent directory.
[Build]   	'go get' is no longer supported outside a module.
[Build]   	To build and install a command, use 'go install' with a version,
[Build]   	like 'go install example.com/cmd@latest'
[Build]   	For more information, see https://golang.org/doc/go-get-install-deprecation
[Build]   	or run 'go help get' or 'go help install'.
[Build]   [0m
[Build]   [proxy] Removing intermediate container 4c9aa873bb07
Some services failed to build:
	proxy: The command '/bin/sh -c go get -u github.com/nadoo/glider@v0.14.0' returned a non-zero code: 1
```

The difference between the pi 0 and other device types, was that pi0 was using a golang base image for the pi0 device type, and trying to install glider in it, while on other device types, we were using a glider docker image directly. I moved the rpi0 to use the same method, and it passes now (locally)



---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
