### PR TITLE
resin-init-flasher: Allow background device registration

### DIFF
--- a/meta-balena-common/recipes-support/resin-device-register/resin-device-register/resin-device-register
+++ b/meta-balena-common/recipes-support/resin-device-register/resin-device-register/resin-device-register
@@ -48,7 +48,7 @@ if [ -z "$API_ENDPOINT" ] || [ -z "$CONFIG_PATH" ]; then
     exit 1
 fi
 
-for retries in {1..3}; do
+while true; do
     if curl -sL -w '%{http_code}' "$API_ENDPOINT"/ping -o /dev/null | egrep "20[0-9]|30[0-9]" >/dev/null
     then
         if [ -n "${REGISTERED_AT}" ]; then

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -157,12 +157,12 @@ STARTTIME=$(date +%s)
 ENDTIME="$STARTTIME"
 TIMEOUT=15
 if command -v "systemctl"; then
-    while [ "$(systemctl is-active openvpn)" != "active" ]
+    while [ "$(systemctl is-active openvpn)" != "active" ] && [ "$(systemctl is-active resin-device-register)" != "active" ]
     do
         if [ $((ENDTIME - STARTTIME)) -le $TIMEOUT ]; then
             sleep 1 && ENDTIME=$((ENDTIME + 1))
         else
-            info "Timeout while waiting for openvpn to come alive. No network?"
+            info "Timeout while waiting for openvpn to come alive and the device to register. No network?"
             break
         fi
     done
@@ -562,22 +562,6 @@ if [ "${EFI}" = "1" ]; then
         else
             # This can safely fail if the secure boot variant does not exist
             rm -f "${EFI_BINARY_SECUREBOOT}" || :
-        fi
-    done
-fi
-
-# Give a chance for the device to register
-STARTTIME=$(date +%s)
-ENDTIME="$STARTTIME"
-TIMEOUT=10
-if command -v "systemctl"; then
-    while [ "$(systemctl is-active resin-device-register.service)" != "active" ]
-    do
-        if [ $((ENDTIME - STARTTIME)) -le $TIMEOUT ]; then
-            sleep 1 && ENDTIME=$((ENDTIME + 1))
-        else
-            info "Timeout while waiting for register to finish. No network?"
-            break
         fi
     done
 fi

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher.service
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Resin init flasher service
 Requires=mnt-boot.mount
-Wants=resin-device-register.service
-After=mnt-boot.mount resin-device-register.service
+Wants=resin-device-register.service openvpn.service
+After=mnt-boot.mount
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
314047e and b5c5214 made flasher block until the resin-device-register service exits and made resin-device-register give up after 6 seconds not to block infinitely when no network is available. This effectively means that if the device fails to register within first 6 seconds, it will never retry, flasher will not report status to the dashboard and the device will only register on first boot.

This patch changes the logic back to resin-device-register trying in the background in an infinite loop and moves the "give the device a chance to register" delay to flasher itself. It also extends the wait to openvpn as flasher already does that and wants VPN to run to be debuggable - in case flashing fails, it would be possible to SSH in via the VPN and look at the logs remotely.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
