### PR TITLE
rollback-health: bind-mount EFI partition when split from boot

### DIFF
--- a/meta-balena-common/recipes-core/balena-rollback/files/rollback-health
+++ b/meta-balena-common/recipes-core/balena-rollback/files/rollback-health
@@ -42,6 +42,14 @@ run_hooks_from_inactive () {
 	mount --bind /mnt/sysroot/inactive/ "${old_rootfs}/mnt/sysroot/inactive/"
 	mount -t sysfs sysfs "${old_rootfs}/sys/"
 
+	# In case of secure boot the boot and EFI partitions are split apart
+	# The EFI partition must be bind-mounted as well to be able to deploy
+	# files under /mnt/boot/EFI
+	if [ -L /mnt/boot/EFI ]; then
+		mkdir -p "${old_rootfs}/mnt/efi"
+		mount --bind /mnt/efi "${old_rootfs}/mnt/efi"
+	fi
+
 	# DURING_UPDATE tells hooks to use the boot files from inactive
 	# which are the good set of files in ROLLBACK_ALTBOOT mode
 	# also tells the bootloaders to switch roots


### PR DESCRIPTION
With secure boot enabled boot and EFI partition are split apart. During rollback-health, when bind-mounting inactive root to run old hooks from, the EFI partition must be bind-mounted as well otherwise the /mnt/boot/EFI symlink is invalid and rollback fails to deploy files into that directory.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
