### PR TITLE
common: cryptsetup: disable read/write workqueues

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup
+++ b/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup
@@ -103,7 +103,10 @@ cryptsetup_run() {
     # and wait for them in a separate loop later
     LUKS_UNLOCKED=""
     for LUKS_UUID in $(lsblk -nlo uuid,fstype "/dev/${BOOT_DEVICE}" | grep crypto_LUKS | cut -d " " -f 1); do
-        cryptsetup luksOpen --key-file $PASSPHRASE_FILE UUID="${LUKS_UUID}" luks-"${LUKS_UUID}"
+        cryptsetup luksOpen --perf-no_read_workqueue \
+                            --perf-no_write_workqueue \
+                            --key-file $PASSPHRASE_FILE \
+                            UUID="${LUKS_UUID}" luks-"${LUKS_UUID}"
         LUKS_UNLOCKED="${LUKS_UNLOCKED} luks-${LUKS_UUID}"
     done
 

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -346,7 +346,10 @@ if [ "$LUKS" = "1" ]; then
         PART_DEV="$internal_dev$PART_PREFIX$INTERNAL_PART_ID"
         info "Encrypting $PART_DEV"
         cryptsetup -q luksFormat "$PART_DEV" "$PASSPHRASE_FILE"
-        cryptsetup luksOpen "$PART_DEV" "$PART_NAME" --key-file "$PASSPHRASE_FILE"
+        cryptsetup luksOpen --perf-no_read_workqueue \
+                            --perf-no_write_workqueue \
+                            --key-file "$PASSPHRASE_FILE" \
+                            "$PART_DEV" "$PART_NAME"
         DM_DEV="/dev/mapper/$PART_NAME"
         if [ "$PART_NAME" = "resin-boot" ]; then
             # Just create the FS, we will split boot and efi below


### PR DESCRIPTION
LUKS throughput is significantly hampered by multiple layers of async kernel APIs and workqueues, which are mostly obsolete now.

Disable read/write workqueues to improve throughput, especially on SSDs.

https://blog.cloudflare.com/speeding-up-linux-disk-encryption/

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
