### PR TITLE
initrdscripts: migrate: use du instead of wc to calculate byte sizes

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/migrate
+++ b/meta-balena-common/recipes-core/initrdscripts/files/migrate
@@ -114,10 +114,10 @@ migrate_run() {
     if [ -n "${image}" ]; then
         EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT="${BALENA_BOOT_MOUNTPOINT}"
         if findmnt "${FLASH_BOOT_MOUNT}" > /dev/null; then
-            _image_size=$(wc -c "${image}" | awk '{print $1}')
-            _flash_boot_size=$(du -bs ${FLASH_BOOT_MOUNT} | awk '{print $1}')
+            _image_size=$(du -cb "${image}" | awk '/total/{print $1}')
+            _flash_boot_size=$(du -cb ${FLASH_BOOT_MOUNT} | awk '/total/{print $1}')
             # shellcheck disable=SC2086
-            _kernel_images_size=$(wc -c ${kernel_images} | awk '/total/{ print $1}')
+            _kernel_images_size=$(du -cb ${kernel_images} | awk '/total/{print $1}')
             _total_size=$(("$_image_size" + "$_flash_boot_size" + "$_kernel_images_size"))
             memory_check "${_total_size}"
         else

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
@@ -137,7 +137,7 @@ regenerate_uuid() {
             # mlabel doesn't work on file directly. It needs a drive to file
             # mapping in its configuration.
             drive=a:
-	    echo "drive ${drive} file=\"$dev\" exclusive" > /etc/mtools.conf
+            echo "drive ${drive} file=\"$dev\" exclusive" > /etc/mtools.conf
             new_uuid="BDEF$(hexdump -n 2 -e '"%02X" 1 "\n"' /dev/urandom)"
             cmd="mlabel -s -N ${new_uuid}"
             if ! eval "${cmd}" "${drive}"; then
@@ -157,9 +157,9 @@ regenerate_uuid() {
                     fi
             fi
             if ! e2fsck -fp "$dev"; then
-		return 1
+                return 1
             fi
-	    new_uuid=$(sed 's/^[^-]*/ba1eadef/' < /proc/sys/kernel/random/uuid)
+            new_uuid=$(sed 's/^[^-]*/ba1eadef/' < /proc/sys/kernel/random/uuid)
             cmd="echo y | EXT2FS_NO_MTAB_OK=1  tune2fs -U ${new_uuid}"
             if ! eval "${cmd}" "${dev}"; then
                 return 1
@@ -181,10 +181,10 @@ regenerate_uuid() {
 #       The default should work fine but it is handy to switch to 'partlabel'
 #       on GPT devices as this does not need to rely on the underlying FS
 #       being labelled correctly.
-function get_part_number_by_label {
-    DEVICE=$1
-    LABEL=$2
-    FIELD=${3:-label}
+get_part_number_by_label() {
+    DEVICE=${1}
+    LABEL=${2}
+    FIELD=${3:-"label"}
 
     lsblk "/dev/${DEVICE}" -nlo "name,${FIELD}" | grep "${LABEL}" | sed -e "s,^${DEVICE}p\?\([0-9][0-9]*\)[ \t]*${LABEL}$,\1,"
 }
@@ -194,7 +194,7 @@ function get_part_number_by_label {
 #   1 - Block device
 #   2 - Partition number
 #   3 - (optional) Alignment block size
-function get_part_size_by_number {
+get_part_size_by_number() {
     DEVICE=$1
     PART_NUMBER=$2
     ALIGN_BLOCK_SIZE=$3
@@ -219,7 +219,7 @@ function get_part_size_by_number {
 # Arguments:
 #   1 - Block device
 #   2 - Partition number
-function get_part_start_by_number {
+get_part_start_by_number() {
     DEVICE=$1
     PART_NUMBER=$2
 

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
@@ -249,7 +249,7 @@ get_internal_device() {
           info "${device} is our install media, skip it..."
           continue
       fi
-      if [ ! fdisk -l "${device}" ]; then
+      if ! fdisk -l "${device}" > /dev/null 2>&1; then
         inform "${device} has no media attached"
         continue
       fi


### PR DESCRIPTION
The `du` utility has the same output format for single or several files, while the `wc` utility doesn't and does not display a total for single files.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
