### PR TITLE
Allow to specify multiple trusted certificates when building for secure boot

### DIFF
--- a/meta-balena-common/classes/sign-efi.bbclass
+++ b/meta-balena-common/classes/sign-efi.bbclass
@@ -20,7 +20,9 @@ do_sign_efi () {
         fi
         REQUEST_FILE=$(mktemp)
         RESPONSE_FILE=$(mktemp)
-        echo "{\"key_id\": \"${SIGN_EFI_KEY_ID}\", \"payload\": \"$(base64 -w 0 ${SIGNING_ARTIFACT})\"}" > "${REQUEST_FILE}"
+        # SIGN_EFI_KEY_ID is a list, use the first key to perform the signing
+        FIRST_KEY_ID=$(echo "${SIGN_EFI_KEY_ID}" | cut -d "," -f 1)
+        echo "{\"key_id\": \"${FIRST_KEY_ID}\", \"payload\": \"$(base64 -w 0 ${SIGNING_ARTIFACT})\"}" > "${REQUEST_FILE}"
         CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt" \
             curl --fail "${SIGN_API}/secureboot/efi" \
                  -X POST \

--- a/meta-balena-common/recipes-support/balena-keys/balena-keys.bb
+++ b/meta-balena-common/recipes-support/balena-keys/balena-keys.bb
@@ -33,8 +33,7 @@ fetch_key() {
     fi
     rm -f "${RESPONSE_FILE}"
     ext="${3#*.}"
-    if [ "${ext}" = "auth" ] || [ "${ext}" = "der" ] ||
-       [ "${ext}" = "esl" ]; then
+    if [ "${ext}" = "auth" ] || [ "${ext}" = "esl" ]; then
         if [ -f "${DEST_DIR}/${3}" ]; then
             tmpdir=$(mktemp -d)
             base64 -d "${DEST_DIR}/${3}" > "${tmpdir}/${3}"
@@ -48,13 +47,10 @@ do_get_public_keys() {
     fetch_key "gpg/key/${SIGN_GRUB_KEY_ID}" ".key" "grub.gpg"
     fetch_key "kmod/cert/${SIGN_KMOD_KEY_ID}" ".cert" "kmod.crt"
     fetch_key "secureboot/pk/${SIGN_EFI_PK_KEY_ID}" ".pk" "PK.auth"
-    fetch_key "secureboot/pk/${SIGN_EFI_PK_KEY_ID}" ".der" "PK.der"
     fetch_key "secureboot/kek/${SIGN_EFI_KEK_KEY_ID}" ".kek" "KEK.auth"
     fetch_key "secureboot/kek/${SIGN_EFI_KEK_KEY_ID}" ".esl" "KEK.esl"
-    fetch_key "secureboot/kek/${SIGN_EFI_KEK_KEY_ID}" ".der" "KEK.der"
     fetch_key "secureboot/db/${SIGN_EFI_KEY_ID}" ".db" "db.auth"
     fetch_key "secureboot/db/${SIGN_EFI_KEY_ID}" ".esl" "db.esl"
-    fetch_key "secureboot/db/${SIGN_EFI_KEY_ID}" ".der" "db.der"
 }
 do_get_public_keys[cleandirs] = "${B}"
 do_get_public_keys[network] = "1"


### PR DESCRIPTION
At this moment we only allow a single certificate for PK, KEK and db, this PR makes it possible to specify a list of certificates using e.g. `SIGN_EFI_KEY_ID=key1,key2,key3`. The key used for signing the actual EFI binary during build will always be the first one specified (`key1` in the example), the rest will just be loaded as trusted. This is a necessary step towards implementing a proper key rotation.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
