### PR TITLE
modemmanager: Fix enabling AT commands via dbus

### DIFF
--- a/meta-balena-common/recipes-connectivity/modemmanager/modemmanager_1.20.6.bb
+++ b/meta-balena-common/recipes-connectivity/modemmanager/modemmanager_1.20.6.bb
@@ -24,7 +24,7 @@ PACKAGECONFIG ??= "mbim qmi \
     ${@bb.utils.filter('DISTRO_FEATURES', 'systemd polkit', d)} \
 "
 
-PACKAGECONFIG[at] = "-Dat_command_via_dbus=true"
+PACKAGECONFIG[at] = "-Dwith_at_command_via_dbus=true"
 PACKAGECONFIG[systemd] = " \
     -Dsystemdsystemunitdir=${systemd_unitdir}/system/, \
     -Dsystemdsystemunitdir=no -Dsystemd_journal=false -Dsystemd_suspend_resume=false \


### PR DESCRIPTION
The recipe did not use the correct configure option that enables sending AT commands via d-bus.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
