### PR TITLE
patch: Make config.js independent from CI/CD runner env

### DIFF
--- a/tests/suites/config.js
+++ b/tests/suites/config.js
@@ -4,10 +4,10 @@ module.exports = [
 	suite: `${__dirname}/../suites/hup`,
 	config: {
 		networkWired: false,
-		networkWireless: false,
-		downloadVersion: 'latest',
-		balenaApiKey: process.env.BALENACLOUD_API_KEY,
-		balenaApiUrl: process.env.BALENACLOUD_API_URL,
+		networkWireless: process.env.WORKER_TYPE === 'qemu' ? false : true,
+    downloadVersion: 'latest',
+    balenaApiKey: process.env.ENVIRONMENT === 'balena-machine' ? process.env.BALENAMACHINE_API_KEY : process.env.BALENACLOUD_API_KEY,
+    balenaApiUrl: process.env.ENVIRONMENT === 'balena-machine' ? process.env.BALENAMACHINE_API_URL : process.env.BALENACLOUD_API_URL,
 		organization: process.env.BALENACLOUD_ORG,
 		sshConfig: {
 			host: process.env.BALENACLOUD_SSH_URL,
@@ -27,7 +27,7 @@ module.exports = [
 	},
 	workers: process.env.WORKER_TYPE === 'qemu' ? ['http://worker'] : {
 		balenaApplication: process.env.BALENACLOUD_APP_NAME,
-		apiKey: process.env.BALENACLOUD_API_KEY,
+		apiKey: process.env.ENVIRONMENT === 'balena-machine' ? process.env.BALENAMACHINE_API_KEY : process.env.BALENACLOUD_API_KEY,
 	},
 },
 {
@@ -35,9 +35,10 @@ module.exports = [
 	suite: `${__dirname}/../suites/cloud`,
 	config: {
 		networkWired: false,
-		networkWireless: false,
-		balenaApiKey: process.env.BALENACLOUD_API_KEY,
-		balenaApiUrl: process.env.BALENACLOUD_API_URL,
+		networkWireless: process.env.WORKER_TYPE === 'qemu' ? false : true,
+    downloadVersion: 'latest',
+    balenaApiKey: process.env.ENVIRONMENT === 'balena-machine' ? process.env.BALENAMACHINE_API_KEY : process.env.BALENACLOUD_API_KEY,
+    balenaApiUrl: process.env.ENVIRONMENT === 'balena-machine' ? process.env.BALENAMACHINE_API_URL : process.env.BALENACLOUD_API_URL,
 		organization: process.env.BALENACLOUD_ORG,
 		sshConfig: {
 			host: process.env.BALENACLOUD_SSH_URL,
@@ -57,7 +58,7 @@ module.exports = [
 	},
 	workers: process.env.WORKER_TYPE === 'qemu' ? ['http://worker'] : {
 		balenaApplication: process.env.BALENACLOUD_APP_NAME,
-		apiKey: process.env.BALENACLOUD_API_KEY,
+		apiKey: process.env.ENVIRONMENT === 'balena-machine' ? process.env.BALENAMACHINE_API_KEY : process.env.BALENACLOUD_API_KEY,
 	},
 },
 {
@@ -65,9 +66,10 @@ module.exports = [
 	suite: `${__dirname}/../suites/os`,
 	config: {
 		networkWired: false,
-		networkWireless: false,
-		balenaApiKey: process.env.BALENACLOUD_API_KEY,
-		balenaApiUrl: process.env.BALENACLOUD_API_URL,
+		networkWireless: process.env.WORKER_TYPE === 'qemu' ? false : true,
+    downloadVersion: 'latest',
+    balenaApiKey: process.env.ENVIRONMENT === 'balena-machine' ? process.env.BALENAMACHINE_API_KEY : process.env.BALENACLOUD_API_KEY,
+    balenaApiUrl: process.env.ENVIRONMENT === 'balena-machine' ? process.env.BALENAMACHINE_API_URL : process.env.BALENACLOUD_API_URL,
 		organization: process.env.BALENACLOUD_ORG,
 		sshConfig: {
 			host: process.env.BALENACLOUD_SSH_URL,
@@ -87,7 +89,7 @@ module.exports = [
 	},
 	workers: process.env.WORKER_TYPE === 'qemu' ? ['http://worker'] : {
 		balenaApplication: process.env.BALENACLOUD_APP_NAME,
-		apiKey: process.env.BALENACLOUD_API_KEY,
+		apiKey: process.env.ENVIRONMENT === 'balena-machine' ? process.env.BALENAMACHINE_API_KEY : process.env.BALENACLOUD_API_KEY,
 	},
 }
 ];


### PR DESCRIPTION
Bringing upon a little change of improvement where the decisions are taken by the config.js about values rather than the CI runner like Jenkins or GH actions

- [ ] @vipulgupta2048 to check if Jenkins is happy with this config

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
