### PR TITLE
tests: os: add retry to decreasing watchdog timeout to prevent timing issues in test

### DIFF
--- a/tests/suites/os/tests/engine-healthcheck/index.js
+++ b/tests/suites/os/tests/engine-healthcheck/index.js
@@ -14,7 +14,6 @@
  */
 
 'use strict';
-
 module.exports = {
 	title: 'Engine healthcheck tests',
 	tests: [
@@ -23,8 +22,9 @@ module.exports = {
 			title: 'Engine watchdog recovery',
 			run: async function (test) {
 				// Decrease the watchdog timeout to make the test run quicker.
-				test.is(
-					await this.worker.executeCommandInHostOS(
+				await this.utils.waitUntil(async() => {
+					test.comment('Decreasing watchdog timeout...');
+					return await this.worker.executeCommandInHostOS(
 						`mkdir -p /run/systemd/system/balena.service.d &&
 						{
 							cat <<- EOF > /run/systemd/system/balena.service.d/override.conf
@@ -37,10 +37,10 @@ module.exports = {
 						echo $?
 						`,
 						this.link,
-					),
-					'0',
-					'Watchdog timeout should have been decreased',
-				);
+					) === "0";
+				}, false, 5, 500 )
+		
+				test.ok(true, 'Watchdog timeout should have been decreased');
 
 				// Make sure the Engine service is up and running.
 				test.comment('Waiting for the Engine to start');

--- a/tests/suites/os/tests/overlap_test/index.js
+++ b/tests/suites/os/tests/overlap_test/index.js
@@ -10,7 +10,7 @@ module.exports = {
 				this.link,
 			);
 
-		if (result.includes('OK')) {
+		if (!result.includes('OK')) {
 			test.comment(`not ok! - kernel - dtb overlap detected`);
 		} else {
 			test.comment(`ok - no overlap detected`);


### PR DESCRIPTION
On at least the beaglebone black, we have a timing issue on this test - the previous test manipulates the dev/prod mode of the device and there's a chance that if that action takes too long, then this test is interfered with. 

I added a retry to the first part of this test which fixes the failure. 

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
