### PR TITLE
Remove a bad check in Internet connection sharing test

### DIFF
--- a/tests/suites/os/tests/internet-sharing/index.js
+++ b/tests/suites/os/tests/internet-sharing/index.js
@@ -98,15 +98,6 @@ module.exports = {
                 count = await countSharedIptables(this);
                 test.equal(count, 0, 'All Internet sharing iptables rules are deleted');
 
-                // Now lock for 3 seconds instead, which will make one of the rules to
-                // not be set.
-                await this.worker.executeCommandInHostOS(
-                    'flock /run/xtables.lock sleep 3 & nmcli c up dummy & wait',
-                    this.link
-                );
-                count = await countSharedIptables(this);
-                test.equal(count, 13, 'One Internet sharing iptables rule is not set');
-
                 // Cleanup
                 await this.worker.executeCommandInHostOS(
                     'nmcli c delete dummy',


### PR DESCRIPTION
In the Internet connection sharing test one of the checks may run into a racing problem. The following command is holding the iptables lock for 3 seconds while NetworkManager activates a connection with sharing enabled:

`flock /run/xtables.lock sleep 3 & nmcli c up dummy & wait`

NetworkManager waits for 2 seconds for the lock to be released and those three seconds should be enough for one of the iptables rules to fail. However there is no guarantee that NetworkManager will start adding the iptables rules that quickly - it may start adding those after one out of those three seconds already passed, which will lead to all iptables rules to be set at the end.

This check is non-essential for the test itself, so it is removed with this commit.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
