### PR TITLE
Use hashes instead of certificates for secure boot image validation

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -1055,7 +1055,7 @@ do_configure:append () {
     fi
 
 }
-do_configure[depends] += "balena-keys:do_deploy"
+do_configure[depends] += "${@oe.utils.conditional('SIGN_API','','',' balena-keys:do_deploy',d)}"
 # Force compile to depend on the last resin task in the chain
 do_compile[deptask] += "do_kernel_resin_checkconfig"
 

--- a/meta-balena-common/classes/sign-efi.bbclass
+++ b/meta-balena-common/classes/sign-efi.bbclass
@@ -20,7 +20,7 @@ do_sign_efi () {
         fi
         REQUEST_FILE=$(mktemp)
         RESPONSE_FILE=$(mktemp)
-        echo "{\"key_id\": \"${SIGN_EFI_KEY_ID}\", \"payload\": \"$(base64 -w 0 ${SIGNING_ARTIFACT})\"}" > "${REQUEST_FILE}"
+        echo "{\"key_id\": \"${SIGN_KMOD_KEY_ID}\", \"payload\": \"$(base64 -w 0 ${SIGNING_ARTIFACT})\"}" > "${REQUEST_FILE}"
         CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt" \
             curl --fail "${SIGN_API}/secureboot/efi" \
                  -X POST \
@@ -52,5 +52,5 @@ do_sign_efi[depends] += " \
 
 do_package[vardeps] += " \
     SIGN_API \
-    SIGN_EFI_KEY_ID \
+    SIGN_KMOD_KEY_ID \
     "

--- a/meta-balena-common/conf/distro/include/balena-os.inc
+++ b/meta-balena-common/conf/distro/include/balena-os.inc
@@ -128,7 +128,6 @@ FIRMWARE_COMPRESSION ?= "0"
 SIGN_API ?= ""
 # Signing keys
 SIGN_GRUB_KEY_ID ?= "2EB29B4CE0132F6337897F5FB8A88D1C62FCC729"
-SIGN_EFI_KEY_ID ?= "balenaos-db"
 SIGN_KMOD_KEY_ID ?= "balenaos-kmod"
 SIGN_EFI_PK_KEY_ID ?= "balenaos-pk"
 SIGN_EFI_KEK_KEY_ID ?= "balenaos-kek"

--- a/meta-balena-common/recipes-bsp/efitools/efitools_git.bb
+++ b/meta-balena-common/recipes-bsp/efitools/efitools_git.bb
@@ -42,7 +42,7 @@ do_deploy() {
 addtask deploy after do_install before do_build
 
 PACKAGES =+ "${PN}-utils"
-FILES:${PN}-utils = "/usr/bin/efi-updatevar /usr/bin/efi-readvar"
+FILES:${PN}-utils = "/usr/bin/efi-updatevar /usr/bin/efi-readvar /usr/bin/sig-list-to-certs"
 
 PACKAGES =+ "${PN}-lockdown"
 FILES:${PN}-lockdown = "/boot/efi/EFI/BOOT/LockDown.efi"

--- a/meta-balena-common/recipes-bsp/grub/grub-efi_%.bbappend
+++ b/meta-balena-common/recipes-bsp/grub/grub-efi_%.bbappend
@@ -1,7 +1,5 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/grub-efi:"
 
-inherit sign-efi
-
 SRC_URI += " \
     file://0001-Add-dummyterm-module.patch \
     "
@@ -44,9 +42,4 @@ do_mkimage:append() {
     fi
 }
 
-do_mkimage[depends] += " \
-    balena-keys:do_deploy \
-    "
-
-SIGNING_ARTIFACTS = "${B}/${GRUB_IMAGE_PREFIX}${GRUB_IMAGE}.secureboot"
-addtask sign_efi after do_mkimage before do_install
+do_mkimage[depends] += "${@oe.utils.conditional('SIGN_API','','',' balena-keys:do_deploy',d)}"

--- a/meta-balena-common/recipes-core/balena-rollback/files/rollback-health
+++ b/meta-balena-common/recipes-core/balena-rollback/files/rollback-health
@@ -58,6 +58,72 @@ run_hooks_from_inactive () {
 EOF
 }
 
+secureboot_apply_dbx() {
+	EFI_DIR="/sys/firmware/efi"
+	EFIVARS_DIR="${EFI_DIR}/efivars"
+	EFIVAR_RE="s,^[^ ]*  *\([^ ]*\) .*$,\1,"
+	SECUREBOOT_VAR="8be4df61-93ca-11d2-aa0d-00e098032b8c-SecureBoot"
+	DBX_SYSFS_FILE="dbx-d719b2cb-3d3a-4596-a3bc-dad00e67656f"
+	PENDING_DBX_DIR="/mnt/data/balenahup/pending-dbx"
+	CURRENT_DB_ESL="/resin-boot/balena-keys/db.esl"
+
+	if [ ! -d "${EFI_DIR}" ]; then
+		# Not an EFI system, nothing to do
+		return
+	fi
+
+	SECUREBOOT_VAL=$(efivar -p -n "${SECUREBOOT_VAR}" | tail -n 1 | sed -e "${EFIVAR_RE}")
+	if [ "${SECUREBOOT_VAL}" -ne 1 ]; then
+		# Secure boot disabled, nothing to do
+		return
+	fi
+
+	if [ ! -d "${PENDING_DBX_DIR}" ]; then
+		# Unexpected state - the directory should have been created by HUP
+		# With it missing, there is nothing we can do
+		echo "Rollback: Directory '${PENDING_DBX_DIR}' should exist but it does not"
+		return
+	fi
+
+	echo "Rollback: Applying pending DBX updates to prevent formerly allowed OS versions to boot"
+	TMPDIR=$(mktemp -d)
+	sig-list-to-certs "${CURRENT_DB_ESL}" "${TMPDIR}/current"
+	# When dbx is empty the immutable attribute is not set, chattr can safely fail
+	chattr -i "${EFIVARS_DIR}/${DBX_SYSFS_FILE}" || :
+	for PENDING_DBX_FILE in "${PENDING_DBX_DIR}/dbx-"*.auth; do
+		if [ "${PENDING_DBX_FILE}" = "${PENDING_DBX_DIR}/dbx-*.auth" ]; then
+			# Nothing matched the glob
+			break
+		fi
+
+		# Check whether any of the hashes we are about to blacklist overlap
+		# with the hashes of the new OS. If so, do not apply the update yet,
+		# otherwise the system would not be bootable on reboot. Leave the update
+		# pending and it will be applied once the hashes change.
+		OVERLAP=0
+		for PENDING_HASH in "${PENDING_DBX_FILE}-"*.hash; do
+			for CURRENT_HASH in "${TMPDIR}/current-"*.hash; do
+				if cmp -s "${PENDING_HASH}" "${CURRENT_HASH}"; then
+					OVERLAP=1
+				fi
+			done
+		done
+		if [ "${OVERLAP}" = "1" ]; then
+			echo "Rollback: Not applying ${PENDING_DBX_FILE} - hashes overlap"
+			continue
+		fi
+
+		echo "Rollback: Applying ${PENDING_DBX_FILE}"
+		if efi-updatevar -a -f "${PENDING_DBX_FILE}" dbx; then
+			rm -f "${PENDING_DBX_FILE}"*
+		else
+			echo "Rollback: Failed to apply ${PENDING_DBX_FILE}, keeping it pending"
+		fi
+	done
+	chattr +i "${EFIVARS_DIR}/${DBX_SYSFS_FILE}" || :
+	rm -rf "${TMPDIR}"
+}
+
 echo "Rollback: Health sanity check"
 
 if [ "$resin_root_part" = "$current_part_idx" ]; then
@@ -88,6 +154,7 @@ if [ "$resin_root_part" = "$current_part_idx" ]; then
 	    rollback-stop || true
 	    echo "Rollback: Running commit hooks"
 	    hostapp-update-hooks-v2 --commit || true
+	    secureboot_apply_dbx
 	else
 		echo "Rollback: Nothing to do. Looks like we are in ROLLBACK_HEALTHY state. Why is script running?"
 		rollback-stop || true

--- a/meta-balena-common/recipes-support/balena-keys/balena-db-hashes.bb
+++ b/meta-balena-common/recipes-support/balena-keys/balena-db-hashes.bb
@@ -1,0 +1,67 @@
+DESCRIPTION = "Balena db hashes for UEFI secure boot"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${BALENA_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+inherit allarch deploy
+
+EXCLUDE_FROM_WORLD = "1"
+INHIBIT_DEFAULT_DEPS = "1"
+ALLOW_EMPTY:${PN} = "1"
+
+do_get_db() {
+    DEST_DIR="${B}/balena-keys"
+    if [ "x${SIGN_API}" = "x" ]; then
+        bbnote "Signing API not defined"
+        return
+    fi
+    mkdir -p "${DEST_DIR}"
+
+    hash-to-efi-sig-list "${DEPLOY_DIR_IMAGE}"/grub-efi-boot*.efi.secureboot "${DEST_DIR}/db.esl"
+
+    REQUEST_FILE=$(mktemp)
+    echo "{\"signing_key_id\": \"${SIGN_EFI_KEK_KEY_ID}\", \"esl\": \"$(base64 -w 0 ${DEST_DIR}/db.esl)\"}" > "${REQUEST_FILE}"
+
+    RESPONSE_FILE=$(mktemp)
+    export CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt"
+    curl --fail "${SIGN_API}/secureboot/db" \
+        -X POST \
+        -H "Content-Type: application/json" \
+        -H "X-API-Key: ${SIGN_API_KEY}" \
+        -d "@${REQUEST_FILE}" \
+        -o "${RESPONSE_FILE}"
+
+    jq -r ".auth" < "${RESPONSE_FILE}" | base64 -d > "${DEST_DIR}/db.auth"
+    rm -f "${REQUEST_FILE}" "${RESPONSE_FILE}"
+}
+do_get_db[cleandirs] = "${B}"
+do_get_db[network] = "1"
+addtask get_db before do_build
+do_get_db[depends] += " \
+    curl-native:do_populate_sysroot \
+    jq-native:do_populate_sysroot \
+    ca-certificates-native:do_populate_sysroot \
+    coreutils-native:do_populate_sysroot \
+    gnupg-native:do_populate_sysroot \
+    efitools-native:do_populate_sysroot \
+    grub-efi:do_deploy \
+    "
+
+do_deploy() {
+    mkdir -p "${DEPLOYDIR}/balena-keys/"
+    for DB_FILE in "${B}/balena-keys/"*; do
+        cp "${DB_FILE}" "${DEPLOYDIR}/balena-keys/"
+    done
+}
+addtask deploy after do_get_db
+
+deltask do_fetch
+deltask do_unpack
+deltask do_patch
+deltask do_configure
+deltask do_compile
+deltask do_install
+
+do_package[vardeps] += " \
+    SIGN_API \
+    SIGN_EFI_KEK_KEY_ID \
+    "

--- a/meta-balena-common/recipes-support/balena-keys/balena-keys.bb
+++ b/meta-balena-common/recipes-support/balena-keys/balena-keys.bb
@@ -7,6 +7,7 @@ inherit allarch deploy
 EXCLUDE_FROM_WORLD = "1"
 INHIBIT_DEFAULT_DEPS = "1"
 ALLOW_EMPTY:${PN} = "1"
+DEPENDS = "balena-db-hashes"
 
 # Fetch the specified public key from the signing server
 #
@@ -47,10 +48,9 @@ do_get_public_keys() {
     fetch_key "gpg/key/${SIGN_GRUB_KEY_ID}" ".key" "grub.gpg"
     fetch_key "kmod/cert/${SIGN_KMOD_KEY_ID}" ".cert" "kmod.crt"
     fetch_key "secureboot/pk/${SIGN_EFI_PK_KEY_ID}" ".pk" "PK.auth"
+    fetch_key "secureboot/pk/${SIGN_EFI_PK_KEY_ID}" ".esl" "PK.esl"
     fetch_key "secureboot/kek/${SIGN_EFI_KEK_KEY_ID}" ".kek" "KEK.auth"
     fetch_key "secureboot/kek/${SIGN_EFI_KEK_KEY_ID}" ".esl" "KEK.esl"
-    fetch_key "secureboot/db/${SIGN_EFI_KEY_ID}" ".db" "db.auth"
-    fetch_key "secureboot/db/${SIGN_EFI_KEY_ID}" ".esl" "db.esl"
 }
 do_get_public_keys[cleandirs] = "${B}"
 do_get_public_keys[network] = "1"
@@ -81,7 +81,6 @@ deltask do_install
 do_package[vardeps] += " \
     SIGN_API \
     SIGN_GRUB_KEY_ID \
-    SIGN_EFI_KEY_ID \
     SIGN_KMOD_KEY_ID \
     SIGN_EFI_PK_KEY_ID \
     SIGN_EFI_KEK_KEY_ID \

--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
@@ -40,14 +40,25 @@ umountEfiVars() {
 }
 
 updateKeys() {
-    for k in db KEK PK; do
-        if cmp "/mnt/boot/balena-keys/${k}.auth" "/resin-boot/balena-keys/${k}.auth"; then
-            continue
-        else
-            error "Updating keys is not currently supported - a fresh installation is required"
-            exit 1
-        fi
-    done
+    # This only updates db at this moment
+    # PK and KEK need to be implemented
+    DB_SYSFS_FILE="db-d719b2cb-3d3a-4596-a3bc-dad00e67656f"
+    chattr -i "${EFIVARS_MOUNTDIR}/${DB_SYSFS_FILE}"
+    efi-updatevar -a -f "/resin-boot/balena-keys/db.auth" db
+    chattr +i "${EFIVARS_MOUNTDIR}/${DB_SYSFS_FILE}"
+
+    # dbx is updated by rollback-health when it confirms that HUP went through
+    # here we just copy out the dbx update from the active partition to a pending
+    # directory for rollback-health to find it later
+    PENDING_DBX_DIR="/mnt/data/balenahup/pending-dbx"
+    ACTIVE_ESL_FILE=$(find "/mnt/sysroot/active" -name "db.esl")
+    ACTIVE_DBX_FILE=$(find "/mnt/sysroot/active" -name "dbx.auth")
+    ACTIVE_DBX_FILE_MD5SUM=$(md5sum "${ACTIVE_DBX_FILE}" | cut -d " " -f 1)
+    DEST_FILE="${PENDING_DBX_DIR}/dbx-${ACTIVE_DBX_FILE_MD5SUM}.auth"
+
+    mkdir -p "${PENDING_DBX_DIR}"
+    cp -a "${ACTIVE_DBX_FILE}" "${DEST_FILE}"
+    sig-list-to-certs "${ACTIVE_ESL_FILE}" "${DEST_FILE}"
 }
 
 # Only applicable in the new OS container
@@ -66,24 +77,26 @@ mountEfiVars
 SECUREBOOT_VAL=$(efivar -p -n "${SECUREBOOT_VAR}" | tail -n 1 | sed -e "${EFIVAR_RE}")
 SETUPMODE_VAL=$(efivar -p -n "${SETUPMODE_VAR}" | tail -n 1 | sed -e "${EFIVAR_RE}")
 
-umountEfiVars
-
 # Only applicable when in secure boot mode
 if [ -z "${SECUREBOOT_VAL}" ] || [ "${SECUREBOOT_VAL}" -ne "1" ]; then
+    umountEfiVars
     exit 0
 fi
 
 # Not applicable when secure boot is in setup mode
 if [ -n "${SETUPMODE_VAL}" ] && [ "${SETUPMODE_VAL}" -ne "0" ]; then
+    umountEfiVars
     exit 0
 fi
 
 # Not applicable if the signatures are in place
 if [ -f "/resin-boot/EFI/BOOT/grub.cfg.sig" ]; then
     updateKeys
+    umountEfiVars
     exit $?
 fi
 
+umountEfiVars
 
 # At this point we are sure the current OS is running in secure boot mode
 # and the new image is not signed, abort the update

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher.bb
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher.bb
@@ -15,7 +15,7 @@ inherit allarch systemd
 
 SYSTEMD_SERVICE:${PN} = "resin-init-flasher.service"
 
-DEPENDS += "balena-keys"
+DEPENDS += "${@oe.utils.conditional('SIGN_API','','',' balena-keys',d)}"
 
 RDEPENDS:${PN} = " \
     bash \


### PR DESCRIPTION
This patch changes the validation of bootable images from certificate signatures to a list of allowed hashes of binaries. This only applies on db level, PK and KEK are still certificates.

The motivation is that certificates expire and we need to be sure that even devices that have been lying on a shelf for several years or whose CMOS battery has died and reset date to 1970-01-01 are still bootable. Using hashes is more aligned with this use-case and also more similar to the approach that embedded SoCs use.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
