### PR TITLE
hostapp-update: bind-mount /sys for Jetson efivars

### DIFF
--- a/meta-balena-common/recipes-containers/hostapp-update/files/hostapp-update
+++ b/meta-balena-common/recipes-containers/hostapp-update/files/hostapp-update
@@ -127,7 +127,7 @@ if [ "$hooks" = 1 ]; then
 	umount $new_rootfs
 
 	# Run the defined hooks in the host OS we update to in new OS environment
-	if balena run --privileged --rm -v /dev:/dev -v /mnt:/mnt -e DURING_UPDATE=1 "$HOSTAPP_IMAGE" hostapp-update-hooks; then
+	if balena run --privileged --rm -v /dev:/dev -v /mnt:/mnt -v /sys:/sys -e DURING_UPDATE=1 "$HOSTAPP_IMAGE" hostapp-update-hooks; then
 		echo "New/Forward hooks (new os container) ran successfully."
 	else
 		run_current_hooks_and_recover


### PR DESCRIPTION
The hostapp-update hooks for UEFI capsule updates
need to create and update the contents of some platform specific efi variables inside the /sys directory, and thus we need to bindmount this directory in the hostapp-update script for internal testing as well as in balenahup for api triggered updates.

Change-type: patch

Tested on AGX Orin Devkit

Connects-to: https://github.com/balena-os/balena-jetson-orin/pull/238

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
