### PR TITLE
balena-rollback/rollback-health: Allow old OS hooks to access efivars

### DIFF
--- a/meta-balena-common/recipes-core/balena-rollback/files/rollback-health
+++ b/meta-balena-common/recipes-core/balena-rollback/files/rollback-health
@@ -42,6 +42,11 @@ run_hooks_from_inactive () {
 	mount --bind /mnt/sysroot/inactive/ "${old_rootfs}/mnt/sysroot/inactive/"
 	mount -t sysfs sysfs "${old_rootfs}/sys/"
 
+	# Allow old OS hooks to access efivars
+	if [ -d /sys/firmware/efi/efivars ]; then
+		mount -t efivarfs efivarfs "${old_rootfs}/sys/firmware/efi/efivars" || true
+	fi
+
 	# In case of secure boot the boot and EFI partitions are split apart
 	# The EFI partition must be bind-mounted as well to be able to deploy
 	# files under /mnt/boot/EFI


### PR DESCRIPTION
This fixes rollback-health failures for boards like the Jetson Seeeed J4012, which updates efivars for capsule updates from container hooks and not from the current OS hooks. This problem was spotted while running Autokit tests as per internal thread https://balena.zulipchat.com/#narrow/stream/403752-channel.2Fsupport-help/topic/Missing.20binder.20module.20in.20L4T.2FBalenaOS/near/419425908

While the actual HUP works because of /sys being bindmounted by hostapp-update, rollbacks will fail to run the old OS hooks unless efivarfs is mounted.

Change-type: patch

Tested manually on the following configurations:

Seeed J4012
- rollback-altboot from latest cloud image to PR - passed
- rollback-health balena-engine from latest cloud image to PR - passed
- rollback-health vpn from latest cloud image to PR - passed
- rollback-health from PR to PR - passed
- HUP from latest cloud image to PR - passed

Orin NX:
- rollback-health from old cloud image to PR - passed
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [x] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
