### PR TITLE
meta-balena-warrior: hold libmbim, libmbim and modemmanager versions

### DIFF
--- a/meta-balena-warrior/conf/distro/include/balena-os-yocto-version.inc
+++ b/meta-balena-warrior/conf/distro/include/balena-os-yocto-version.inc
@@ -1,2 +1,3 @@
 PREFERRED_VERSION_tpm2-tss = "3.0.3"
 PREFERRED_VERSION_libmbim = "1.26.2"
+PREFERRED_VERSION_libqmi = "1.30.2"

--- a/meta-balena-warrior/conf/distro/include/balena-os-yocto-version.inc
+++ b/meta-balena-warrior/conf/distro/include/balena-os-yocto-version.inc
@@ -1,3 +1,4 @@
 PREFERRED_VERSION_tpm2-tss = "3.0.3"
 PREFERRED_VERSION_libmbim = "1.26.2"
 PREFERRED_VERSION_libqmi = "1.30.2"
+PREFERRED_VERSION_modemmanager = "1.18.4"

--- a/meta-balena-warrior/conf/distro/include/balena-os-yocto-version.inc
+++ b/meta-balena-warrior/conf/distro/include/balena-os-yocto-version.inc
@@ -1,1 +1,2 @@
 PREFERRED_VERSION_tpm2-tss = "3.0.3"
+PREFERRED_VERSION_libmbim = "1.26.2"

--- a/meta-balena-warrior/conf/layer.conf
+++ b/meta-balena-warrior/conf/layer.conf
@@ -8,3 +8,5 @@ BBFILE_PATTERN_balena-warrior := "^${LAYERDIR}/"
 BBFILE_PRIORITY_balena-warrior = "1337"
 
 LAYERSERIES_COMPAT_balena-warrior = "warrior"
+# Do not get further changes from upstream meta-balena
+BBMASK += "meta-balena/meta-balena-common/recipes-connectivity/modemmanager/modemmanager_%.bbappend"

--- a/meta-balena-warrior/recipes-connectivity/libmbim/libmbim_1.26.2.bb
+++ b/meta-balena-warrior/recipes-connectivity/libmbim/libmbim_1.26.2.bb
@@ -1,0 +1,16 @@
+SUMMARY = "libmbim is library for talking to WWAN devices by MBIM protocol"
+DESCRIPTION = "libmbim is a glib-based library for talking to WWAN modems and devices which speak the Mobile Interface Broadband Model (MBIM) protocol"
+HOMEPAGE = "http://www.freedesktop.org/wiki/Software/libmbim/"
+LICENSE = "GPLv2 & LGPLv2.1"
+LIC_FILES_CHKSUM = " \
+    file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+    file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c \
+"
+
+DEPENDS = "glib-2.0 glib-2.0-native libgudev autoconf-archive"
+
+inherit autotools pkgconfig bash-completion gobject-introspection
+
+SRC_URI = "http://www.freedesktop.org/software/${BPN}/${BPN}-${PV}.tar.xz"
+
+SRC_URI[sha256sum] = "10c77bf5b5eb8c92ba80e9b519923ad9b898362bc8e1928e2bc9a17eeba649af"

--- a/meta-balena-warrior/recipes-connectivity/libqmi/libqmi_1.30.2.bb
+++ b/meta-balena-warrior/recipes-connectivity/libqmi/libqmi_1.30.2.bb
@@ -1,0 +1,21 @@
+SUMMARY = "libqmi is a library for talking to WWAN devices by QMI protocol"
+DESCRIPTION = "libqmi is a glib-based library for talking to WWAN modems and \
+               devices which speak the Qualcomm MSM Interface (QMI) protocol"
+HOMEPAGE = "http://www.freedesktop.org/wiki/Software/libqmi"
+LICENSE = "GPLv2 & LGPLv2.1"
+LIC_FILES_CHKSUM = " \
+    file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+    file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c \
+"
+
+DEPENDS = "glib-2.0 glib-2.0-native"
+
+inherit autotools pkgconfig bash-completion gobject-introspection
+
+SRC_URI = "http://www.freedesktop.org/software/${BPN}/${BPN}-${PV}.tar.xz"
+
+SRC_URI[sha256sum] = "be01ece0ea2c2194cbea5744bf5aaf06c04ba5fb7ec7887a13116c76d114fedd"
+
+PACKAGECONFIG ??= "udev mbim"
+PACKAGECONFIG[udev] = ",--without-udev,libgudev"
+PACKAGECONFIG[mbim] = "--enable-mbim-qmux,--disable-mbim-qmux,libmbim"

--- a/meta-balena-warrior/recipes-connectivity/modemmanager/balena-files/77-mm-huawei-configuration.rules
+++ b/meta-balena-warrior/recipes-connectivity/modemmanager/balena-files/77-mm-huawei-configuration.rules
@@ -1,0 +1,11 @@
+# Copyright (c) 2013 The Chromium OS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+# This file specifies udev rules to configure certain Huawei modems to select
+# the USB configuration expected by Chrome OS.
+# Huawei ME936: Select the MBIM configuration
+ACTION=="add|change", SUBSYSTEM=="usb", \
+  ENV{DEVTYPE}=="usb_device|usb_interface", \
+  ATTRS{idVendor}=="12d1", ATTRS{idProduct}=="15bb", \
+  ATTRS{bNumConfigurations}=="3", ATTRS{bConfigurationValue}!="3", \
+  RUN+="/lib/udev/mm-huawei-configuration-switch.sh %E{DEVTYPE} %S%p 3"

--- a/meta-balena-warrior/recipes-connectivity/modemmanager/balena-files/77-mm-u-blox-modeswitch.rules
+++ b/meta-balena-warrior/recipes-connectivity/modemmanager/balena-files/77-mm-u-blox-modeswitch.rules
@@ -1,0 +1,5 @@
+ACTION!="add|change", GOTO="modeswitch_rules_end"
+
+KERNEL=="ttyACM*", ATTRS{idVendor}=="1546", ATTRS{idProduct}=="1146", TAG+="systemd", ENV{SYSTEMD_WANTS}="u-blox-switch@%E{DEVNAME}.service"
+
+LABEL="modeswitch_rules_end"

--- a/meta-balena-warrior/recipes-connectivity/modemmanager/balena-files/ModemManager.conf.systemd
+++ b/meta-balena-warrior/recipes-connectivity/modemmanager/balena-files/ModemManager.conf.systemd
@@ -1,0 +1,5 @@
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/ModemManager --log-journal
+Restart=always
+RestartSec=10s

--- a/meta-balena-warrior/recipes-connectivity/modemmanager/balena-files/core-switch-bash-shell-scripts-to-use-bin-sh-for-use.patch
+++ b/meta-balena-warrior/recipes-connectivity/modemmanager/balena-files/core-switch-bash-shell-scripts-to-use-bin-sh-for-use.patch
@@ -1,0 +1,53 @@
+From 91ed72aa29ede06d3a5115128e2267793ca611d4 Mon Sep 17 00:00:00 2001
+From: "Bruce A. Johnson" <waterfordtrack@gmail.com>
+Date: Wed, 22 Dec 2021 14:24:02 -0500
+Subject: [PATCH] core: switch bash shell scripts to use /bin/sh for use
+ w/Busybox.
+
+Fixes https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/issues/483
+---
+ data/fcc-unlock/105b           | 2 +-
+ data/fcc-unlock/1199           | 2 +-
+ data/fcc-unlock/1eac           | 2 +-
+ test/mmcli-test-sms            | 2 +-
+ tools/tests/test-wrapper.sh.in | 2 +-
+ 5 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/data/fcc-unlock/105b b/data/fcc-unlock/105b
+index 21fe5329..f276050f 100644
+--- a/data/fcc-unlock/105b
++++ b/data/fcc-unlock/105b
+@@ -1 +1 @@
+-#!/bin/bash
++#!/bin/sh
+diff --git a/data/fcc-unlock/1199 b/data/fcc-unlock/1199
+index 0109c6ab..e1d3804c 100644
+--- a/data/fcc-unlock/1199
++++ b/data/fcc-unlock/1199
+@@ -1 +1 @@
+-#!/bin/bash
++#!/bin/sh
+diff --git a/data/fcc-unlock/1eac b/data/fcc-unlock/1eac
+index 1068d9c2..d9342852 100644
+--- a/data/fcc-unlock/1eac
++++ b/data/fcc-unlock/1eac
+@@ -1 +1 @@
+-#!/bin/bash
++#!/bin/sh
+diff --git a/test/mmcli-test-sms b/test/mmcli-test-sms
+index 038d777d..8229d36a 100755
+--- a/test/mmcli-test-sms
++++ b/test/mmcli-test-sms
+@@ -1 +1 @@
+-#!/bin/bash
++#!/bin/sh
+diff --git a/tools/tests/test-wrapper.sh.in b/tools/tests/test-wrapper.sh.in
+index d64ea4cb..fcdb56de 100644
+--- a/tools/tests/test-wrapper.sh.in
++++ b/tools/tests/test-wrapper.sh.in
+@@ -1 +1 @@
+-#!/bin/bash
++#!/bin/sh
+-- 
+2.35.1
+

--- a/meta-balena-warrior/recipes-connectivity/modemmanager/balena-files/mm-huawei-configuration-switch.sh
+++ b/meta-balena-warrior/recipes-connectivity/modemmanager/balena-files/mm-huawei-configuration-switch.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Copyright (c) 2014 The Chromium OS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# $1 is either "usb_device" or "usb_interface" depending on what triggered this
+# script.
+# $2 is the full sysfs path to the device/interface.
+# $3 is the configuration mode number we switch the modem to
+
+switch_device_configuration() {
+  # expect:
+  #  $1 : sysfs path for the device.
+  #  $2 : the configuration mode number we switch the modem to
+  echo "$2" > "$1"/bConfigurationValue
+}
+
+if [ "$1" = "usb_device" ]
+then
+  switch_device_configuration "$2" "$3"
+else
+  switch_device_configuration "$(dirname "$2")" "$3"
+fi

--- a/meta-balena-warrior/recipes-connectivity/modemmanager/balena-files/u-blox-switch.sh
+++ b/meta-balena-warrior/recipes-connectivity/modemmanager/balena-files/u-blox-switch.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+MODEM_TTY_PATH=$1
+
+# wait for the modem to be powered on
+while [ x`mmcli -m 0 --output-keyvalue 2>/dev/null | grep -i power-state | awk -F ": " '{ print $2 }'` != x"on" ] ; do sleep 1; done
+
+echo -e "AT+UUSBCONF=2,\"ECM\"\r\n" > $MODEM_TTY_PATH
+
+echo -e "AT+CFUN=1,1\r\n" > $MODEM_TTY_PATH

--- a/meta-balena-warrior/recipes-connectivity/modemmanager/balena-files/u-blox-switch@.service
+++ b/meta-balena-warrior/recipes-connectivity/modemmanager/balena-files/u-blox-switch@.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Switch u-blox modem from RNDIS to ECM mode
+Wants=ModemManager.service
+After=ModemManager.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/u-blox-switch.sh %I

--- a/meta-balena-warrior/recipes-connectivity/modemmanager/modemmanager_%.bbappend
+++ b/meta-balena-warrior/recipes-connectivity/modemmanager/modemmanager_%.bbappend
@@ -1,0 +1,34 @@
+FILESEXTRAPATHS_append := ":${THISDIR}/balena-files"
+SYSTEMD_AUTO_ENABLE = "enable"
+
+SRC_URI_append = " \
+    file://77-mm-huawei-configuration.rules \
+    file://mm-huawei-configuration-switch.sh \
+    file://77-mm-u-blox-modeswitch.rules \
+    file://u-blox-switch@.service \
+    file://u-blox-switch.sh \
+    file://ModemManager.conf.systemd \
+"
+
+PACKAGECONFIG_remove = "polkit"
+
+do_install_append() {
+    install -d ${D}${base_libdir}/udev/rules.d/
+    install -m 0644 ${WORKDIR}/77-mm-huawei-configuration.rules ${D}${base_libdir}/udev/rules.d/
+    install -m 0755 ${WORKDIR}/mm-huawei-configuration-switch.sh ${D}${base_libdir}/udev/
+    install -m 0644 ${WORKDIR}/77-mm-u-blox-modeswitch.rules ${D}${base_libdir}/udev/rules.d
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/u-blox-switch.sh ${D}${bindir}
+    install -d ${D}${systemd_unitdir}/system/ModemManager.service.d
+    install -m 0644 ${WORKDIR}/ModemManager.conf.systemd ${D}${systemd_unitdir}/system/ModemManager.service.d/ModemManager.conf
+    install -m 0644 ${WORKDIR}/u-blox-switch@.service ${D}${systemd_unitdir}/system
+}
+
+FILES_${PN} += " \
+    ${base_libdir}/udev/rules.d/77-mm-huawei-configuration.rules \
+    ${base_libdir}/udev/mm-huawei-configuration-switch.sh \
+    ${base_libdir}/udev/rules.d/77-mm-u-blox-modeswitch.rules \
+    ${systemd_unitdir}/system/u-blox-switch@.service \
+    ${bindir}/u-blox-switch.sh \
+    ${systemd_unitdir}/system/ModemManager.service.d/ModemManager.conf \
+    "

--- a/meta-balena-warrior/recipes-connectivity/modemmanager/modemmanager_1.18.4.bb
+++ b/meta-balena-warrior/recipes-connectivity/modemmanager/modemmanager_1.18.4.bb
@@ -1,0 +1,61 @@
+SUMMARY = "ModemManager is a daemon controlling broadband devices/connections"
+DESCRIPTION = "ModemManager is a DBus-activated daemon which controls mobile broadband (2G/3G/4G) devices and connections"
+HOMEPAGE = "http://www.freedesktop.org/wiki/Software/ModemManager/"
+LICENSE = "GPL-2.0 & LGPL-2.1"
+LIC_FILES_CHKSUM = " \
+    file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+    file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c \
+"
+
+inherit gnomebase gettext systemd vala gobject-introspection bash-completion
+
+DEPENDS = "glib-2.0 libgudev dbus-glib intltool-native libxslt-native"
+
+SRC_URI = " \
+    http://www.freedesktop.org/software/ModemManager/ModemManager-${PV}.tar.xz \
+    file://core-switch-bash-shell-scripts-to-use-bin-sh-for-use.patch \
+"
+SRC_URI[sha256sum] = "11fb970f63e2da88df4b6d8759e4ee649944c515244b979bf50a7a6df1d7f199"
+
+
+S = "${WORKDIR}/ModemManager-${PV}"
+
+PACKAGECONFIG ??= "mbim qmi \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'systemd polkit', d)} \
+"
+
+PACKAGECONFIG[systemd] = "--with-systemdsystemunitdir=${systemd_unitdir}/system/,,"
+PACKAGECONFIG[polkit] = "--with-polkit=yes,--with-polkit=no,polkit"
+# Support WWAN modems and devices which speak the Mobile Interface Broadband Model (MBIM) protocol.
+PACKAGECONFIG[mbim] = "--with-mbim,--without-mbim,libmbim"
+# Support WWAN modems and devices which speak the Qualcomm MSM Interface (QMI) protocol.
+PACKAGECONFIG[qmi] = "--with-qmi,--without-qmi,libqmi"
+
+EXTRA_OECONF = " \
+    --with-udev-base-dir=${nonarch_base_libdir}/udev \
+    --with-at-command-via-dbus=yes \
+"
+
+EXTRA_OECONF_append_toolchain-clang = " --enable-more-warnings=no"
+
+FILES_${PN} += " \
+    ${datadir}/icons \
+    ${datadir}/polkit-1 \
+    ${datadir}/dbus-1 \
+    ${datadir}/ModemManager \
+    ${libdir}/ModemManager \
+    ${systemd_unitdir}/system \
+"
+
+FILES_${PN}-dev += " \
+    ${libdir}/ModemManager/*.la \
+"
+
+FILES_${PN}-staticdev += " \
+    ${libdir}/ModemManager/*.a \
+"
+
+FILES_${PN}-dbg += "${libdir}/ModemManager/.debug"
+
+SYSTEMD_SERVICE_${PN} = "ModemManager.service"
+


### PR DESCRIPTION
The current meta-balena libmbim is not compatible with sumo's libc version.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
