### PR TITLE
classes: sign: add a retry to the signing call

### DIFF
--- a/meta-balena-common/classes/sign-efi.bbclass
+++ b/meta-balena-common/classes/sign-efi.bbclass
@@ -22,7 +22,7 @@ do_sign_efi () {
         RESPONSE_FILE=$(mktemp)
         echo "{\"key_id\": \"${SIGN_KMOD_KEY_ID}\", \"payload\": \"$(base64 -w 0 ${SIGNING_ARTIFACT})\"}" > "${REQUEST_FILE}"
         CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt" \
-            curl --fail "${SIGN_API}/secureboot/efi" \
+            curl --fail --retry 5  "${SIGN_API}/secureboot/efi" \
                  -X POST \
                  -H "Content-Type: application/json" \
                  -H "X-API-Key: ${SIGN_API_KEY}" \

--- a/meta-balena-common/classes/sign-gpg.bbclass
+++ b/meta-balena-common/classes/sign-gpg.bbclass
@@ -17,7 +17,7 @@ do_sign_gpg () {
         RESPONSE_FILE=$(mktemp)
         echo "{\"key_id\": \"${SIGN_GRUB_KEY_ID}\", \"payload\": \"$(base64 -w 0 ${SIGNING_ARTIFACT})\"}" > "${REQUEST_FILE}"
         CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt" \
-            curl --fail "${SIGN_API}/gpg/sign" \
+            curl --retry 5 --fail "${SIGN_API}/gpg/sign" \
                  -X POST \
                  -H "Content-Type: application/json" \
                  -H "X-API-Key: ${SIGN_API_KEY}" \

--- a/meta-balena-common/classes/sign-kmod.bbclass
+++ b/meta-balena-common/classes/sign-kmod.bbclass
@@ -16,7 +16,7 @@ do_sign_kmod () {
         REQUEST_FILE=$(mktemp)
         RESPONSE_FILE=$(mktemp)
         echo "{\"key_id\": \"${SIGN_KMOD_KEY_ID}\", \"payload\": \"$(base64 -w 0 ${SIGNING_ARTIFACT})\"}" > "${REQUEST_FILE}"
-        CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt" curl --fail --silent "${SIGN_API}/kmod/sign" -X POST -H "Content-Type: application/json" -H "X-API-Key: ${SIGN_API_KEY}" -d "@${REQUEST_FILE}" > "${RESPONSE_FILE}"
+        CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt" curl --retry 5 --fail --silent "${SIGN_API}/kmod/sign" -X POST -H "Content-Type: application/json" -H "X-API-Key: ${SIGN_API_KEY}" -d "@${REQUEST_FILE}" > "${RESPONSE_FILE}"
         jq -r ".signed" < "${RESPONSE_FILE}" | base64 -d > "${SIGNING_ARTIFACT}.signed"
         rm -f "${REQUEST_FILE}" "${RESPONSE_FILE}"
     done


### PR DESCRIPTION
When the signed artifacts are big we see closed connections because of timeouts in the front caches. A retry should help.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
