### PR TITLE
tests: hup: add slight delay after fetchos

### DIFF
--- a/tests/suites/hup/suite.js
+++ b/tests/suites/hup/suite.js
@@ -15,6 +15,7 @@ const zlib = require('zlib');
 
 // required for unwrapping images
 const imagefs = require('balena-image-fs');
+const Bluebird = require('bluebird')
 const stream = require('stream');
 const pipeline = util.promisify(stream.pipeline);
 
@@ -273,6 +274,8 @@ module.exports = {
 			this.suite.options.balenaOS.download.version,
 			this.suite.deviceType.slug,
 		);
+
+		await Bluebird.delay(1000*10)
 
 		const keys = await this.utils.createSSHKey(this.sshKeyPath);
 		this.log("Logging into balena with balenaSDK");


### PR DESCRIPTION
for the large iamges of the jetson-tx2 device type, there seemed to be some timing problem where the tests would progress before the full image was downloaded - causing the device to never be provisioned. Added a small delay after `fetchOs` just to get the tests passing for jetson, while looking into fully fixing the fetchOS function

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
