### PR TITLE
os-helpers-fs: get_internal_device() skip disks w/out media

### DIFF
--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
@@ -249,6 +249,10 @@ get_internal_device() {
           inform "${device} is our install media, skip it..."
           continue
       fi
+      if [ ! fdisk -l "${device}" ]; then
+        inform "${device} has no media attached"
+        continue
+      fi
       if test -b "$(readlink -f "${device}")"; then
           if ! [[ "${device_pattern}" = md/* ]]; then
               if mdadm --examine "${device}" | grep -q Array; then


### PR DESCRIPTION
Block device nodes are sometimes created without attached media. These devices can neither be read from, nor written to. In this case, the flasher will attempt to install to the invalid disk and fail.  Detect this case and skip the disk to allow flashing to continue.

```
sh-5.1$ ls -la /dev/sda
brw-rw---- 1 root disk 8, 0 Feb  9 09:36 /dev/sda
sh-5.1$ lsblk /dev/sda
NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINTS
sda    8:0    1   0B  0 disk 
sh-5.1$ fdisk -l /dev/sda
fdisk: cannot open /dev/sda: No medium found
sh-5.1$ echo $?
1
```

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
