### PR TITLE
HUP rollback checks: refer to balenaEngine by its full name

### DIFF
--- a/meta-balena-common/recipes-core/balena-rollback/files/rollback-tests
+++ b/meta-balena-common/recipes-core/balena-rollback/files/rollback-tests
@@ -33,10 +33,10 @@ if [ -f /mnt/state/rollback-health-variables ]; then
 	fi
 fi
 
-# Balena health check
+# balenaEngine health check
 if /usr/lib/balena/balena-healthcheck ; then
-	echo "Rollback: Balena looks healthy"
+	echo "Rollback: balenaEngine looks healthy"
 else
-	echo "Rollback: ERROR: Balena is not healthy!"
+	echo "Rollback: ERROR: balenaEngine is not healthy!"
 	exit 1
 fi


### PR DESCRIPTION
Previously, it was being referred to only as "balena". Being explicit that this is about balenaEngine makes it simpler to grep for Engine-related portions of balenaOS. Might also help a tad bit when looking at logs.

@klutchell Thanks for pointing me into the right files. I haven't located this because all my searches were using "engine", which is not mentioned at all in this file. I am proposing this little change to make it more discoverable. WDYT?