### PR TITLE
modemmanager: Enable back AT commands through D-Bus and mmcli

### DIFF
--- a/meta-balena-common/recipes-connectivity/modemmanager/modemmanager_%.bbappend
+++ b/meta-balena-common/recipes-connectivity/modemmanager/modemmanager_%.bbappend
@@ -13,6 +13,8 @@ SRC_URI:append = " \
 
 PACKAGECONFIG:remove = "polkit"
 
+PACKAGECONFIG:append = "at"
+
 do_install:append() {
     install -d ${D}${base_libdir}/udev/rules.d/
     install -m 0644 ${WORKDIR}/77-mm-huawei-configuration.rules ${D}${base_libdir}/udev/rules.d/


### PR DESCRIPTION
That feature was lost when transitioning from autotools to meson.

Change-type: patch
Changelog-entry: Enable back ModemManager AT commands through D-Bus and	mmcli


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
