### PR TITLE
image-balena.bbclass: deploy grub-conf before building the boot partition

### DIFF
--- a/meta-balena-common/classes/image-balena.bbclass
+++ b/meta-balena-common/classes/image-balena.bbclass
@@ -243,6 +243,7 @@ do_resin_boot_dirgen_and_deploy () {
 		fi
 	fi
 }
+do_resin_boot_dirgen_and_deploy[depends] += "${@bb.utils.contains_any('BALENA_IMAGE_BOOTLOADER', 'grub grub-efi', 'grub-conf:do_deploy', '', d)}"
 
 QUIRK_FILES ?= " \
     etc/hosts \


### PR DESCRIPTION
`do_resin_boot_dirgen_and_deploy` needs all the partial files deployed when it runs as it will be copying them to the actual boot partition. There is a race condition between it and `grub_conf:do_deploy`, we have seen builds fail when `grub_conf:do_deploy` does not execute in time. This patch adds an explicit dependency to avoid such situation.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
