### PR TITLE
workflows: Switch to balenaOS ESR [bot] for authentication

### DIFF
--- a/.github/workflows/meta-balena-esr.yml
+++ b/.github/workflows/meta-balena-esr.yml
@@ -16,6 +16,14 @@ on:
         type: string
         description: ESR version override, for example 2022.10. By default it uses current year and month.
 
+env:
+  # get the user id of the GitHub App
+  # gh api /users/balenaos-esr%5Bbot%5D
+  GIT_AUTHOR_NAME: balenaos-esr[bot]
+  GIT_AUTHOR_EMAIL: 146746583+balenaos-esr[bot]@users.noreply.github.com
+  GIT_COMMITTER_NAME: balenaos-esr[bot]
+  GIT_COMMITTER_EMAIL: 146746583+balenaos-esr[bot]@users.noreply.github.com
+
 jobs:
   fetch:
     runs-on: ubuntu-latest
@@ -27,18 +35,14 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@0914d50df753bbc42180d982a6550f195390069f # v2.0.0
-        continue-on-error: true
         id: gh_app_token
         with:
-          app_id: ${{ vars.APP_ID || '291899' }}
-          installation_id: ${{ vars.INSTALLATION_ID || '34046907' }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: >-
-            {
-              "contents": "write",
-              "metadata": "read",
-              "pull_requests": "write"
-            }
+          app_id: ${{ vars.ESR_BOT_APP_ID || '400859' }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.event.repository.owner.login }}
+          private_key: ${{ secrets.ESR_BOT_PRIVATE_KEY }}
+          repositories: >
+            ["${{ github.event.repository.name }}"]
 
       - uses: actions/checkout@v4
         with:
@@ -141,8 +145,6 @@ jobs:
           with open(filePath, 'w') as modified:
               yaml.dump(ydata, modified)
           EOF
-          git config --global user.name 'flowzone-app[bot]'
-          git config --global user.email '124931076+flowzone-app[bot]@users.noreply.github.com'
           git add repo.yml
           git commit -F- <<-EOF
           Declare ESR ${os_esr_branch:0:-2}

--- a/.github/workflows/update-backports.yml
+++ b/.github/workflows/update-backports.yml
@@ -10,6 +10,14 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  # get the user id of the GitHub App
+  # gh api /users/balenaos-esr%5Bbot%5D
+  GIT_AUTHOR_NAME: balenaos-esr-bot[bot]
+  GIT_AUTHOR_EMAIL: 146746583+balenaos-esr-bot[bot]@users.noreply.github.com
+  GIT_COMMITTER_NAME: balenaos-esr-bot[bot]
+  GIT_COMMITTER_EMAIL: 146746583+balenaos-esr-bot[bot]@users.noreply.github.com
+
 jobs:
   fetch:
     runs-on: ubuntu-latest
@@ -21,18 +29,14 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@0914d50df753bbc42180d982a6550f195390069f # v2.0.0
-        continue-on-error: true
         id: gh_app_token
         with:
-          app_id: ${{ vars.APP_ID || '291899' }}
-          installation_id: ${{ vars.INSTALLATION_ID || '34046907' }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: >-
-            {
-              "contents": "write",
-              "metadata": "read",
-              "pull_requests": "write"
-            }
+          app_id: ${{ vars.ESR_BOT_APP_ID || '400859' }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.event.repository.owner.login }}
+          private_key: ${{ secrets.ESR_BOT_PRIVATE_KEY }}
+          repositories: >
+            ["${{ github.event.repository.name }}"]
 
       - uses: actions/checkout@v4
         with:
@@ -112,8 +116,6 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token }}
         run: |
-          git config --global user.name 'flowzone-app[bot]'
-          git config --global user.email '124931076+flowzone-app[bot]@users.noreply.github.com'
           branch_name="balenaci/update-backports"
           git checkout -b ${branch_name} HEAD
           git add repo.yml


### PR DESCRIPTION
Flowzone App no longer has workflow:write permissions for security reasons.

This new balenaOS ESR bot has contents:write and workflows:write permissions but is only available on balenaOS repositories.

See: https://github.com/apps/balenaos-esr
Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
