### PR TITLE
resin-init-flasher: Set the temporary secure boot entry as BootNext

### DIFF
--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -255,6 +255,14 @@ if [ -d /sys/firmware/efi ]; then
                    --label "${BOOT_ENTRY_LABEL} installer with secure boot" \
                    --loader "${LOADER_PATH}.secureboot"
 
+                # Find the newly created entry and set it as BootNext
+                # Some systems do not respect the UEFI boot order so even if "efibootmgr --create"
+                # makes the new entry first in the boot order, such systems will still try to boot
+                # something else. Because we enabled secure boot, this would trigger a security violation.
+                boot_uuid="$(lsblk -nlo partuuid "${flasher_boot}")"
+                new_entry="$(efibootmgr -v | grep "${boot_uuid}" | grep -i "${LOADER_PATH}.secureboot" | head -n 1 | sed -e "s/^Boot\([0-9a-fA-F]*\).*$/\1/")"
+                efibootmgr -n "${new_entry}"
+
                 sync
                 reboot -f
             fi


### PR DESCRIPTION
`efibootmgr --create` should make the newly created entry first in the boot order but we have seen some devices ignore this altogether and try to boot something else, which in our case causes a security violation since we enrolled secure boot keys and need to boot into a secure flasher after reboot.

This patch sets the newly created boot entry into BootNext variable which should be respected by the firmware as a temporary boot target.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
