### PR TITLE
networkmanager: make FORWARD rules for shared interfaces last in chain

### DIFF
--- a/meta-balena-common/recipes-connectivity/networkmanager/balena-files/90shared
+++ b/meta-balena-common/recipes-connectivity/networkmanager/balena-files/90shared
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Copyright 2024 Balena Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This script hooks to the "up" event of every interface
+# It checks whether there is a rule commented "nm-shared-$IFNAME"
+# in the FORWARD chain and if it is, removes it from its current
+# position and appends to the end.
+#
+# This is necessary because of a race condition between NetworkManager
+# and the balenaEngine when setting up their respective sets of firewall
+# rules. If the balenaEngine sets up its rules last (IOW on top
+# of the FORWARD chain), containers are allowed to route to the DHCP
+# clients behind the shared interface. If NetworkManager sets its rules
+# last, the containers will be denied access to the shared network.
+#
+# While the latter seems cleaner, some users actually benefit from
+# the containers being able to route behind the shared interface,
+# so we choose to prefer that behavior. This script overcomes
+# the race condition and always sets the FORWARD rules
+# as if balenaEngine came up last.
+
+. /usr/libexec/os-helpers-logging
+
+if [ "$2" != "up" ]
+then
+  exit 0
+fi
+
+IFNAME="$1"
+
+# Look for the FORWARD rule that NetworkManager adds for interfaces
+# configured as shared. This will have a comment "nm-shared-$IFNAME"
+# and jump into a chain named "sh-fw-$IFNAME"
+FW_RULE_NO=$(iptables -L FORWARD --line-number | grep "sh-fw-${IFNAME}" | grep "nm-shared-${IFNAME}" | cut -d " " -f 1)
+if [ "x${FW_RULE_NO}" = "x" ]
+then
+  exit 0
+fi
+
+# Safeguard, this should never happen
+# Exactly 0 or 1 rule should match, bail out if there are more & investigate
+if [ "$(echo ${FW_RULE_NO} | wc -w)" -gt 1 ]
+then
+  fail "More than one rule matched when looking for 'nm-shared-${IFNAME}', bailing out"
+fi
+
+info "Found shared FORWARD rule 'nm-shared-${IFNAME}' at index ${FW_RULE_NO}, moving down"
+
+FW_RULE_ARGS="$(iptables -S FORWARD ${FW_RULE_NO})"
+
+# Append the rule to the bottom
+# Do not quote ${FW_RULE_ARGS}, this needs to expand
+iptables ${FW_RULE_ARGS}
+
+# Remove the rule from its original position
+iptables -D FORWARD "${FW_RULE_NO}"

--- a/meta-balena-common/recipes-connectivity/networkmanager/networkmanager_1.40.4.bbappend
+++ b/meta-balena-common/recipes-connectivity/networkmanager/networkmanager_1.40.4.bbappend
@@ -5,6 +5,7 @@ FILESEXTRAPATHS:append := ":${THISDIR}/balena-files:${THISDIR}/${BPN}"
 SRC_URI:append = " \
     file://NetworkManager.conf.systemd \
     file://NetworkManager.conf \
+    file://90shared \
     file://98dhcp_ntp \
     file://99onoffline_ntp \
     file://README.ignore \
@@ -24,6 +25,7 @@ RDEPENDS:${PN}:append = " \
     chronyc \
     balena-net-config \
     resolvconf \
+    os-helpers-logging \
     "
 FILES:${PN}:append = " ${sysconfdir}/*"
 
@@ -55,6 +57,7 @@ do_install:append() {
 
     # Install balena dispatch scripts in /usr/lib/NetworkManager/dispatcher.d/ as
     # /etc/NetworkManager/dispatcher.d/ is used for user-provided scripts
+    install -m 0755 ${WORKDIR}/90shared ${D}${libdir}/NetworkManager/dispatcher.d/
     install -m 0755 ${WORKDIR}/98dhcp_ntp ${D}${libdir}/NetworkManager/dispatcher.d/
     install -m 0755 ${WORKDIR}/99onoffline_ntp ${D}${libdir}/NetworkManager/dispatcher.d/
 


### PR DESCRIPTION
At this moment there is a race condition between NetworkManager and the engine when a shared interface is configured. If the interface is configured first and the engine second, the containers are allowed to access DHCP hosts behind the shared interface. If the engine comes up first and the shared interface second, access will be denied.

This patch adds a dispatcher script that always configures the firewall rules as if the engine came up last. This does not really address the underlying issue but it overcomes the race condition and makes the behavior deterministic, which is good enough at this point.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
