### PR TITLE
openvpn: set auth-retry to nointeract

### DIFF
--- a/meta-balena-common/recipes-connectivity/openvpn/files/openvpn.service
+++ b/meta-balena-common/recipes-connectivity/openvpn/files/openvpn.service
@@ -12,7 +12,7 @@ RestartSec=10s
 OOMScoreAdjust=-1000
 PIDFile=/run/openvpn/openvpn.pid
 ExecStartPre=-@BASE_BINDIR@/sh -c "@BASE_BINDIR@/systemctl is-active --quiet os-config || @BASE_BINDIR@/systemctl start os-config"
-ExecStart=/usr/sbin/openvpn --writepid /run/openvpn/openvpn.pid --cd /etc/openvpn/ --config /etc/openvpn/openvpn.conf --connect-retry 5 120
+ExecStart=/usr/sbin/openvpn --writepid /run/openvpn/openvpn.pid --cd /etc/openvpn/ --config /etc/openvpn/openvpn.conf --connect-retry 5 120 --auth-retry nointeract
 
 [Install]
 Alias=openvpn-resin.service


### PR DESCRIPTION
This means that when we fail due to auth rather than exiting and always restarting after 10s it should now back off according to the connect-retry setting

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
