### PR TITLE
resin-init-flasher: Format encrypted partitions as LUKS2

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup
+++ b/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup
@@ -46,6 +46,17 @@ wait4udev() {
     return 0
 }
 
+ensure_luks2() {
+    LUKS_DEVICE="$1"
+
+    LUKS_VERSION=$(cryptsetup luksDump "${LUKS_DEVICE}" | grep "^Version:" | cut -f 2)
+
+    if [ "${LUKS_VERSION}" = 1 ]; then
+        info "Converting ${LUKS_DEVICE} to LUKS2"
+        cryptsetup convert -q --type luks2 "${LUKS_DEVICE}"
+    fi
+}
+
 cryptsetup_enabled() {
     # Flasher should not try to unlock the partitions
     if [ "$bootparam_flasher" = "true" ]; then
@@ -110,6 +121,7 @@ cryptsetup_run() {
     # and wait for them in a separate loop later
     LUKS_UNLOCKED=""
     for LUKS_UUID in $(lsblk -nlo uuid,fstype "/dev/${BOOT_DEVICE}" | grep crypto_LUKS | cut -d " " -f 1); do
+        ensure_luks2 "/dev/disk/by-uuid/${LUKS_UUID}"
         cryptsetup luksOpen --key-file $PASSPHRASE_FILE UUID="${LUKS_UUID}" luks-"${LUKS_UUID}"
         LUKS_UNLOCKED="${LUKS_UNLOCKED} luks-${LUKS_UUID}"
     done

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -369,7 +369,7 @@ if [ "$LUKS" = "1" ]; then
 
         PART_DEV="$internal_dev$PART_PREFIX$INTERNAL_PART_ID"
         info "Encrypting $PART_DEV"
-        cryptsetup -q luksFormat "$PART_DEV" "$PASSPHRASE_FILE"
+        cryptsetup -q luksFormat --type luks2 "$PART_DEV" "$PASSPHRASE_FILE"
         cryptsetup luksOpen "$PART_DEV" "$PART_NAME" --key-file "$PASSPHRASE_FILE"
         DM_DEV="/dev/mapper/$PART_NAME"
         if [ "$PART_NAME" = "resin-boot" ]; then


### PR DESCRIPTION
This should be the default but with no explicit argument we still end up with LUKS1 partitions. This patch adds the parameter to enforce LUKS2 formatting.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
