### PR TITLE
Fix improperly returning multiple matching devices in `get_internal_device`

### DIFF
--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
@@ -265,7 +265,7 @@ get_internal_device() {
           fi
 
           echo "${device}"
-          break
+          break 2
         else
         info "$device is not a block device, skipping"
       fi


### PR DESCRIPTION
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
