### PR TITLE
linux/kernel-devsrc: Fix aarch64 kernel-headers-test build

### DIFF
--- a/meta-balena-kirkstone/recipes-kernel/linux/kernel-devsrc.bbappend
+++ b/meta-balena-kirkstone/recipes-kernel/linux/kernel-devsrc.bbappend
@@ -8,6 +8,11 @@ do_install:append() {
 	if [ "${ARCH}" = "arm64" ]; then
 	    # v6.1+
 	    cp -a --parents arch/arm64/kernel/asm-offsets.c $kerneldir/build/
+            cp -a --parents arch/arm64/tools/gen-sysreg.awk $kerneldir/build/ 2>/dev/null || :
+            cp -a --parents arch/arm64/tools/sysreg $kerneldir/build/ 2>/dev/null || :
+            if [ -e $kerneldir/build/arch/arm64/tools/gen-sysreg.awk ]; then
+                 sed -i -e "s,#!.*awk.*,#!${USRBINPATH}/env awk," $kerneldir/build/arch/arm64/tools/gen-sysreg.awk
+            fi
 	fi
 
 	if [ "${ARCH}" = "powerpc" ]; then
@@ -25,6 +30,7 @@ do_install:append() {
             # v6.1+
             cp -a --parents arch/arm/kernel/asm-offsets.c $kerneldir/build/ 2>/dev/null || :
             cp -a --parents arch/arm/kernel/signal.h $kerneldir/build/ 2>/dev/null || :
+            cp -a --parents arch/arm/tools/gen-sysreg.awk $kerneldir/build/ 2>/dev/null || :
 	fi
 
 	if [ "${ARCH}" = "x86" ]; then


### PR DESCRIPTION
This fix has been ported from the following upstream change: https://patchwork.yoctoproject.org/project/oe-core/patch/002c31d6add77e1002fb1ccd4050ce826a654170.1659653543.git.bruce.ashfield@gmail.com/ and fixes the following compilation error on generic-aarch64:

    make[1]: *** No rule to make target 'arch/arm64/tools/gen-sysreg.awk',
    needed by 'arch/arm64/include/generated/asm/sysreg-defs.h'.  Stop.

Change-type: patch

Fixes build failure for generic-aarch64 in https://github.com/balena-os/balena-generic/pull/263

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
