### PR TITLE
balena-image-bootloader-initramfs.bb: Add fsck module

### DIFF
--- a/meta-balena-common/recipes-core/images/balena-image-bootloader-initramfs.bb
+++ b/meta-balena-common/recipes-core/images/balena-image-bootloader-initramfs.bb
@@ -10,6 +10,7 @@ PACKAGE_INSTALL = " \
     glibc-gconv-ibm850 \
     initramfs-module-abroot \
     initramfs-module-debug \
+    initramfs-module-fsck \
     initramfs-module-kexec \
     initramfs-module-udev \
     initramfs-framework-base \

--- a/meta-balena-common/recipes-core/initrdscripts/files/fsck
+++ b/meta-balena-common/recipes-core/initrdscripts/files/fsck
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# shellcheck disable=SC1091
+. /usr/libexec/os-helpers-fs
+
 fsck_enabled() {
     # On flasher we don't run fsck
     # shellcheck disable=SC2154


### PR DESCRIPTION
The balena bootloader initramfs contains the rootfs module and that will get the rootfs mounted but not checked first for errors. This is problematic because at first boot with network connectivity available, time will sync but the rootfs will still have the last mount time in
1970. If at that point the rootfs gets corrupted then at next boot the rootfs' initramfs module from balena-bootloader will try to mount the rootfs without checking it first and then after that the filesystem check triggered by the fsck module from the actual kernel initramfs will fail like this:

[init][INFO] Running filesystem checks on partition resin-rootA (/dev/disk/by-state/resin-rootA) resin-rootA contains a file system with errors, check forced. resin-rootA: Inodes that were part of a corrupted orphan linked list found.

resin-rootA: UNEXPECTED INCONSISTENCY; RUN fsck MANUALLY.
        (i.e., without -a or -p options)

This commit will add the fsck module to balena bootloader's initramfs which will trigger filesystem checks before the rootfs module runs.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
