### PR TITLE
tests: os: skip persistent logging test for pi0

### DIFF
--- a/tests/suites/os/tests/config-json/index.js
+++ b/tests/suites/os/tests/config-json/index.js
@@ -259,6 +259,17 @@ module.exports = {
 		},
 		{
 			title: 'persistentLogging configuration test',
+			deviceType:{
+				type: 'object',
+				required: ['slug'],
+				properties: {
+				  slug: {
+					not: {
+					  const: "raspberry-pi"
+					}
+				  }
+				}
+			},
 			run: async function(test) {
 				const context = this.context.get();
 


### PR DESCRIPTION
there is currently an issue with persistent logging on the rpi0 https://github.com/balena-os/balena-raspberrypi/issues/927

in order to accelerate releases for this device type @alexgg suggested we could skip this test for the pi0, as its currently blocking

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
