### PR TITLE
os-helpers: do not fail build if API tests fail

### DIFF
--- a/meta-balena-common/recipes-support/os-helpers/os-helpers.bb
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers.bb
@@ -54,15 +54,15 @@ do_test_api() {
     . ${WORKDIR}/os-helpers-api
     # GET 200
     if ! api_get_request "${endpoint}/ping"; then
-        bberror "${PN}: API request failed "
+        bbwarn "${PN}: API request failed "
     fi
     # 404 Not found
     if api_get_request "${endpoint}/notfound"; then
-        bberror "API request unexpectedly suceeded"
+        bbwarn "API request unexpectedly suceeded"
     fi
     # 401 Unauthorized
     if api_get_request "${endpoint}/v6/device"; then
-        bberror "API request unexpectedly suceeded"
+        bbwarn "API request unexpectedly suceeded"
     fi
 }
 addtask test_api before do_package after do_install


### PR DESCRIPTION
The purpose of testing the API calls is to detect breaking changes, not to fail builds because of temporary network or API access problems.

Printing a warning instead should be enough for developers to detect breaking changes.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
