### PR TITLE
flasher: fix installation when in user mode w/ sb disabled

### DIFF
--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -194,7 +194,7 @@ if [ -d /sys/firmware/efi ]; then
         | awk 'NR==1, $1 == "Value:" {next}; NF {print $2}')
 
     if [ "${SECUREBOOT_ENABLED}" != "1" ]; then
-        if [ "${SETUPMODE_VAR}" -ne "1" ]; then
+        if [ "${SECUREBOOT_VAR}" -eq "1" ] && [ "${SETUPMODE_VAR}" -ne "1" ]; then
             # Bail out when keys are already enrolled but secure boot is not
 	    # enabled in config.json, as the installed system will not have
 	    # FDE, and it's ambiguous if the user wants secure boot


### PR DESCRIPTION
Previously, we bailed out of the installer when the system was in user mode (keys enrolled) but the user had not opted in to secure boot, as it was ambiguous whether the user actually wanted SB/FDE.

However, some systems come with vendor keys pre-enrolled, and a user may simply turn off secure boot in the firmware setup menu without erasing the keys. This would result in the installer bailing out even though secure boot is disabled in the firmware menu.

Check that secure boot is enabled in addition to having keys enrolled before bailing out.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
