### PR TITLE
initrdscripts: move mounting of log mounts to finish module

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/finish
+++ b/meta-balena-common/recipes-core/initrdscripts/files/finish
@@ -13,6 +13,22 @@ finish_enabled() {
     return 0
 }
 
+relocate_log_mount() {
+    # Preserve log file in rootfs
+    # Move the /run mountpoint to the rootfs mountpoint
+    if [ -d "${ROOTFS_DIR}/run" ]; then
+        if mountpoint '/run' > /dev/null; then
+            mount -n -o move /run "${ROOTFS_DIR}/run"
+        fi
+    else
+        # Older releases do not create /run so use /tmp instead
+        if mountpoint '/run' > /dev/null; then
+            mount -n -o move /run "${ROOTFS_DIR}/tmp"
+        fi
+    fi
+    sync "${ROOTFS_DIR}/run" "${ROOTFS_DIR}/tmp" || true
+}
+
 finish_run() {
     if [ -n "$ROOTFS_DIR" ]; then
         if [ ! -d $ROOTFS_DIR/dev ]; then
@@ -25,6 +41,8 @@ finish_run() {
         mount --move /dev $ROOTFS_DIR/dev
         mount --move /proc $ROOTFS_DIR/proc
         mount --move /sys $ROOTFS_DIR/sys
+        debug "Moving log mount into rootfs..."
+        relocate_log_mount
 
         cd $ROOTFS_DIR
         exec switch_root $ROOTFS_DIR ${bootparam_init:-/sbin/init}

--- a/meta-balena-common/recipes-core/initrdscripts/files/migrate
+++ b/meta-balena-common/recipes-core/initrdscripts/files/migrate
@@ -32,26 +32,9 @@ memory_check() {
     swapoff -a && swapon -a
     _memfree=$(awk '/MemFree/{free=$2} END{print (free*1024)}' /proc/meminfo)
     if [ "${_memfree}" -lt "${_size}" ]; then
-        relocate_log_mount
         fail "Not enough memory: requested ${_size}, available ${_memfree}"
     fi
     return 0
-}
-
-relocate_log_mount() {
-    # Preserve log file in rootfs
-    # Move the /run mountpoint to the rootfs mountpoint
-    if [ -d "${ROOTFS_DIR}/run" ]; then
-        if mountpoint '/run' > /dev/null; then
-            mount -n -o move /run "${ROOTFS_DIR}/run"
-        fi
-    else
-        # Older releases do not create /run so use /tmp instead
-        if mountpoint '/run' > /dev/null; then
-            mount -n -o move /run "${ROOTFS_DIR}/tmp"
-        fi
-    fi
-    sync "${ROOTFS_DIR}/run" "${ROOTFS_DIR}/tmp" || true
 }
 
 # Enable module function
@@ -85,7 +68,6 @@ migrate_enabled() {
                     info "Migration requested in configuration"
                 fi
             else
-                relocate_log_mount
                 fail "Flash boot partition not found in ${internal_dev}"
             fi
 
@@ -102,7 +84,6 @@ migrate_enabled() {
     fi
     # Booting from external media - leave flashing after pivot-rooting
     umount "${FLASH_BOOT_MOUNT}" > /dev/null || true
-    relocate_log_mount
     return 1
 }
 
@@ -121,7 +102,6 @@ migrate_run() {
             _total_size=$(("$_image_size" + "$_flash_boot_size" + "$_kernel_images_size"))
             memory_check "${_total_size}"
         else
-            relocate_log_mount
             fail "Flash boot partition not found in ${internal_dev}"
         fi
         # Copy the raw image to memory
@@ -151,7 +131,6 @@ migrate_run() {
         # Run flasher - should not return
         /usr/bin/resin-init-flasher
     else
-        relocate_log_mount
         # If recovery mode, wait for adbd to exit
         if [ -n "${ADBD_PID}" ]; then
             # adbd is not a child process so cannot wait

--- a/meta-balena-common/recipes-core/initrdscripts/files/migrate
+++ b/meta-balena-common/recipes-core/initrdscripts/files/migrate
@@ -83,7 +83,9 @@ migrate_enabled() {
         fi
     fi
     # Booting from external media - leave flashing after pivot-rooting
-    umount "${FLASH_BOOT_MOUNT}" > /dev/null || true
+    if mountpoint "${FLASH_BOOT_MOUNT}"; then
+        umount "${FLASH_BOOT_MOUNT}" > /dev/null || true
+    fi
     return 1
 }
 

--- a/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -109,9 +109,10 @@ FILES:initramfs-module-recovery = "/init.d/00-recovery"
 SUMMARY:initramfs-module-migrate = "OS Migration"
 RDEPENDS:initramfs-module-migrate = " \
     util-linux-findmnt \
-    util-linux-mountpoint \
     resin-init-flasher \
     bash \
     balena-config-vars-config \
     "
 FILES:initramfs-module-migrate = "/init.d/92-migrate"
+
+RDEPENDS:${PN}-base:append = " util-linux-mountpoint"

--- a/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -110,6 +110,7 @@ SUMMARY:initramfs-module-migrate = "OS Migration"
 RDEPENDS:initramfs-module-migrate = " \
     util-linux-findmnt \
     resin-init-flasher \
+    util-linux-mountpoint \
     bash \
     balena-config-vars-config \
     "


### PR DESCRIPTION
The log files are kept in the /run partition that also houses the udev database.

By moving the /run partition to $ROOTFS_DIR/run in the migrate module, the udev database persists across reboots.

The udevcleanup module was introduced to cleanup the database so it's regenerated on the final rootfs as the rules are different between initramfs and final rootfs. By moving /run before udevcleanup ran, the cleanup was not effective.

This commit moves the relocation of the /run mount to the finish module, after udevcleanup is run, and groups it with the other relocations needed for the pivot switch.

Looking at git history, the relocation of the /run partition was initially done in the rootfs module, so when the migrate module was introduced and needed to mount the rootfs, this relocation was just moved into the migration module itself, without considering later modules like finish.

Change-type: minor


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [x] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
