### PR TITLE
tests/bluetooth: Leave Autokit host discoverable on BT for a longer p…

### DIFF
--- a/tests/suites/os/tests/bluetooth/index.js
+++ b/tests/suites/os/tests/bluetooth/index.js
@@ -37,7 +37,10 @@ module.exports = {
 					// get the testbot bluetooth name
 					let btName = await this.worker.executeCommandInWorker('bluetoothctl show | grep Name');
 					let btNameParsed = /(.*): (.*)/.exec(btName); // the bluetoothctl command returns "Name: <btname>", so extract the <btname here>
-					// make testbot bluetooth discoverable
+
+          // leave the host discoverable for a longer period of time to prevent sporadic discover failures with Pi3
+          await this.worker.executeCommandInWorker('bluetoothctl discoverable-timeout 1200');
+          // make testbot bluetooth discoverable
 					await this.worker.executeCommandInWorker('bluetoothctl discoverable on');
 
 					// scan for bluetooth devices on DUT, we retry a couple of times


### PR DESCRIPTION
…eriod of time

We've noticed that leaving the host discoverable indefinitely on Pi3 Autokit hosts solves sporadic scan failures. Thus, leaving the host discoverable for 20 minutes should be sufficient to prevent these cases.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
