### PR TITLE
balena-rollback: Run device-specific healtchecks

### DIFF
--- a/meta-balena-common/recipes-core/balena-rollback/balena-rollback.bb
+++ b/meta-balena-common/recipes-core/balena-rollback/balena-rollback.bb
@@ -27,6 +27,7 @@ SRC_URI = " \
     file://rollback-stop \
     file://rollback-tests \
     file://rollback-parse-bootloader \
+    file://rollback-board-healthcheck \
     "
 S = "${WORKDIR}"
 
@@ -48,6 +49,7 @@ do_install() {
     install -m 0775 ${S}/rollback-stop ${D}${bindir}
     install -m 0775 ${S}/rollback-tests ${D}${bindir}
     install -m 0775 ${S}/rollback-parse-bootloader ${D}${bindir}
+    install -m 0775 ${S}/rollback-board-healthcheck ${D}${bindir}
     install -c -m 0644 ${S}/rollback-altboot.service ${D}${systemd_unitdir}/system
     install -c -m 0644 ${S}/rollback-clear-bootcount.service ${D}${systemd_unitdir}/system
     install -c -m 0644 ${S}/rollback-health.service ${D}${systemd_unitdir}/system

--- a/meta-balena-common/recipes-core/balena-rollback/files/rollback-board-healthcheck
+++ b/meta-balena-common/recipes-core/balena-rollback/files/rollback-board-healthcheck
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# This file can be overriden in the device integration repository,
+# with any board specific healthchecks necessary.
+#
+set -o errexit
+
+exit 0

--- a/meta-balena-common/recipes-core/balena-rollback/files/rollback-tests
+++ b/meta-balena-common/recipes-core/balena-rollback/files/rollback-tests
@@ -40,3 +40,13 @@ else
 	echo "Rollback: ERROR: balenaEngine is not healthy!"
 	exit 1
 fi
+
+# The following script can be overriden by device integration
+# repositories with board specific healthchecks
+echo "Rollback: Running board specific healthchecks..."
+if /usr/bin/rollback-board-healthcheck ; then
+	echo "Rollback: No issues detected."
+else
+	echo "Rollback: ERROR: Board specific healthchecks failed!"
+	exit 1
+fi


### PR DESCRIPTION
In this PR we add a generic script which can be overridden by device integration repositories to run device-specific healthchecks in the new OS, after HUP.

This allows devices like Jetsons to check if the UEFI firmware they run after the update is in sync with the kernel version, and the rest of the BSP elements.

Connects-to PR: https://github.com/balena-os/balena-jetson-orin/pull/348 / Commit: https://github.com/balena-os/balena-jetson-orin/pull/348/commits/b47e0ff20c160544993d130039c6c26d4982229b

Added as per the internal discussion: https://balena.zulipchat.com/#narrow/stream/360838-balena-io.2Fos.2Fdevices/topic/Jetson.20AGX.20Orin.20devkit/near/400946825

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
