### PR TITLE
balena-net-config: Ensure NM dispatcher scripts are executable

### DIFF
--- a/meta-balena-common/recipes-connectivity/balena-net-config/balena-net-config/balena-net-config
+++ b/meta-balena-common/recipes-connectivity/balena-net-config/balena-net-config/balena-net-config
@@ -30,7 +30,7 @@ fi
 DISPATCHER_NM=${BALENA_BOOT_MOUNTPOINT}/dispatcher.d/
 if [ -d "$DISPATCHER_NM" ]; then
 	cp -r "$DISPATCHER_NM" /etc/NetworkManager/
-	chmod 600 /etc/NetworkManager/dispatcher.d/*
+	chmod 755 /etc/NetworkManager/dispatcher.d/*
 	sync -f "/etc/NetworkManager/"
 fi
 


### PR DESCRIPTION

This commit fixes the following error:
```
    nm-dispatcher[4209]: req:1 'hostname': find-scripts: Cannot execute '/etc/NetworkManager/dispatcher.d/50-example-script.sh': not executable by owner.
```
Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [x] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
