### PR TITLE
bail out in kexec initramfs hook on failure

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/kexec
+++ b/meta-balena-common/recipes-core/initrdscripts/files/kexec
@@ -34,5 +34,5 @@ kexec_run() {
 
     umount "${ROOTFS_DIR}"
 
-    kexec -e
+    kexec -e || fail "kexec failed with $?, abort"
 }


### PR DESCRIPTION
Kexec is used to boot into the decrypted kernel in the hostapp on systems with secure boot and full-disk encryption.

If kexec fails, we don't want to continue with the rest of the boot process in the first stage kernel, so bail out on failure.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
