### PR TITLE
hostapp-update-hooks: add debug mode

### DIFF
--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/hostapp-update-hooks
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/hostapp-update-hooks
@@ -2,6 +2,11 @@
 
 set -o errexit
 
+# shellcheck disable=SC1091
+. /usr/libexec/os-helpers-logging
+# shellcheck disable=SC1091
+. /usr/sbin/balena-config-defaults
+
 old_os_before_hooks=0
 old_os_after_hooks=0
 forward_hooks=1
@@ -35,6 +40,15 @@ Options:
 	-h, --help
 		Display this help and exit.
 EOF
+}
+
+DEBUG=$(jq -r '.debug // empty' "${CONFIG_PATH}")
+run_hook () {
+	if [ "${DEBUG}" = "1" ]; then
+		/bin/sh -x "$1"
+	else
+		"$1"
+	fi
 }
 
 # Parse arguments
@@ -82,13 +96,13 @@ list_of_old_os_after_hooks=$(find "${HOOKS_DIR}" -type f | grep after | sort)
 
 if [ "$old_os_before_hooks" = "1" ] ; then
 	for hook in $list_of_old_os_before_hooks; do
-		"$hook"
+		run_hook "$hook"
 	done
 fi
 
 if [ "$forward_hooks" = "1" ] ; then
 	for hook in $list_of_forward_hooks; do
-		if ! "$hook" ; then
+		if ! run_hook "$hook" ; then
 			forward_cleanup=1
 			break
 		fi
@@ -97,19 +111,19 @@ fi
 
 if [ "$old_os_after_hooks" = "1" ] ; then
 	for hook in $list_of_old_os_after_hooks; do
-		"$hook"
+		run_hook "$hook"
 	done
 fi
 
 if [ "$commit_hooks" = "1" ] ; then
 	for hook in $list_of_forward_commit_hooks; do
-		"$hook"
+		run_hook "$hook"
 	done
 fi
 
 if [ "$forward_cleanup" = "1" ] ; then
 	for hook in $list_of_forward_cleanup_hooks; do
-		"$hook"
+		run_hook "$hook"
 	done
 	exit 1
 fi


### PR DESCRIPTION
This provides an easy switch to enable tracing on HUP hooks that works both on old and new OS hooks as enabling it depends on a config.json setting.

It is meant to debug field issues with HUP failure where all we see is:
```
Before hooks (old os) ran successfully
Failed to run the new hooks. Running current hooks..
```
For example:
https://jel.ly.fish/support-thread-1-0-0-front-cnv-eq6ipvx

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
