### PR TITLE
resin-init-flasher: check that commands exist before calling

### DIFF
--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -62,7 +62,8 @@ trap clean ERR
 function report_progress() {
     _ratio="${1}"
     _msg="${2}"
-    if [ -n "${API_ENDPOINT}" ]; then
+
+    if command -v "resin-device-progress"  > /dev/null && [ -n "${API_ENDPOINT}" ]; then
         resin-device-progress --percentage "${_ratio}" --state "${_msg}" || true
     else
         info "Unprovisioned: Percentage ${_ratio}, status ${_msg}"


### PR DESCRIPTION
When running in the initramfs, the resin-device-progress package is not installed as we cannot guarantee that the initramfs would be able to bring up all types of network interfaces.

This commit adds a check for the script to exists instead of getting a `command not found` when an API endpoint is defined.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
