### PR TITLE
kernel-balena: add signing key to modules input chain

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -1060,6 +1060,7 @@ do_configure[depends] += "${@oe.utils.conditional('SIGN_API','','',' balena-keys
 do_compile[deptask] += "do_kernel_resin_checkconfig"
 # Remove kernel module certificates generated during previous build
 do_configure[cleandirs] += "${@oe.utils.conditional('SIGN_API','','','${B}',d)}"
+do_compile_kernelmodules[file-checksums] += "${@oe.utils.conditional('SIGN_API','','','${STAGING_KERNEL_BUILDDIR}/certs/signing_key.pem:True',d)}"
 do_configure[vardeps] += " \
     SIGN_API \
     "


### PR DESCRIPTION
We have seen cases when using state cache with multiple parallel builds were the kernel modules in the state cache are unchanged even though a new kernel has been rebuilt.

The hypothesis that this tries to solve is that there is a window between a new kernel build and a rebuild of the corresponding kernel modules where the new kernel is used with the old state cached modules as the input chain has not changed.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
