### PR TITLE
resindataexpander: authenticate cryptsetup-resize

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup
+++ b/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup
@@ -137,7 +137,6 @@ cryptsetup_run() {
         wait4udev "/dev/mapper/${DM_NAME}"
     done
 
-    rm -f "$PASSPHRASE_FILE"
     umount "$EFI_MOUNT_DIR"
     rmdir "$EFI_MOUNT_DIR"
 

--- a/meta-balena-common/recipes-core/initrdscripts/files/resindataexpander
+++ b/meta-balena-common/recipes-core/initrdscripts/files/resindataexpander
@@ -71,7 +71,7 @@ resindataexpander_run() {
             if [ "${dataparttype}" = "crypt" ]; then
                 datapartmap=$(lsblk ${datapart} -nlo name)
                 info "resindataexpander: Expand LUKS volume for data partition..."
-                cryptsetup resize "${datapartmap}"
+                cryptsetup resize "${datapartmap}" --key-file "$PASSPHRASE_FILE"
                 info "resindataexpander: Expanded LUKS volume for data partition"
                 sync
             fi


### PR DESCRIPTION
According to the man page for cryptsetup-resize:

  If cryptsetup detected volume key for active device loaded in
  kernel keyring service, resize action would first try to retrieve the
  key using a token. Only if it failed, it’d ask for a passphrase to
  unlock a keyslot (LUKS) or to derive a volume key again (plain mode).
  The kernel keyring is used by default for LUKS2 devices.

In some cases, specifically when running a newly flashed secure boot enabled system in QEMU, the cryptsetup-resize execution in resindataexpander will request the LUKS passphrase. Presumably because the utility was unable to retrieve the key from the kernel keyring, possibly a race condition.

Pass the LUKS passphrase to cryptsetup-resize explicitly as a parameter to avoid this.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
