### PR TITLE
tests: use deviceType contract to determine network config

### DIFF
--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -131,22 +131,41 @@ module.exports = {
     });
 
     // Network definitions - these are given to the testbot via the config sent via the config.js
-    if (this.suite.options.balenaOS.network.wired === true) {
-      this.suite.options.balenaOS.network.wired = {
-        nat: true,
-      };
-    } else {
-      delete this.suite.options.balenaOS.network.wired;
-    }
-    if (this.suite.options.balenaOS.network.wireless === true) {
-      this.suite.options.balenaOS.network.wireless = {
-        ssid: this.suite.options.id,
-        psk: `${this.suite.options.id}_psk`,
-        nat: true,
-      };
-    } else {
-      delete this.suite.options.balenaOS.network.wireless;
-    }
+    // If suites config.js has networkWired: true, override the device contract
+		if (this.suite.options.balenaOS.network.wired === true) {
+			this.suite.options.balenaOS.network.wired = {
+				nat: true,
+			};
+		} else if(this.suite.deviceType.data.connectivity.wifi === false){
+			// DUT has no wifi - use wired ethernet sharing to connect to DUT
+			this.suite.options.balenaOS.network.wired = {
+				nat: true,
+			};
+		} 
+		else {
+			// device has wifi, use wifi hotspot to connect to DUT
+			delete this.suite.options.balenaOS.network.wired;
+		}
+
+		// If suites config.js has networkWireless: true, override the device contract
+		if (this.suite.options.balenaOS.network.wireless === true) {
+			this.suite.options.balenaOS.network.wireless = {
+				ssid: this.suite.options.id,
+				psk: `${this.suite.options.id}_psk`,
+				nat: true,
+			};
+		} else if(this.suite.deviceType.data.connectivity.wifi === true){
+			// device has wifi, use wifi hotspot to connect to DUT
+			this.suite.options.balenaOS.network.wireless = {
+				ssid: this.suite.options.id,
+				psk: `${this.suite.options.id}_psk`,
+				nat: true,
+			};
+		} 
+		else {
+			// no wifi on DUT
+			delete this.suite.options.balenaOS.network.wireless;
+		}
 
     // Authenticating balenaSDK
     await this.context

--- a/tests/suites/config.js
+++ b/tests/suites/config.js
@@ -4,7 +4,7 @@ module.exports = [
 	suite: `${__dirname}/../suites/hup`,
 	config: {
 		networkWired: false,
-		networkWireless: process.env.WORKER_TYPE === 'qemu' ? false : true,
+		networkWireless: false,
 		downloadVersion: 'latest',
 		balenaApiKey: process.env.BALENACLOUD_API_KEY,
 		balenaApiUrl: 'balena-cloud.com',
@@ -31,7 +31,7 @@ module.exports = [
 	suite: `${__dirname}/../suites/cloud`,
 	config: {
 		networkWired: false,
-		networkWireless: process.env.WORKER_TYPE === 'qemu' ? false : true,
+		networkWireless: false,
 		balenaApiKey: process.env.BALENACLOUD_API_KEY,
 		balenaApiUrl: 'balena-cloud.com',
 		organization: process.env.BALENACLOUD_ORG,
@@ -57,7 +57,7 @@ module.exports = [
 	suite: `${__dirname}/../suites/os`,
 	config: {
 		networkWired: false,
-		networkWireless: process.env.WORKER_TYPE === 'qemu' ? false : true,
+		networkWireless: false,
 		balenaApiKey: process.env.BALENACLOUD_API_KEY,
 		balenaApiUrl: 'balena-cloud.com',
 		organization: process.env.BALENACLOUD_ORG,

--- a/tests/suites/hup/suite.js
+++ b/tests/suites/hup/suite.js
@@ -262,20 +262,39 @@ module.exports = {
 		console.log(this.suite.options)
 
 		// Network definitions
+		// If suites config.js has networkWired: true, override the device contract
 		if (this.suite.options.balenaOS.network.wired === true) {
 			this.suite.options.balenaOS.network.wired = {
 				nat: true,
 			};
-		} else {
+		} else if(this.suite.deviceType.data.connectivity.wifi === false){
+			// DUT has no wifi - use wired ethernet sharing to connect to DUT
+			this.suite.options.balenaOS.network.wired = {
+				nat: true,
+			};
+		} 
+		else {
+			// device has wifi, use wifi hotspot to connect to DUT
 			delete this.suite.options.balenaOS.network.wired;
 		}
+
+		// If suites config.js has networkWireless: true, override the device contract
 		if (this.suite.options.balenaOS.network.wireless === true) {
 			this.suite.options.balenaOS.network.wireless = {
 				ssid: this.suite.options.id,
 				psk: `${this.suite.options.id}_psk`,
 				nat: true,
 			};
-		} else {
+		} else if(this.suite.deviceType.data.connectivity.wifi === true){
+			// device has wifi, use wifi hotspot to connect to DUT
+			this.suite.options.balenaOS.network.wireless = {
+				ssid: this.suite.options.id,
+				psk: `${this.suite.options.id}_psk`,
+				nat: true,
+			};
+		} 
+		else {
+			// no wifi on DUT
 			delete this.suite.options.balenaOS.network.wireless;
 		}
 

--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -216,20 +216,39 @@ module.exports = {
 		});
 
 		// Network definitions - here we check what network configuration is selected for the DUT for the suite, and add the appropriate configuration options (e.g wifi credentials)
+		// If suites config.js has networkWired: true, override the device contract
 		if (this.suite.options.balenaOS.network.wired === true) {
 			this.suite.options.balenaOS.network.wired = {
 				nat: true,
 			};
-		} else {
+		} else if(this.suite.deviceType.data.connectivity.wifi === false){
+			// DUT has no wifi - use wired ethernet sharing to connect to DUT
+			this.suite.options.balenaOS.network.wired = {
+				nat: true,
+			};
+		} 
+		else {
+			// device has wifi, use wifi hotspot to connect to DUT
 			delete this.suite.options.balenaOS.network.wired;
 		}
+
+		// If suites config.js has networkWireless: true, override the device contract
 		if (this.suite.options.balenaOS.network.wireless === true) {
 			this.suite.options.balenaOS.network.wireless = {
 				ssid: this.suite.options.id,
 				psk: `${this.suite.options.id}_psk`,
 				nat: true,
 			};
-		} else {
+		} else if(this.suite.deviceType.data.connectivity.wifi === true){
+			// device has wifi, use wifi hotspot to connect to DUT
+			this.suite.options.balenaOS.network.wireless = {
+				ssid: this.suite.options.id,
+				psk: `${this.suite.options.id}_psk`,
+				nat: true,
+			};
+		} 
+		else {
+			// no wifi on DUT
 			delete this.suite.options.balenaOS.network.wireless;
 		}
 


### PR DESCRIPTION
At the moment we use the `networkWired` and `networkWireless` attributes in the suites config.js to determine whether or not to access the DUT via wifi or ethernet. 

We have this hard coded to be wifi in meta balena. So we are blocked when running tests on devices with ethernet only (without using a usb wifi dongle as we've done in the past). So this PR:

- sets the default config.js `networkWired` and `networkWireless` in this repo, which is used in jenkins, to false
- the test suite checks the devicetype contract to determine whether or not to use wifi or ethernet
- setting `networkWired` or `networkWireless` to true in the config.js overrides the contract - which is useful for debugging connectivity issues
- dependant on this PR: https://github.com/balena-os/leviathan-worker/pull/64 - which was made to stop qemu worker crashing when `networkWireless: true`, even though its an unused setting
- setting as draft to test on real hardware before any merging happens
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
