### PR TITLE
Extract balena ca before os-config watcher service

### DIFF
--- a/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/config-json.service
+++ b/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/config-json.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Config.json watcher service
+Before=extract-balena-ca.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This is to avoid any race conditions before os-config does any required steps when config.json is changed.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
