### PR TITLE
initrdscripts: migrate: correctly identify boot device

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/migrate
+++ b/meta-balena-common/recipes-core/initrdscripts/files/migrate
@@ -74,7 +74,8 @@ migrate_enabled() {
             #   alternative disks
             #
             internal_dev=$(get_internal_device "${INTERNAL_DEVICE_KERNEL}")
-            FLASH_BOOT_DEVICE=$(get_dev_path_in_device_with_label "${internal_dev}" "flash-boot")
+            boot_dev=$(findmnt --noheadings --canonicalize --output SOURCE "${ROOTFS_DIR}" | xargs lsblk -no pkname)
+            FLASH_BOOT_DEVICE=$(get_dev_path_in_device_with_label "/dev/${boot_dev}" "flash-boot")
             if [ -n "${FLASH_BOOT_DEVICE}" ]; then
                 FLASH_BOOT_MOUNT="/tmp/flash-boot"
                 mkdir -p "${FLASH_BOOT_MOUNT}"
@@ -92,9 +93,8 @@ migrate_enabled() {
             # (excluding RAM and swap devices)
             if [[ ( -n "${_migrate}" && "${_migrate}" = "1" ) || $(lsblk -nde 251,1 | wc -l) -eq "1" ]]; then
                 # Check that we are booting from the same disk we want to program
-                device=$(findmnt --noheadings --canonicalize --output SOURCE "${ROOTFS_DIR}" | xargs lsblk -no pkname)
-                if [ "${internal_dev#/dev/}" = "${device}" ]; then
-                    info "Running migration on ${device}..."
+                if [ "${internal_dev#/dev/}" = "${boot_dev}" ]; then
+                    info "Running migration on ${internal_dev}..."
                     return 0
                 fi
             fi

--- a/meta-balena-common/recipes-core/initrdscripts/files/recovery
+++ b/meta-balena-common/recipes-core/initrdscripts/files/recovery
@@ -37,8 +37,8 @@ recovery_run() {
     fi
     mkdir /dev/pts
     mount -t devpts devpts /dev/pts
-    ADBD_TIMEOUT="${bootparam_adbdtimeout:-10m}"
-    ADBD_KILLTIMEOUT="${bootparam_adbdkilltimeout:-15m}"
+    ADBD_TIMEOUT="${bootparam_adbdtimeout:-10}"
+    ADBD_KILLTIMEOUT="${bootparam_adbdkilltimeout:-15}"
     if [ "${ADBD_TIMEOUT}" -gt "${ADBD_KILLTIMEOUT}" ]; then
         ADBD_KILLTIMEOUT="${ADBD_TIMEOUT}"
     fi

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -559,7 +559,7 @@ if [ "$EFI" = "1" ]; then
     done
 
     efibootmgr --create \
-               --disk "/dev/$(lsblk -ndo pkname "$(get_dev_path_from_label ${EFIPART_LABEL})")" \
+               --disk "/dev/$(lsblk -ndo pkname "$(get_dev_path_in_device_with_label ${internal_dev} ${EFIPART_LABEL})")" \
                --part "$(get_part_number_by_label "${internal_dev#/dev/}" "${EFIPART_LABEL}")" \
                --label "${BOOT_ENTRY_LABEL}" \
                --loader "${LOADER_PATH}"

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -409,11 +409,8 @@ mkdir -p $INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT
 info "Mounting internal device boot partition."
 
 # Wait for the devices to be detected for a while
-BOOT_MOUNT="/dev/disk/by-label/resin-boot"
-if ! timeout 10 bash -c 'until test -L /dev/disk/by-label/resin-boot; do sleep 1; done'; then
-    BOOT_MOUNT=$(get_dev_path_in_device_with_label "${internal_dev}" resin-boot)
-fi
-
+timeout 10 bash -c 'until test -L /dev/disk/by-label/resin-boot; do sleep 1; done'
+BOOT_MOUNT=$(get_dev_path_in_device_with_label "${internal_dev}" resin-boot)
 if [ -n "${BOOT_MOUNT}" ]; then
     if ! mount "${BOOT_MOUNT}"  "${INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}"; then
         fail "Failed to mount disk labeled as 'resin-boot'."

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -532,7 +532,7 @@ info "Board specific flash procedure..."
 info "Log end"
 # Preserve logs when running from initramfs
 if [ -n "${INITRAMFS_LOGFILE}" ] && [ -f "${INITRAMFS_LOGFILE}" ]; then
-    cp "${INITRAMFS_LOGFILE}" "${INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/migration_$(date +"%Y%m%dT%H%M")"
+    cp -fv "${INITRAMFS_LOGFILE}" "${INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/migration_$(date +"%Y%m%dT%H%M")"
 fi
 
 umount $INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT


### PR DESCRIPTION
The internal target device to program is not always the device the system is booting from. Make sure the `flash-boot` partition search is done on the booting device.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
