### PR TITLE
common: create KERNEL_HEADERS_PACKAGES var

### DIFF
--- a/meta-balena-common/classes/image-balena.bbclass
+++ b/meta-balena-common/classes/image-balena.bbclass
@@ -6,7 +6,7 @@ inherit image_types_balena kernel-balena-noimage
 
 # When building a Balena OS image, we also generate the kernel modules headers
 # and ship them in the deploy directory for out-of-tree kernel modules build
-DEPENDS += "coreutils-native jq-native ${@bb.utils.contains('BALENA_DISABLE_KERNEL_HEADERS', '1', '', 'kernel-modules-headers kernel-devsrc kernel-headers-test', d)}"
+DEPENDS += "${@bb.utils.contains('BALENA_DISABLE_KERNEL_HEADERS', '1', '', 'coreutils-native jq-native ${KERNEL_HEADERS_PACKAGES}', d)}"
 
 # Deploy the license.manifest of the current image we baked
 deploy_image_license_manifest () {

--- a/meta-balena-common/conf/distro/include/balena-os.inc
+++ b/meta-balena-common/conf/distro/include/balena-os.inc
@@ -89,6 +89,8 @@ INITRAMFS_IMAGE_BUNDLE = "1"
 KERNEL_INITRAMFS = "-initramfs"
 INITRAMFS_TASK = ""
 
+KERNEL_HEADERS_PACKAGES ?= "kernel-modules-headers kernel-devsrc kernel-headers-test"
+
 # resinOS defaults to ipk packages
 PACKAGE_CLASSES ?= "package_ipk"
 

--- a/meta-balena-common/recipes-kernel/linux/kernel-devsrc.bbappend
+++ b/meta-balena-common/recipes-kernel/linux/kernel-devsrc.bbappend
@@ -16,4 +16,4 @@ INSANE_SKIP:${PN} = "arch debug-files"
 # kernel-modules-headers recipe does some work on the kernel tree.
 # We'd like to make sure that we dont tarball at the same time as that
 # recipe is working on the tree
-DEPENDS += "kernel-modules-headers"
+DEPENDS += "${@bb.utils.contains('KERNEL_HEADERS_PACKAGES', 'kernel-modules-headers', 'kernel-modules-headers', '', d)}"


### PR DESCRIPTION
Allow device repositories to modify the packages built to supply kernel headers. This can be used to disable building kernel-modules-headers in favor of just kernel-devsrc in cases where the former is broken.

Change-type: patch

Relates to: https://github.com/balena-os/balena-generic/pull/244

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
