### PR TITLE
os-helpers-logging: replace broken container check

### DIFF
--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-logging
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-logging
@@ -26,7 +26,7 @@ log () {
     # Only print to journal if we are running in the hostOS
     # and not running in a container (like HUP hooks)
     # as container output already ends up in the journal
-    if [ "$(awk 'NR==1 {print $1; exit}' /proc/1/sched)" == "systemd" ]; then
+    if [ ! -f '/.dockerenv' ] && [ ! -f '/run/.containerenv' ]; then
        echo "${_message}" |  systemd-cat --level-prefix=0 --identifier="$ME" --priority="${PRIORITY}" 2> /dev/null || true
     fi
 }


### PR DESCRIPTION
Detecting whether the script is running in a PID namespace by checking `/proc/1/sched` does not work for newer kernels
(see https://github.com/systemd/systemd/pull/17917).

Properly detecting this is too cumbersome for a bash logging script, see https://github.com/systemd/systemd/pull/17902, however, falling back to the last check, that is, seeing if `/.dockerenv` exists is easy enough and works for our use case.

This scritp will only be called from the hostOS, and the only case it is called from a container during in HUP and the container is always a hostOS image. So even though the interface chosen by moby, a file under /, is bad interface in general, it works fine for the specific limitations of balenaOS.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
