### PR TITLE
renovate: Include to and from versions for supervisor and engine

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,17 +14,19 @@
   "regexManagers": [
     {
       "fileMatch": ["(^|/)balena-supervisor.inc$"],
-      "matchStrings": ["SUPERVISOR_VERSION \\?= \"(?<currentValue>.*?)\"\\n"],
+      "matchStrings": ["SUPERVISOR_VERSION \\?= \"v?(?<currentValue>.*?)\"\\n"],
       "depNameTemplate": "balena-supervisor",
       "packageNameTemplate": "balena-os/balena-supervisor",
-      "datasourceTemplate": "github-tags"
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
       "fileMatch": ["(^|/)balena_git.bb$"],
-      "matchStrings": ["BALENA_VERSION = \"(?<currentValue>.*?)\"\\n"],
+      "matchStrings": ["BALENA_VERSION = \"v?(?<currentValue>.*?)\"\\n"],
       "depNameTemplate": "balena-engine",
       "packageNameTemplate": "balena-os/balena-engine",
-      "datasourceTemplate": "github-tags"
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^v?(?<version>.*)$"
     }
   ],
   "packageRules": [
@@ -34,12 +36,12 @@
         ".*balena-supervisor",
         ".*balena-engine"
       ],
-      "commitBody": "Update {{depName}}\nChange-type: {{updateType}}",
+      "commitBody": "Update {{depName}} from {{currentVersion}} to {{newVersion}}\n\nChange-type: {{updateType}}",
       "automerge": true,
       "platformAutomerge": true,
       "postUpgradeTasks": {
         "commands": [
-          "sed -r \"s|SRCREV = \\\"[0-9a-f]+\\\"|SRCREV = \\\"$(git ls-remote -t {{{sourceUrl}}} refs/tags/{{{newVersion}}} | awk '{print $1}')\\\"|\" -i {{{packageFile}}}"
+          "sed -r \"s|SRCREV = \\\"[0-9a-f]+\\\"|SRCREV = \\\"$(git ls-remote -t {{{sourceUrl}}} refs/tags/v{{{newVersion}}} | awk '{print $1}')\\\"|\" -i {{{packageFile}}}"
         ],
         "fileFilters": [
           "**/balena_git.bb"


### PR DESCRIPTION
This allows properly formatted commit messages to support nested changelogs.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
