### PR TITLE
tests: hup: fix flashing for tx2

### DIFF
--- a/tests/suites/hup/suite.js
+++ b/tests/suites/hup/suite.js
@@ -334,6 +334,7 @@ module.exports = {
 						persistentLogging: true,
 						// Set local mode so we can perform local pushes of containers to the DUT
 						localMode: true,
+						apiEndpoint: 'https://api.balena-cloud.com',
 						developmentMode: true,
 					},
 				},


### PR DESCRIPTION
the tx2 has exhibited a weird quirk with the hup suite. When trying to flash the DUT with the most recent prod image fetched via the SDK, the DUT fails to internally flash - it turned out that it was due to `resin-device-register` failing during `resin-init-flasher`. 

```
[ERROR] resin-device-register : Please set API_ENDPOINT and CONFIG_PATH environment variable
```

Adding the `apiEndpoint: 'https://api.balena-cloud.com',` to the DUT `config.json` fixes this issue. It is unknown why this fails only specifically for the tx2 device type - potentially there is some sort of sequencing or timing difference. 

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
