### PR TITLE
flasher: fix secure boot setup with enrolled keys

### DIFF
--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -216,7 +216,7 @@ if [ -d /sys/firmware/efi ]; then
         inform "Secure boot is enabled, proceeding with lockdown"
         LUKS=1
 
-        if [ "${SETUPMODE_VAR##+(0)}" = "1" ]; then
+        if [ "${SETUPMODE_VAR}" -eq "1" ]; then
             inform "Secure boot setup mode detected - programming keys"
             # Enroll PK last, as it should disable setup mode
             for e in db KEK PK; do
@@ -229,7 +229,7 @@ if [ -d /sys/firmware/efi ]; then
             # Check that we're in user mode
             SETUPMODE_VAR=$(efivar -p -n 8be4df61-93ca-11d2-aa0d-00e098032b8c-SetupMode \
                 | awk 'NR==1, $1 == "Value:" {next}; NF {print $2}')
-            if [ "${SETUPMODE_VAR##+(0)}" = "1" ]; then
+            if [ "${SETUPMODE_VAR}" -eq "1" ]; then
                 # Setting up keys hasn't disabled setup mode, try a reboot into flasher
                 inform "Rebooting flasher after secure mode setup to boot in secure boot mode."
                 # Make sure to reboot into the installer

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -204,7 +204,7 @@ if [ -d /sys/firmware/efi ]; then
         | awk 'NR==1, $1 == "Value:" {next}; NF {print $2}')
 
     if [ "${SECUREBOOT_ENABLED}" = "1" ]; then
-        if [ "${SECUREBOOT_VAR##+(0)}" = "1" ]; then
+        if [ -z "${SECUREBOOT_VAR}" ]; then
             fail "Secure boot is configured, but is not supported in firmware."
         fi
 

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -204,7 +204,14 @@ if [ -d /sys/firmware/efi ]; then
     SETUPMODE_VAR=$(efivar -p -n 8be4df61-93ca-11d2-aa0d-00e098032b8c-SetupMode \
         | awk 'NR==1, $1 == "Value:" {next}; NF {print $2}')
 
-    if [ "${SECUREBOOT_ENABLED}" = "1" ]; then
+    if [ "${SECUREBOOT_ENABLED}" != "1" ]; then
+        if [ "${SETUPMODE_VAR}" -ne "1" ]; then
+            # Bail out when keys are already enrolled but secure boot is not
+	    # enabled in config.json, as the installed system will not have
+	    # FDE, and it's ambiguous if the user wants secure boot
+            fail "Secure boot keys are enrolled but secure boot is not enabled"
+        fi
+    else
         if [ -z "${SECUREBOOT_VAR}" ]; then
             fail "Secure boot is configured, but is not supported in firmware."
         fi

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -197,7 +197,8 @@ if [ -d /sys/firmware/efi ]; then
     EFI=1
     SECUREBOOT_ENABLED=$(
         [ "$(jq .installer.secureboot "${CONFIG_PATH}")" = "true" ] \
-        && echo 1)
+        && echo 1 \
+        || echo 0)
     SECUREBOOT_VAR=$(efivar -p -n 8be4df61-93ca-11d2-aa0d-00e098032b8c-SecureBoot \
         | awk 'NR==1, $1 == "Value:" {next}; NF {print $2}')
     SETUPMODE_VAR=$(efivar -p -n 8be4df61-93ca-11d2-aa0d-00e098032b8c-SetupMode \


### PR DESCRIPTION
When refactoring secure boot setup, a logic mistake in the purpose and use of SECUREBOOT_VAR meant that devices booting the flasher with keys already enrolled would bail out with an incorrect message about secure boot not being supported in firmware.

This variable is `00` on systems with secure boot support in firmware, but not enabled and enforced, `01` on systems where secure boot is enforced, and empty when secure boot is unsupported.

Change this conditional to bail out only when the variable is empty, indicating that secure boot is unsupported.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
