### PR TITLE
kernel-balena: do not use cache for signed kernel modules

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -1109,6 +1109,10 @@ do_sign_gpg:append () {
     done
 }
 
+# Parallel builds sharing state cache will mismatch singed kernel and modules
+# Avoid using cache for signed kernel modules to avoid this
+do_compile_kernelmodules[nostamp] = "${@oe.utils.conditional('SIGN_API','','','1',d)}"
+
 do_deploy:prepend () {
     SIGNING_ARTIFACTS="${SIGNING_ARTIFACTS_BASE}"
 }


### PR DESCRIPTION
On parallel builds that share a state cache there are mismatches between a signed kernel and modules. Avoid using the cache when building signed modules to avoid this mismatch.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
