### PR TITLE
timesync-https: increase default connection max time to 10s

### DIFF
--- a/meta-balena-common/recipes-core/systemd/timeinit/timesync-https.sh
+++ b/meta-balena-common/recipes-core/systemd/timeinit/timesync-https.sh
@@ -49,7 +49,7 @@ fi
 
 while [ true  ]; do
 	SYS_TIME=$(get_system_time_as_timestamp)
-	readarray -t https_header <<<$(curl -m5 -k -I -s $OS_NET_CONN_URI | sed 's/\r$//'  | awk '/HTTP/{printf $2"\n"} /[Dd]ate/{print $2, $3, $4, $5, $6, $7"\n"}')
+	readarray -t https_header <<<$(curl -m10 -k -I -s $OS_NET_CONN_URI | sed 's/\r$//'  | awk '/HTTP/{printf $2"\n"} /[Dd]ate/{print $2, $3, $4, $5, $6, $7"\n"}')
 	SERVER_CODE=${https_header[0]}
 	SERVER_TIME_STRING=${https_header[1]}
 	if [ "$SERVER_CODE" = "$EXPECTED_SERVER_CODE" ]; then


### PR DESCRIPTION
We have seen cases of networks that were not able to receive a response in the current 5s.

Increasing the default to 10s should have no negative effect.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
