### PR TITLE
Skip boot switch check for imx8mm-var-dart-plt

### DIFF
--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -37,6 +37,7 @@ const flasherConfig = (deviceType) => {
 	return (
 		[
 			'imx8mmebcrs08a2',
+			'imx8mm-var-dart-plt',
 		].includes(deviceType)
 	);
 }

--- a/tests/suites/hup/suite.js
+++ b/tests/suites/hup/suite.js
@@ -38,6 +38,7 @@ const flasherConfig = (deviceType) => {
 	return (
 		[
 			'imx8mmebcrs08a2',
+			'imx8mm-var-dart-plt',
 		].includes(deviceType)
 	);
 }

--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -38,6 +38,7 @@ const flasherConfig = (deviceType) => {
 	return (
 		[
 			'imx8mmebcrs08a2',
+			'imx8mm-var-dart-plt',
 		].includes(deviceType)
 	);
 }


### PR DESCRIPTION
This DT is similar to the ebcrs08a2, which uses a u-boot check for the boot switch to skip provisioning.


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested - manually
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
