### PR TITLE
initrdscripts: make initramfs-module-cryptsetup pull libgcc in

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -78,7 +78,7 @@ RDEPENDS:initramfs-module-fsuuidsinit = "${PN}-base"
 FILES:initramfs-module-fsuuidsinit = "/init.d/75-fsuuidsinit"
 
 SUMMARY:initramfs-module-cryptsetup = "Unlock encrypted partitions"
-RDEPENDS:initramfs-module-cryptsetup = "${PN}-base cryptsetup lvm2-udevrules os-helpers-logging os-helpers-fs os-helpers-tpm2"
+RDEPENDS:initramfs-module-cryptsetup = "${PN}-base cryptsetup libgcc lvm2-udevrules os-helpers-logging os-helpers-fs os-helpers-tpm2"
 FILES:initramfs-module-cryptsetup = "/init.d/72-cryptsetup"
 
 SUMMARY:initramfs-module-kexec = "Find and start a new kernel if in stage2"


### PR DESCRIPTION
cryptsetup lazily depends on libgcc. With libgcc missing, certain operations, especially luksOpen will fail with
`libgcc_s.so.1 must be installed for pthread_exit to work` which panics the kernel and triggers a reboot loop indistinguishable from a "device has been tampered with" state on regular builds with no console output.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
