### PR TITLE
resin-init-flasher: add jq dependency

### DIFF
--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher.bb
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher.bb
@@ -35,6 +35,7 @@ RDEPENDS:${PN}:append = "${@oe.utils.conditional('SIGN_API','','',' cryptsetup d
 # This should be just fine
 BALENA_IMAGE ?= "balena-image-${MACHINE}.balenaos-img"
 
+do_install[depends] += "jq-native:do_populate_sysroot"
 do_install() {
     # Make sure devices with internal storage, aka flasher device types define `INTERNAL_DEVICE_KERNEL` in integration layers
     if [ "$(jq -r '.data.storage.internal' "${TOPDIR}/../contracts/contracts/hw.device-type/${MACHINE}/contract.json")" = "true" ] &&[ -z "${INTERNAL_DEVICE_KERNEL}" ]; then


### PR DESCRIPTION
Without this dependency, the call to `jq` does not happen and the check for INTERNAL_DEVICE_KERNEL is not performed.

Several devices that define internal storage but do not define INTERNAL_DEVICE_KERNEL will now fail and need to be fixed.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
