### PR TITLE
balena-image-flasher: Default image type to balenaos-img

### DIFF
--- a/meta-balena-common/recipes-core/images/balena-image-flasher.bb
+++ b/meta-balena-common/recipes-core/images/balena-image-flasher.bb
@@ -8,8 +8,7 @@ REQUIRED_DISTRO_FEATURES += " systemd"
 
 BALENA_FLAG_FILE = "${BALENA_FLASHER_FLAG_FILE}"
 
-# Each machine should append this with their specific configuration
-IMAGE_FSTYPES = ""
+IMAGE_FSTYPES = "balenaos-img"
 
 BALENA_ROOT_FSTYPE = "ext4"
 


### PR DESCRIPTION
This avoids device repositories having to specify it, and it can always be overwritten in append files.

This change is an extension of https://github.com/balena-os/meta-balena/commit/a3c276a1058d05e66991871bf167079fc2824843

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
