### PR TITLE
systemd: add systemd-run as it is an external dependency for balenaHUP

### DIFF
--- a/meta-balena-common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-balena-common/recipes-core/systemd/systemd_%.bbappend
@@ -43,6 +43,7 @@ FILES:${PN} += " \
     /etc/mtab \
     ${sysconfdir}/systemd/journald.conf.d \
     "
+FILES:${PN}-extra-utils:remove = " ${bindir}/systemd-run"
 
 do_install:append() {
     install -d -m 0755 ${D}/${sysconfdir}/systemd/journald.conf.d


### PR DESCRIPTION
By removing `systemd-run` from the extra-utils package it gets automatically added to the systemd main package.

This avoids the `system-extra-utils` dependency that brings in too many unused elements.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
