### PR TITLE
tests: cloud: if no existing release, create generic fleet

### DIFF
--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -178,9 +178,19 @@ module.exports = {
 
     // create a balena application
     this.log("Creating application in cloud...");
+
+    let appDeviceType = this.suite.deviceType.slug;
+    // check to see if there is an existing release for this device type in balena cloud - if not, create a generic-arch fleet
+    // This is required for new device types with no existing balena cloud releases, as the fleet creation fails if there are no releases yet
+    // It can't accept invalid deviceType because we check contracts already in the start
+    if (((await this.cloud.balena.models.os.getAvailableOsVersions(this.suite.deviceType.slug)).length) === 0) {
+      appDeviceType = `generic-${this.suite.deviceType.data.arch}`;
+      this.log(`No existing releases found for ${this.suite.deviceType.slug}... creating fleet with ${appDeviceType}`)
+    }
+
     const app = await this.cloud.balena.models.application.create({
       name: this.balena.name,
-      deviceType: this.suite.deviceType.slug,
+      deviceType: appDeviceType,
       organization: this.balena.organization,
     });
 


### PR DESCRIPTION
This is to solve the test failures for the cloud suite when there is no existing balena cloud release - causing the app creation to fail. In this case we use a generic-arch fleet instead. 

Should reduce some of the friction for first deployment

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
