### PR TITLE
tests: make immediate problems more clear in all suites

### DIFF
--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -275,10 +275,12 @@ module.exports = {
     await this.worker.on();
 
     // create tunnels
-    this.log('Creating SSH tunnels to DUT');
-    await this.worker.createSSHTunnels(
-      this.link
-    );
+		await test.resolves(
+			this.worker.createSSHTunnels(
+				this.link,
+			),
+			`Should detect ${this.link} on local network and establish tunnel`
+		)
 
     this.log('Waiting for device to be reachable');
     await test.resolves(

--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -60,7 +60,7 @@ const enableSerialConsole = async (imagePath) => {
 
 module.exports = {
   title: "Managed BalenaOS release suite",
-  run: async function () {
+  run: async function (test) {
     const Worker = this.require("common/worker");
     const BalenaOS = this.require("components/os/balenaos");
     const Balena = this.require("components/balena/sdk");
@@ -281,16 +281,16 @@ module.exports = {
     );
 
     this.log('Waiting for device to be reachable');
-    await this.utils.waitUntil(async () => {
-      this.log("Trying to ssh into device");
-      let hostname = await this.context
-        .get()
-        .worker.executeCommandInHostOS(
-          "cat /etc/hostname",
-          this.link
-        )
-      return (hostname === `${this.balena.uuid.slice(0, 7)}`)
-    }, true, 60, 5 * 1000);
+    await test.resolves(
+			this.utils.waitUntil(async () => {
+				let hostname = await this.worker.executeCommandInHostOS(
+				"cat /etc/hostname",
+				this.link
+				)
+				return (hostname === this.link.split('.')[0])
+			}, true),
+			`Device ${this.link} be reachable over local SSH connection`
+		)
 
     // Retrieving journalctl logs: register teardown after device is reachable
     this.suite.teardown.register(async () => {

--- a/tests/suites/hup/suite.js
+++ b/tests/suites/hup/suite.js
@@ -154,10 +154,12 @@ const initDUT = async (that, test, target) => {
 	await that.worker.addSSHKey(that.sshKeyPath);
 
 	// create tunnels
-	console.log('Creating SSH tunnels to DUT');
-	await that.worker.createSSHTunnels(
-		that.link,
-	);
+	await test.resolves(
+		that.worker.createSSHTunnels(
+			that.link,
+		),
+		`Should detect ${that.link} on local network and establish tunnel`
+	)
 
 	await test.resolves(
 		that.utils.waitUntil(async () => {

--- a/tests/suites/hup/suite.js
+++ b/tests/suites/hup/suite.js
@@ -159,15 +159,17 @@ const initDUT = async (that, test, target) => {
 		that.link,
 	);
 
-	test.comment(`Waiting for DUT to be reachable`);
-	await that.utils.waitUntil(async () => {
-		return (
-			(await that.worker.executeCommandInHostOS(
-				'[[ -f /etc/hostname ]] && echo pass || echo fail',
-				target,
-			)) === 'pass'
-		);
-	}, true);
+	await test.resolves(
+		that.utils.waitUntil(async () => {
+			return (
+				(await that.worker.executeCommandInHostOS(
+					'[[ -f /etc/hostname ]] && echo pass || echo fail',
+					target,
+				)) === 'pass'
+			);
+		}, true),
+		`Device ${that.link} should be reachable over local SSH connection`
+	)
 	test.comment(`DUT flashed`);
 
 	// Retrieving journalctl logs

--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -298,17 +298,16 @@ module.exports = {
 			this.link,
 		);
 
-		this.log('Waiting for device to be reachable');
-		await this.utils.waitUntil(async () => {
-			this.log("Trying to ssh into device");
-			let hostname = await this.context
-			.get()
-			.worker.executeCommandInHostOS(
-			  "cat /etc/hostname",
-			  this.link
-			)
-			return (hostname === this.link.split('.')[0])
-		}, true);
+		await test.resolves(
+			this.utils.waitUntil(async () => {
+				let hostname = await this.worker.executeCommandInHostOS(
+				"cat /etc/hostname",
+				this.link
+				)
+				return (hostname === this.link.split('.')[0])
+			}, true),
+			`Device ${this.link} should be reachable over local SSH connection`
+		)
 
 		// Retrieving journalctl logs: register teardown after device is reachable
 		this.suite.teardown.register(async () => {

--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -293,10 +293,12 @@ module.exports = {
 		await this.worker.addSSHKey(this.sshKeyPath);
 
 		// create tunnels
-		this.log('Creating SSH tunnels to DUT');
-		await this.worker.createSSHTunnels(
-			this.link,
-		);
+		await test.resolves(
+			this.worker.createSSHTunnels(
+				this.link,
+			),
+			`Should detect ${this.link} on local network and establish tunnel`
+		)
 
 		await test.resolves(
 			this.utils.waitUntil(async () => {


### PR DESCRIPTION
There are 2 changes in this PR:

1. reword and re-organise the initial attempt at connecting to the DUT via the local SSH connection. Making this a "test" improves the logging slightly, and reports a cleaner message than the error that was thrown before. This will make it more obvious to newcomers what has happened, and includes this failure to connect within the test report
2. add a simple test to the cloud and OS suites at the beginning to confirm that the engine and supervisor are running. This is to immediately and clearly catch cases where either, in particular the supervisor, don't start and get into a healthy state. Without this, we would have to wait until the `container-healthcheck` tests to find out if the supervisor has started in the os suite- and even then, its not clear from the logs that this is what killed the test run. In the cloud suite, we would only be able to infer that the supervisor didn't start, by the device not registering as `online` in the dashboard. 

These small changes are intended to just make obvious failures a bit clearer

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
