### PR TITLE
balena-config-vars: increase config.json parsing resilience

### DIFF
--- a/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/balena-config-vars
+++ b/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/balena-config-vars
@@ -81,14 +81,12 @@ else
     echo "[WARN] $0: Missing fatrw command"
 fi
 
-if [ "${USE_CACHE}" -eq "1" ] && [ -n "${BALENA_CONFIG_VARS_CACHE}" ] && [ -f "${BALENA_CONFIG_VARS_CACHE}" ]; then
-        . "${BALENA_CONFIG_VARS_CACHE}"
-else
-    [ -n "${BALENA_CONFIG_VARS_CACHE}" ] && [ -f "${BALENA_CONFIG_VARS_CACHE}" ] && rm -f "${BALENA_CONFIG_VARS_CACHE}"
-
-    # If config.json provides redefinitions for our vars let us rewrite their
-    # runtime value
-    if [ -f $CONFIG_PATH ]; then
+# Parse the configuration path into the CONFIG_PARAMS variable
+#
+# Returns: 0 if CONFIG_PARAMS is not empty, 1 if it is empty
+#
+read_config() {
+    if [ -f "$CONFIG_PATH" ]; then
         CONFIG_PARAMS=$("${CAT}" "${CONFIG_PATH}" | jq -r '@sh "
              API_ENDPOINT=\(.apiEndpoint // "")
              APPLICATION_ID=\(.applicationId // "")
@@ -117,18 +115,35 @@ else
         if [ "$RESULT" = "4" ]; then
             echo "[ERROR] $0: Failed to parse '$CONFIG_PATH'."
             exit 1
-        else
-            if [ -n "${BALENA_CONFIG_VARS_CACHE}" ]; then
-                tmpfile=$(mktemp)
-                echo "${CONFIG_PARAMS}" | sed -e 's/^[[:space:]]*//' > "${tmpfile}"
-                chmod a+rx "${tmpfile}"
-                mv "${tmpfile}" "${BALENA_CONFIG_VARS_CACHE}"
-            fi
-            eval "$CONFIG_PARAMS"
         fi
+        test -n "${CONFIG_PARAMS}"
     else
-        echo "[WARNING] $0 : '$CONFIG_PATH' not found."
+        echo "[ERROR] $0 : '$CONFIG_PATH' not found."
+        exit 1
     fi
+}
+
+if [ "${USE_CACHE}" -eq "1" ] && [ -n "${BALENA_CONFIG_VARS_CACHE}" ] && [ -f "${BALENA_CONFIG_VARS_CACHE}" ]; then
+        . "${BALENA_CONFIG_VARS_CACHE}"
+else
+    [ -n "${BALENA_CONFIG_VARS_CACHE}" ] && [ -f "${BALENA_CONFIG_VARS_CACHE}" ] && rm -f "${BALENA_CONFIG_VARS_CACHE}"
+
+    # If config.json provides redefinitions for our vars let us rewrite their
+    # runtime value
+    if ! read_config; then
+        # Re-try once
+        if ! read_config; then
+            echo "[ERROR] $0: Failed to read '$CONFIG_PATH'."
+            exit 1
+        fi
+    fi
+    if [ -n "${BALENA_CONFIG_VARS_CACHE}" ] && [ -n "${CONFIG_PARAMS}" ]; then
+        tmpfile=$(mktemp)
+        echo "${CONFIG_PARAMS}" | sed -e 's/^[[:space:]]*//' > "${tmpfile}"
+        chmod a+rx "${tmpfile}"
+        mv "${tmpfile}" "${BALENA_CONFIG_VARS_CACHE}"
+    fi
+    eval "$CONFIG_PARAMS"
 fi
 
 # "null" is a valid setting in config.json that should write


### PR DESCRIPTION
There have been reports of an empty config vars cache file - probably because of a race condition when the reading of config.json happens just as the file is being replaced.

Add some checks and retries to avoid this errors from happening.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [x] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
