### PR TITLE
tests: os: engine healthcheck: increase allowed time

### DIFF
--- a/tests/suites/os/tests/engine-healthcheck/index.js
+++ b/tests/suites/os/tests/engine-healthcheck/index.js
@@ -168,7 +168,7 @@ module.exports = {
 				// the old healthcheck on a Pi 3 (10.7s) and the new healthcheck
 				// on a Pi Zero (4.5s) -- rounded up to make false positives
 				// less likely.
-				const limitSecs = 8.0;
+				const limitSecs = 10.0;
 				test.ok(
 					Number(result) < limitSecs,
 					`Healthchecks should run in less than ${limitSecs}s, took ${result}s`


### PR DESCRIPTION
This test has failed multiple times now on slow devices, pi 0 W, and generic-aarch64 (emulated without kvm) - usually with a time of around 9 seconds. Increase to 10  - let me know if this defeats the purpose of the test completely however

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
