### PR TITLE
initrdscripts: give the root device a chance to come up before cryptsetup

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup
+++ b/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup
@@ -5,6 +5,13 @@
 . /usr/libexec/os-helpers-fs
 . /usr/libexec/os-helpers-tpm2
 
+# Give a chance to the by-state directory to appear
+# We do not expect any particular device or partition to come up
+# but if balenaOS is correctly configured on the device the by-state
+# directory will eventually be created by the custom udev rule.
+# This is useful if the rootfs is on a device that takes a while
+# to initialize such as a USB disk.
+wait4file "/dev/disk/by-state" "50"
 EFI_DEV=$(get_state_path_from_label "balena-efi")
 
 wait4udev() {


### PR DESCRIPTION
At this moment if the cryptsetup initrd script executes before the root device comes up (e.g. when booting off a USB disk), it assumes that encryption is not in place because it was not able to find the EFI partition.

This patch adds a wait4file loop to the script that waits for the /dev/disk/by-state directory. This is not tied to any particular partition or device but since the directory does not exist by default and is only created by a custom balenaOS udev rule, its existence implies that the rule fired and a device with balenaOS partitions is present in the system.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
