### PR TITLE
resin-u-boot.class: Fix for older u-boot versions

### DIFF
--- a/meta-balena-common/classes/resin-u-boot.bbclass
+++ b/meta-balena-common/classes/resin-u-boot.bbclass
@@ -111,6 +111,10 @@ do_inject_check_crc32_cmd() {
         # Older u-boot versions do not have env.h
         if [ ! -f ${S}/include/env.h ]; then
             sed -i 's/env.h/common.h/g' ${WORKDIR}/balena_check_crc32.c
+            if ! grep -q env_get "${S}/include/common.h"; then
+                sed -i 's/env_get/getenv/g' "${WORKDIR}/balena_check_crc32.c"
+                sed -i 's/env_set/setenv/g' "${WORKDIR}/balena_check_crc32.c"
+            fi
         fi
         cp ${WORKDIR}/balena_check_crc32.c ${S}/cmd/
         if ! grep -q "balena_check_crc32" ${S}/cmd/Makefile ; then


### PR DESCRIPTION
The env_get() function was renamed from getenv() in commit 00caae6d47645e68d6e5277aceb69592b49381a6
env: Rename getenv/_f() to env_get()

Fix the balena_check_crc32 function to build for those older u-boots too.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
