### PR TITLE
mkfs-hostapp-native: Update base image in Dockerfile

### DIFF
--- a/meta-balena-common/recipes-containers/mkfs-hostapp-native/files/Dockerfile
+++ b/meta-balena-common/recipes-containers/mkfs-hostapp-native/files/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 
 VOLUME /mnt/sysroot/inactive
 


### PR DESCRIPTION
Update Dockerfile base image from debian strech to the latest stable debian bullseye to fix mkfs-hostapp-native build.

The old image has been moved in Dockerhub to debian/eol.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
