### PR TITLE
meta-balena-thud: libmbim: use v 1.24.2

### DIFF
--- a/meta-balena-thud/conf/distro/include/balena-os-yocto-version.inc
+++ b/meta-balena-thud/conf/distro/include/balena-os-yocto-version.inc
@@ -1,1 +1,2 @@
 PREFERRED_VERSION_tpm2-tss = "3.0.3"
+PREFERRED_VERSION_libmbim = "1.24.2"

--- a/meta-balena-thud/recipes-connectivity/libmbim/libmbim_1.24.2.bb
+++ b/meta-balena-thud/recipes-connectivity/libmbim/libmbim_1.24.2.bb
@@ -1,0 +1,17 @@
+SUMMARY = "libmbim is library for talking to WWAN devices by MBIM protocol"
+DESCRIPTION = "libmbim is a glib-based library for talking to WWAN modems and devices which speak the Mobile Interface Broadband Model (MBIM) protocol"
+HOMEPAGE = "http://www.freedesktop.org/wiki/Software/libmbim/"
+LICENSE = "GPLv2 & LGPLv2.1"
+LIC_FILES_CHKSUM = " \
+    file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+    file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c \
+"
+
+DEPENDS = "glib-2.0 glib-2.0-native libgudev autoconf-archive"
+
+inherit autotools pkgconfig bash-completion gobject-introspection
+
+SRC_URI = "http://www.freedesktop.org/software/${BPN}/${BPN}-${PV}.tar.xz"
+
+SRC_URI[md5sum] = "6c2b490af87773c8446f37536e7411ac"
+SRC_URI[sha256sum] = "32198c099987849c5f442d1cbf4b6e43e645cbdbe9cfdc197b19ddd63c6981e4"


### PR DESCRIPTION
The current meta-balena libmbim is not compatible with thud's libc version.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
