### PR TITLE
grub-conf: Do not hardcode the path for grub_extraenv

### DIFF
--- a/meta-balena-common/recipes-bsp/grub/grub-conf/grub.cfg_external_template
+++ b/meta-balena-common/recipes-bsp/grub/grub-conf/grub.cfg_external_template
@@ -2,7 +2,7 @@
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 insmod ext2
 insmod configfile
-source /grub/grub_extraenv
+source ${prefix}/grub_extraenv
 default=boot
 timeout=@@TIMEOUT@@
 

--- a/meta-balena-common/recipes-bsp/grub/grub-conf/grub.cfg_internal_luks_template
+++ b/meta-balena-common/recipes-bsp/grub/grub-conf/grub.cfg_internal_luks_template
@@ -11,7 +11,6 @@ insmod configfile
 timeout=@@TIMEOUT@@
 
 load_env --skip-sig bootcount resin_root_part upgrade_available
-source /grub/grub_extraenv
 
 if [ ${upgrade_available} = 1 ] ; then
  if [ ${bootcount} = 1 ] ; then

--- a/meta-balena-common/recipes-bsp/grub/grub-conf/grub.cfg_internal_template
+++ b/meta-balena-common/recipes-bsp/grub/grub-conf/grub.cfg_internal_template
@@ -11,7 +11,7 @@ insmod configfile
 timeout=@@TIMEOUT@@
 
 load_env --skip-sig bootcount resin_root_part upgrade_available
-source /grub/grub_extraenv
+source ${prefix}/grub_extraenv
 
 if [ ${upgrade_available} = 1 ] ; then
  if [ ${bootcount} = 1 ] ; then


### PR DESCRIPTION
At this moment `grub.cfg` sources `/grub/grub_extraenv` which works fine on MBR systems, however on EFI systems this does not work because GRUB is installed in `/EFI/BOOT/` rather than `/grub/`.

This patch replaces the hardcoded `/grub` with `${prefix}` which should expand to the appropriate directory regardless of the platform. It also removes the loading of `grub_extraenv` from the secure boot variant of the GRUB config since this would not load without a signature anyway.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
