### PR TITLE
plymouth: Remove --retain-splash flag from plymouth quit

### DIFF
--- a/meta-balena-common/recipes-core/plymouth/plymouth_%.bbappend
+++ b/meta-balena-common/recipes-core/plymouth/plymouth_%.bbappend
@@ -9,6 +9,10 @@ SRC_URI:append = " \
     file://plymouth-start-balena-os.conf \
     "
 
+# remove patch that adds the retain splash option, as it's not needed
+# and prevents user apps from writing to tty consoles even after stopping plymouth
+SRC_URI:remove = "file://0001-plymouth-Add-the-retain-splash-option.patch"
+
 # install our theme, and remove some extra files to save a significant
 # amount of space
 do_install:append() {


### PR DESCRIPTION
This flag isn't needed on balenaOS as the splash screen remains even after plymouthd is stopped.

Having the flag in place prevents user apps from writing to tty consoles after stopping plymouth via dbus.

Change-type: patch
See: https://balena.fibery.io/Inputs/Pattern/User-apps-cannot-write-to-tty-screens-in-balenaOS-2.113.18-4471

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [x] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
