### PR TITLE
kernel-balena: remove mispelled config setting

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -449,7 +449,6 @@ BALENA_CONFIGS[xtables] = " \
 # Deactivate the audit susbsystem and the audit syscall
 BALENA_CONFIGS_DEPS[audit] = " \
     CONFIG_HAVE_AUDITSYSCALL=n \
-    CONIFG_SECURITY=n \
     "
 
 BALENA_CONFIGS[audit] = " \


### PR DESCRIPTION
The kernel-balena class contains:
CONIFG_SECURITY=n

which is mispelled and not being applied. The commit where this was introduced claims it's needed to completely disable the audit logs, and also that the security framework is unused.

I disagree in that it's unused - the hostOS is not using any security framework, but applications may, so luckily the security framework was never disabled.

Removing this mispelled entry should have no functional effect. Whether the audit subsystem is disabled will depend on the final kernel configuration. Definitely we have not seen a need to disable it recently, and we have not seen the kernel log flooded with messages.

I'd argue the disabling of the audit subsystem in meta-balena serves no need but I also have no specific reason to remove it at the moment.

Fixes #2947

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
