### PR TITLE
flasher: make secure boot provisioning more robust

### DIFF
--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -444,6 +444,12 @@ fi
 
 if [ "$LUKS" = "1" ]; then
     # Split EFI and boot partitions
+
+    # We want to keep the paths identical with the devices that do not have
+    # the split. On the newly provisioned OS the efi and boot partitions will
+    # be mounted under /mnt/efi and /mnt/boot respectively, but OS tools
+    # expect everything to be under /mnt/boot. Symlink /mnt/boot/EFI to
+    # ../efi/EFI so that /mnt/boot/EFI/ points to the correct directory.
     EFI_MOUNT_DIR="$INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT/../efi"
     mkdir -p "$EFI_MOUNT_DIR"
     EFI_MOUNT=$(get_dev_path_in_device_with_label "${internal_dev}" balena-efi)
@@ -454,6 +460,9 @@ if [ "$LUKS" = "1" ]; then
     ln -s "../efi/EFI" "$INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT/EFI"
 
     # Move all non-EFI files to boot partition
+    # Only keep /EFI directory on the efi partition, everything else
+    # e.g. config.json, system-connections etc. goes to the encrypted
+    # boot partition
     for FILE in "$EFI_MOUNT_DIR/"*; do
         if [ "$FILE" = "$EFI_MOUNT_DIR/EFI" ]; then
             continue
@@ -461,6 +470,9 @@ if [ "$LUKS" = "1" ]; then
 
         mv "$FILE" "$INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT/"
     done
+
+    # At this point the efi partition should only have the /EFI directory,
+    # let's add the rest of the files necessary to boot and unlock the partitions
 
     # Store files necessary for TPM decryption to the EFI partitions
     mv "$TPM_RESULT_DIR/persistent.ctx" "$EFI_MOUNT_DIR/balena-luks.ctx" && sync
@@ -473,6 +485,7 @@ if [ "$LUKS" = "1" ]; then
     # TODO: Remove or replace by a proper stage2 bootloader when that is ready
     find / -xdev -type f -name "bzImage*" -exec cp -a {} "${EFI_MOUNT_DIR}" +
 
+    # We have a separate grub.cfg for encrypted devices, use it
     if [ -f "$EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT/$INTERNAL_DEVICE_BOOTLOADER_CONFIG_LUKS" ]; then
         INTERNAL_DEVICE_BOOTLOADER_CONFIG="$INTERNAL_DEVICE_BOOTLOADER_CONFIG_LUKS"
     fi

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -45,6 +45,8 @@ LUKS=0
 EFI=0
 EFIVARS_MOUNTDIR="/sys/firmware/efi/efivars"
 SECUREBOOT_ENABLED=0
+BOOT_ENTRY_LABEL="balenaOS"
+LOADER_PATH="/EFI/BOOT/bootx64.efi"
 
 . /usr/libexec/os-helpers-fs
 . /usr/libexec/os-helpers-logging
@@ -241,9 +243,17 @@ if [ -d /sys/firmware/efi ]; then
             if [ "${SETUPMODE_VAR}" -eq "1" ]; then
                 # Setting up keys hasn't disabled setup mode, try a reboot into flasher
                 info "Rebooting flasher after secure mode setup to boot in secure boot mode."
-                # Make sure to reboot into the installer
-                bootcurrent=$(efibootmgr | grep BootCurrent | awk '{print $2}')
-                efibootmgr -n "${bootcurrent}"
+
+                # Create a one-time boot entry for signed flasher
+                # By default flasher is unsigned, after programming the keys we want to boot
+                # into a properly signed flasher as we expect secure boot to be enabled.
+                flasher_boot=$(findmnt --noheadings --canonicalize --output SOURCE /mnt/boot)
+                efibootmgr --create \
+                   --disk "/dev/$(lsblk -nlo pkname ${flasher_boot})" \
+                   --part "$(lsblk -nlo maj:min ${flasher_boot} | cut -d: -f2)" \
+                   --label "${BOOT_ENTRY_LABEL} installer with secure boot" \
+                   --loader "${LOADER_PATH}.secureboot"
+
                 sync
                 reboot -f
             fi
@@ -572,22 +582,18 @@ umount $INTERNAL_DEVICE_BOOT_PART_MOUNTPOINT
 sync
 
 EFIPART_LABEL="resin-boot"
-LOADER_PATH="/EFI/BOOT/bootx64.efi"
-BOOT_ENTRY_LABEL="balenaOS"
 if [ "$EFI" = "1" ]; then
     if [ "$LUKS" = "1" ]; then
         EFIPART_LABEL=balena-efi
     fi
 
     # remove duplicate entries
+    # this will also remove the temporary secure boot installer entry
     for label in resinOS "${BOOT_ENTRY_LABEL}"; do
-        duplicates="$(efibootmgr \
-		| grep "${label}" \
-		| sed 's/Boot*//g' \
-		| sed "s/* ${label}//g")"
+        duplicates="$(efibootmgr | grep "${label}" | sed -e "s/^Boot\([0-9a-fA-F]*\).*$/\1/")"
         for entry in ${duplicates}; do
             efibootmgr -B -b "${entry}"
-	done
+        done
     done
 
     efibootmgr --create \

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -218,8 +218,21 @@ if [ -d /sys/firmware/efi ]; then
             for e in db KEK PK; do
                 # Remove immutable attribute
                 chattr -i ${EFIVARS_MOUNTDIR}/${e}* > /dev/null || true
-                if [ -f "${EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/balena-keys/${e}.auth" ]; then
-                    /usr/bin/efi-updatevar -f "${EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/balena-keys/${e}.auth" "${e}"
+
+                # Use the .esl format for db. This only works in setup mode and above we have confirmed
+                # it is enabled. The .auth files are signed for appending during updates
+                # and while most UEFI implementations don't care, some of them will only allow
+                # to actually append. Here we want to replace the existing keys by ours.
+                FORMAT="auth"
+                EXTRA_ARGS=""
+                if [ "${e}" = "db" ]; then
+                    FORMAT="esl"
+                    EXTRA_ARGS="-e"
+                fi
+
+                KEY_FILE="${EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/balena-keys/${e}.${FORMAT}"
+                if [ -f "${KEY_FILE}" ]; then
+                    /usr/bin/efi-updatevar ${EXTRA_ARGS} -f "${KEY_FILE}" "${e}"
                 fi
             done
             # Check that we're in user mode


### PR DESCRIPTION
This fixes corner cases discovered while testing on a variety of HW. It should make more HW work with secure boot out of box.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
