### PR TITLE
balena-keys: add SIGN_KMOD_KEY_APPEND

### DIFF
--- a/meta-balena-common/conf/distro/include/balena-os.inc
+++ b/meta-balena-common/conf/distro/include/balena-os.inc
@@ -129,6 +129,7 @@ SIGN_API ?= ""
 # Signing keys
 SIGN_GRUB_KEY_ID ?= "2EB29B4CE0132F6337897F5FB8A88D1C62FCC729"
 SIGN_KMOD_KEY_ID ?= "balenaos-kmod"
+SIGN_KMOD_KEY_APPEND ?= ""
 SIGN_EFI_PK_KEY_ID ?= "balenaos-pk"
 SIGN_EFI_KEK_KEY_ID ?= "balenaos-kek"
 


### PR DESCRIPTION
This variable accepts the base64 encoded public key of a kernel module signing keypair and appends it to the list of trusted keys the kernel will use to validate signed modules. Multiple keys may be appended, delimited with a semicolon.

A PEM file can be used like so:

```
SIGN_KMOD_KEY_APPEND="$( sed -e '/-----BEGIN CERTIFICATE-----/d' \
                             -e 's/-----END CERTIFICATE-----/;/g' \
                             -e '$d' signing_key.pem \
                         | tr -d '\n' )"

balena-yocto-scripts/build/balena-build.sh \
    -g "-a SIGN_KMOD_KEY_APPEND=${SIGN_KMOD_KEY_APPEND}" \
    ...
```

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
