### PR TITLE
balena-unique-key: avoid all digits short UUIDs

### DIFF
--- a/meta-balena-common/recipes-support/balena-unique-key/balena-unique-key/balena-unique-key
+++ b/meta-balena-common/recipes-support/balena-unique-key/balena-unique-key/balena-unique-key
@@ -48,11 +48,17 @@ if ! key=$("${CAT}" "${CONFIG_PATH}" | jq -r ".$key_name //empty"); then
 fi
 
 if [ -z "$key" ]; then
+    key=$(openssl rand -hex 16)
+    cnt=100
+    while echo "$key" | grep -q -E '^[0-9]{7}'; do
+        key=$(openssl rand -hex 16)
+        cnt=$((cnt -1))
+        if [ ! $cnt ]; then
+            echo "[ERROR] balena-unique-key : Failed to generate the random key."
+            exit 1
+        fi
+    done
     echo "[INFO] balena-unique-key: $key_name missing from config file. Generating..."
-    if ! key=$(openssl rand -hex 16); then
-        echo "[ERROR] balena-unique-key : Failed to generate the random key."
-        exit 1
-    fi
     "${CAT}" "$CONFIG_PATH" | jq ".$key_name=\"$key\"" | "${WR}" "$CONFIG_PATH"
 else
     echo "[INFO] balena-unique-key : Device already has $key_name assigned."


### PR DESCRIPTION
All digit short UUIDs are not resolved and instead treated as IP addresses. Iterate the UUID generation to avoid them starting with 7 digits.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
