### PR TITLE
tests: cloud: retry balena push in case of failure

### DIFF
--- a/tests/suites/cloud/package.json
+++ b/tests/suites/cloud/package.json
@@ -1,13 +1,14 @@
 {
   "dependencies": {
+    "async-retry": "^1.3.3",
     "balena-image-fs": "^7.0.6",
     "balena-sdk": "^15.34.1",
+    "bluebird": "^3.5.3",
     "dockerode": "^3.2.1",
     "fs-extra": "^8.1.0",
     "lodash": "^4.17.11",
     "request": "^2.88.0",
     "request-promise": "^4.2.4",
-    "ssh-keygen": "^0.4.1",
-    "bluebird": "^3.5.3"
+    "ssh-keygen": "^0.4.1"
   }
 }


### PR DESCRIPTION
To remove edge case of test failure because of `balena push` failures due to transient issues

Change-type: patch

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
