### PR TITLE
resin_update_state_probe: ignore RAID members when looking for root

### DIFF
--- a/meta-balena-common/recipes-core/systemd/systemd/resin_update_state_probe
+++ b/meta-balena-common/recipes-core/systemd/systemd/resin_update_state_probe
@@ -50,7 +50,25 @@ else
 	ruuid=$(get_cmdline_root_uuid)
 fi
 # Determine if the partition is on the same drive as root
-rpdev=$(lsblk -nlo pkname,uuid | grep "${ruuid}" | cut -d " " -f1) || true
+rpdev=""
+
+# Look for the filesystem by UUID
+# lsblk returns multiple entries when the root is on RAID1
+# (the virtual MD device and each of the members).
+# Loop through the candidates and ignore RAID members.
+# This will also randomly choose the first device that matches the UUID
+# if multiple devices with the same filesystem UUID are connected
+# (e.g. a cloned drive).
+for cand in $(lsblk -nlo pkname,uuid | grep "${ruuid}" | cut -d " " -f1); do
+	cand_fstype=$(lsblk "/dev/${cand}" -ndlo fstype) || true
+	if [ "${cand_fstype}" = "linux_raid_member" ]; then
+		continue
+	fi
+
+	rpdev="${cand}"
+	break
+done
+
 if [ -n "${rpdev}" ]; then
 	rptype=$(lsblk -nlo type,uuid | grep "${ruuid}" | cut -d " " -f1) || true
 	if [ "${rptype}" = "crypt" ]; then


### PR DESCRIPTION
At this moment `resin_update_state_probe` looks for the root partition by UUID and assumes that only a single device is returned. This assumption breaks when the root is on a MD RAID1 device as not only the virtual MD device holds a filesystem with the given UUID, each member does as well.

This patch makes `resin_update_state_probe` ignore devices that are RAID members which in that case will only return the MD device as expected.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
