### PR TITLE
patch: add -w LDFlags for balena-engine compilation

### DIFF
--- a/meta-balena-common/recipes-containers/balena/balena_git.bb
+++ b/meta-balena-common/recipes-containers/balena/balena_git.bb
@@ -88,7 +88,7 @@ do_compile() {
 	export CGO_CFLAGS="${CFLAGS} --sysroot=${STAGING_DIR_TARGET}"
 	export CGO_LDFLAGS="${LDFLAGS} --sysroot=${STAGING_DIR_TARGET}"
 	export DOCKER_BUILDTAGS="${BUILD_TAGS} ${PACKAGECONFIG_CONFARGS}"
-	export DOCKER_LDFLAGS="-s"
+	export DOCKER_LDFLAGS="-s -w"
 	export GO111MODULE=off
 
 	export DISABLE_WARN_OUTSIDE_CONTAINER=1


### PR DESCRIPTION
This will prevent the DWARF debug info generation and so produce a smaller engine build