### PR TITLE
recipes-bsp: add recipe for GRUB 2.12

### DIFF
--- a/meta-balena-common/conf/image-uefi.conf
+++ b/meta-balena-common/conf/image-uefi.conf
@@ -1,0 +1,21 @@
+# Location of EFI files inside EFI System Partition
+EFIDIR ?= "/EFI/BOOT"
+
+# Prefix where ESP is mounted inside rootfs. Set to empty if package is going
+# to be installed to ESP directly
+EFI_PREFIX ?= "/boot"
+
+# Location inside rootfs.
+EFI_FILES_PATH = "${EFI_PREFIX}${EFIDIR}"
+
+# The EFI name for the architecture
+EFI_ARCH ?= "INVALID"
+EFI_ARCH:x86 = "ia32"
+EFI_ARCH:x86-64 = "x64"
+EFI_ARCH:aarch64 = "aa64"
+EFI_ARCH:arm = "arm"
+EFI_ARCH:riscv32 = "riscv32"
+EFI_ARCH:riscv64 = "riscv64"
+
+# Determine name of bootloader image
+EFI_BOOT_IMAGE ?= "boot${EFI_ARCH}.efi"

--- a/meta-balena-common/recipes-bsp/grub/files/0001-Disable-mfpmath-sse-as-well-when-SSE-is-disabled.patch
+++ b/meta-balena-common/recipes-bsp/grub/files/0001-Disable-mfpmath-sse-as-well-when-SSE-is-disabled.patch
@@ -1,0 +1,44 @@
+From 006799e9c4babe8a8340a24501b253e759614a2d Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 13 Jan 2016 19:17:31 +0000
+Subject: [PATCH] Disable -mfpmath=sse as well when SSE is disabled
+
+Fixes
+
+configure:20574: i586-poky-linux-gcc  -m32    -march=core2 -msse3
+-mtune=generic -mfpmath=sse
+--sysroot=/usr/local/dev/yocto/grubtest2/build/tmp/sysroots/emenlow -o
+conftest -O2 -pipe -g -feliminate-unused-debug-types -Wall -W -Wshadow
+-Wpointer-arith -Wmissing-prototypes -Wundef -Wstrict-prototypes -g
+-falign-jumps=1 -falign-loops=1 -falign-functions=1 -mno-mmx -mno-sse
+-mno-sse2 -mno-3dnow -fno-dwarf2-cfi-asm -m32 -fno-stack-protector
+-mno-stack-arg-probe -Werror -nostdlib -Wl,--defsym,___main=0x8100
+-Wall -W -I$(top_srcdir)/include -I$(top_builddir)/include
+-DGRUB_MACHINE_PCBIOS=1 -DGRUB_MACHINE=I386_PC -Wl,-O1
+-Wl,--hash-style=gnu -Wl,--as-needed conftest.c  >&5
+conftest.c:1:0: error: SSE instruction set disabled, using 387
+arithmetics [-Werror]
+cc1: all warnings being treated as errors
+
+Signed-off-by: Nitin A Kamble <nitin.a.kamble@intel.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Upstream-Status: Pending
+
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index cd667a2..8263876 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -846,7 +846,7 @@ fi
+ if ( test "x$target_cpu" = xi386 || test "x$target_cpu" = xx86_64 ) && test "x$platform" != xemu; then
+   # Some toolchains enable these features by default, but they need
+   # registers that aren't set up properly in GRUB.
+-  TARGET_CFLAGS="$TARGET_CFLAGS -mno-mmx -mno-sse -mno-sse2 -mno-sse3 -mno-3dnow"
++  TARGET_CFLAGS="$TARGET_CFLAGS -mno-mmx -mno-sse -mno-sse2 -mno-sse3 -mno-3dnow -mfpmath=387"
+ fi
+ 
+ if ( test "x$target_cpu" = xi386 || test "x$target_cpu" = xx86_64 ); then

--- a/meta-balena-common/recipes-bsp/grub/files/0001-RISC-V-Restore-the-typcast-to-long.patch
+++ b/meta-balena-common/recipes-bsp/grub/files/0001-RISC-V-Restore-the-typcast-to-long.patch
@@ -1,0 +1,37 @@
+From b47029e8e582d17c6874d2622fe1a5b834377dbb Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 26 Mar 2021 11:59:43 -0700
+Subject: [PATCH] RISC-V: Restore the typcast to 64bit type
+
+this makes the type promotions clear and explicit
+It was already typecasted to long but was accidentally dropped in [1]
+which stated to cause failures on riscv32 as reported in [2]
+
+[1] https://git.savannah.gnu.org/cgit/grub.git/commit/?id=2bf40e9e5be9808b17852e688eead87acff14420
+[2] https://savannah.gnu.org/bugs/index.php?60283
+
+Upstream-Status: Submitted
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Cc: Andreas Schwab <schwab@suse.de>
+Cc: Daniel Kiper <daniel.kiper@oracle.com>
+Cc: Chester Lin <clin@suse.com>
+Cc: Nikita Ermakov <arei@altlinux.org>
+Cc: Alistair Francis <alistair.francis@wdc.com>
+
+---
+ util/grub-mkimagexx.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/util/grub-mkimagexx.c b/util/grub-mkimagexx.c
+index e50b295..2f09255 100644
+--- a/util/grub-mkimagexx.c
++++ b/util/grub-mkimagexx.c
+@@ -1310,7 +1310,7 @@ SUFFIX (relocate_addrs) (Elf_Ehdr *e, struct section_metadata *smd,
+ 		  */
+ 
+ 		 sym_addr += addend;
+-		 off = sym_addr - target_section_addr - offset - image_target->vaddr_offset;
++		 off = (grub_int64_t)sym_addr - target_section_addr - offset - image_target->vaddr_offset;
+ 
+ 		 switch (ELF_R_TYPE (info))
+ 		   {

--- a/meta-balena-common/recipes-bsp/grub/files/0001-grub.d-10_linux.in-add-oe-s-kernel-name.patch
+++ b/meta-balena-common/recipes-bsp/grub/files/0001-grub.d-10_linux.in-add-oe-s-kernel-name.patch
@@ -1,0 +1,54 @@
+From a80592e20f6c4b928a22862f52f268ab9d9908b2 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 13 Jan 2016 19:28:00 +0000
+Subject: [PATCH] grub.d/10_linux.in: add oe's kernel name
+
+Our kernel's name is bzImage, we need add it to grub.d/10_linux.in so
+that the grub-mkconfig and grub-install can work correctly.
+
+We only need add the bzImage to util/grub.d/10_linux.in, but also add it
+to util/grub.d/20_linux_xen.in to keep compatibility.
+
+Signed-off-by: Robert Yang <liezhi.yang@windriver.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Upstream-Status: Inappropriate [OE specific]
+
+---
+ util/grub.d/10_linux.in     | 6 +++---
+ util/grub.d/20_linux_xen.in | 2 +-
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
+index cc393be..8545cb6 100644
+--- a/util/grub.d/10_linux.in
++++ b/util/grub.d/10_linux.in
+@@ -166,12 +166,12 @@ machine=`uname -m`
+ case "x$machine" in
+     xi?86 | xx86_64)
+ 	list=
+-	for i in /boot/vmlinuz-* /vmlinuz-* /boot/kernel-* ; do
++	for i in /boot/bzImage-* /bzImage-* /boot/vmlinuz-* /vmlinuz-* /boot/kernel-* ; do
+ 	    if grub_file_is_not_garbage "$i" ; then list="$list $i" ; fi
+ 	done ;;
+-    *) 
++    *)
+ 	list=
+-	for i in /boot/vmlinuz-* /boot/vmlinux-* /vmlinuz-* /vmlinux-* /boot/kernel-* ; do
++	for i in /boot/bzImage-* /boot/vmlinuz-* /boot/vmlinux-* /bzImage-* /vmlinuz-* /vmlinux-* /boot/kernel-* ; do
+                   if grub_file_is_not_garbage "$i" ; then list="$list $i" ; fi
+ 	done ;;
+ esac
+diff --git a/util/grub.d/20_linux_xen.in b/util/grub.d/20_linux_xen.in
+index 94dd8be..36cd554 100644
+--- a/util/grub.d/20_linux_xen.in
++++ b/util/grub.d/20_linux_xen.in
+@@ -181,7 +181,7 @@ EOF
+ }
+ 
+ linux_list=
+-for i in /boot/vmlinu[xz]-* /vmlinu[xz]-* /boot/kernel-*; do
++for i in /boot/bzImage[xz]-* /bzImage[xz]-* /boot/vmlinu[xz]-* /vmlinu[xz]-* /boot/kernel-*; do
+     if grub_file_is_not_garbage "$i"; then
+     	basename=$(basename $i)
+ 	version=$(echo $basename | sed -e "s,^[^0-9]*-,,g")

--- a/meta-balena-common/recipes-bsp/grub/files/autogen.sh-exclude-pc.patch
+++ b/meta-balena-common/recipes-bsp/grub/files/autogen.sh-exclude-pc.patch
@@ -1,0 +1,34 @@
+From 14c1d0459fb3561e627d3a5f6e91a0d2f7b4aa45 Mon Sep 17 00:00:00 2001
+From: Naveen Saini <naveen.kumar.saini@intel.com>
+Date: Mon, 15 Mar 2021 14:44:15 +0800
+Subject: [PATCH] autogen.sh: exclude .pc from po/POTFILES.in
+
+Exclude the .pc from po/POTFILES.in since quilt uses "patch --backup",
+which will create the backup file under .pc, this may cause unexpected
+errors, for example, on CentOS 5.x, if the backup file is null
+(newfile), it's mode will be 000, then we will get errors when xgettext
+try to read it.
+
+Upstream-Status: Inappropriate [OE specific]
+
+Signed-off-by: Robert Yang <liezhi.yang@windriver.com>
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
+
+---
+ autogen.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/autogen.sh b/autogen.sh
+index 195daa5..773b7b4 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -26,7 +26,7 @@ fi
+ export LC_COLLATE=C
+ unset LC_ALL
+ 
+-find . -iname '*.[ch]' ! -ipath './grub-core/lib/libgcrypt-grub/*' ! -ipath './build-aux/*' ! -ipath './grub-core/lib/libgcrypt/src/misc.c' ! -ipath './grub-core/lib/libgcrypt/src/global.c' ! -ipath './grub-core/lib/libgcrypt/src/secmem.c'  ! -ipath './util/grub-gen-widthspec.c' ! -ipath './util/grub-gen-asciih.c' ! -ipath './gnulib/*' ! -ipath './grub-core/lib/gnulib/*' |sort > po/POTFILES.in
++find . -iname '*.[ch]' ! -ipath './grub-core/lib/libgcrypt-grub/*' ! -ipath './build-aux/*' ! -ipath './grub-core/lib/libgcrypt/src/misc.c' ! -ipath './grub-core/lib/libgcrypt/src/global.c' ! -ipath './grub-core/lib/libgcrypt/src/secmem.c'  ! -ipath './util/grub-gen-widthspec.c' ! -ipath './util/grub-gen-asciih.c' ! -ipath './gnulib/*' ! -ipath './grub-core/lib/gnulib/*' ! -path './.pc/*' |sort > po/POTFILES.in
+ find util -iname '*.in' ! -name Makefile.in  |sort > po/POTFILES-shell.in
+ 
+ echo "Importing unicode..."

--- a/meta-balena-common/recipes-bsp/grub/files/cfg
+++ b/meta-balena-common/recipes-bsp/grub/files/cfg
@@ -1,0 +1,2 @@
+search.file ($cmdpath)/EFI/BOOT/grub.cfg root
+set prefix=($root)/EFI/BOOT

--- a/meta-balena-common/recipes-bsp/grub/files/grub-module-explicitly-keeps-symbole-.module_license.patch
+++ b/meta-balena-common/recipes-bsp/grub/files/grub-module-explicitly-keeps-symbole-.module_license.patch
@@ -1,0 +1,60 @@
+From b316ed326bd492106006d78f5bfcd767b49a4f2e Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Wed, 17 Aug 2016 04:06:34 -0400
+Subject: [PATCH] grub module explicitly keeps symbole .module_license
+
+While using oe-core toolchain to strip grub module 'all_video.mod',
+it stripped symbol table:
+
+---------------
+root@localhost:~# objdump -t all_video.mod
+
+all_video.mod:     file format elf64-x86-64
+
+SYMBOL TABLE:
+no symbols
+--------------
+
+It caused grub to load module all_video failed.
+--------------
+grub> insmod all_video
+error: no symbol table.
+--------------
+
+Tweak strip option to keep symbol .module_license could workaround
+the issue.
+--------------
+root@localhost:~# objdump -t all_video.mod
+
+all_video.mod:     file format elf64-x86-64
+
+SYMBOL TABLE:
+0000000000000000 l    d  .text  0000000000000000 .text
+0000000000000000 l    d  .data  0000000000000000 .data
+0000000000000000 l    d  .module_license        0000000000000000 .module_license
+0000000000000000 l    d  .bss   0000000000000000 .bss
+0000000000000000 l    d  .moddeps       0000000000000000 .moddeps
+0000000000000000 l    d  .modname       0000000000000000 .modname
+--------------
+
+Upstream-Status: Pending
+
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+
+---
+ grub-core/genmod.sh.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/grub-core/genmod.sh.in b/grub-core/genmod.sh.in
+index e57c4d9..42bb1ba 100644
+--- a/grub-core/genmod.sh.in
++++ b/grub-core/genmod.sh.in
+@@ -56,7 +56,7 @@ if test x@TARGET_APPLE_LINKER@ != x1; then
+ 	if test x@platform@ != xemu; then
+ 	    @TARGET_STRIP@ --strip-unneeded \
+ 		-K grub_mod_init -K grub_mod_fini \
+-		-K _grub_mod_init -K _grub_mod_fini \
++		-K _grub_mod_init -K _grub_mod_fini -K .module_license \
+ 		-R .note.gnu.gold-version -R .note.GNU-stack \
+ 		-R .gnu.build.attributes \
+ 		-R .rel.gnu.build.attributes \

--- a/meta-balena-common/recipes-bsp/grub/grub-bootconf_1.00.bb
+++ b/meta-balena-common/recipes-bsp/grub/grub-bootconf_1.00.bb
@@ -1,0 +1,32 @@
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+SUMMARY = "Basic grub.cfg for use in EFI systems"
+DESCRIPTION = "Grub might require different configuration file for \
+different machines."
+HOMEPAGE = "https://www.gnu.org/software/grub/manual/grub/grub.html#Configuration"
+
+RPROVIDES:${PN} += "virtual-grub-bootconf"
+
+inherit grub-efi-cfg
+
+require conf/image-uefi.conf
+
+S = "${WORKDIR}"
+
+GRUB_CFG = "${S}/grub-bootconf"
+LABELS = "boot"
+
+ROOT ?= "root=/dev/sda2"
+
+python do_configure() {
+    bb.build.exec_func('build_efi_cfg', d)
+}
+
+do_configure[vardeps] += "APPEND ROOT"
+
+do_install() {
+	install -d ${D}${EFI_FILES_PATH}
+	install grub-bootconf ${D}${EFI_FILES_PATH}/grub.cfg
+}
+
+FILES:${PN} = "${EFI_FILES_PATH}/grub.cfg"

--- a/meta-balena-common/recipes-bsp/grub/grub-efi/0001-Add-dummyterm-module.patch
+++ b/meta-balena-common/recipes-bsp/grub/grub-efi/0001-Add-dummyterm-module.patch
@@ -1,7 +1,7 @@
-From 8c231b09bcd8742506e6511009573bd24c46dfc6 Mon Sep 17 00:00:00 2001
+From dbc0ac6617a91ad8b37c40fc0e1ea3e429650541 Mon Sep 17 00:00:00 2001
 From: Michal Toman <michalt@balena.io>
 Date: Tue, 23 Nov 2021 19:37:18 +0100
-Subject: [PATCH] Add dummyterm module
+Subject: [PATCH 1/1] Add dummyterm module
 
 We want GRUB to output nothing and accept no input under specific. By default
 GRUB has no such option and will require at least one input and one output
@@ -9,6 +9,7 @@ to be configured. This patch adds a dummy terminal module that throws away
 any input or output that goes through it.
 
 Signed-off-by: Michal Toman <michalt@balena.io>
+Signed-off-by: Joseph Kogut <joseph@balena.io>
 ---
  grub-core/Makefile.core.def |  5 +++
  grub-core/term/dummy.c      | 65 +++++++++++++++++++++++++++++++++++++
@@ -16,10 +17,10 @@ Signed-off-by: Michal Toman <michalt@balena.io>
  create mode 100644 grub-core/term/dummy.c
 
 diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
-index 8022e1c0a..0c0a344ec 100644
+index d2cf29584..00d6c04a4 100644
 --- a/grub-core/Makefile.core.def
 +++ b/grub-core/Makefile.core.def
-@@ -1042,6 +1042,11 @@ module = {
+@@ -1071,6 +1071,11 @@ module = {
    enable = x86;
  };
  
@@ -103,5 +104,5 @@ index 000000000..e204a4e3a
 +  grub_term_unregister_output (&grub_dummy_term_output);
 +}
 -- 
-2.31.1
+2.42.0
 

--- a/meta-balena-common/recipes-bsp/grub/grub-efi_2.12.bb
+++ b/meta-balena-common/recipes-bsp/grub/grub-efi_2.12.bb
@@ -1,0 +1,105 @@
+require grub2.inc
+
+require conf/image-uefi.conf
+
+GRUBPLATFORM = "efi"
+
+DEPENDS:append = " grub-native"
+RDEPENDS:${PN} = "grub-common virtual-grub-bootconf"
+
+SRC_URI += " \
+           file://cfg \
+          "
+
+S = "${WORKDIR}/grub-${PV}"
+
+# Determine the target arch for the grub modules
+python __anonymous () {
+    import re
+    target = d.getVar('TARGET_ARCH')
+    prefix = "" if d.getVar('EFI_PROVIDER') == "grub-efi" else "grub-efi-"
+    if target == "x86_64":
+        grubtarget = 'x86_64'
+    elif re.match('i.86', target):
+        grubtarget = 'i386'
+    elif re.match('aarch64', target):
+        grubtarget = 'arm64'
+    elif re.match('arm', target):
+        grubtarget = 'arm'
+    elif re.match('riscv64', target):
+        grubtarget = 'riscv64'
+    elif re.match('riscv32', target):
+        grubtarget = 'riscv32'
+    else:
+        raise bb.parse.SkipRecipe("grub-efi is incompatible with target %s" % target)
+    grubimage = prefix + d.getVar("EFI_BOOT_IMAGE")
+    d.setVar("GRUB_TARGET", grubtarget)
+    d.setVar("GRUB_IMAGE", grubimage)
+    prefix = "grub-efi-" if prefix == "" else ""
+    d.setVar("GRUB_IMAGE_PREFIX", prefix)
+}
+
+inherit deploy
+
+CACHED_CONFIGUREVARS += "ac_cv_path_HELP2MAN="
+EXTRA_OECONF += "--enable-efiemu=no"
+
+do_mkimage() {
+	cd ${B}
+
+	GRUB_MKIMAGE_MODULES="${GRUB_BUILDIN}"
+
+	# If 'all' is included in GRUB_BUILDIN we will include all available grub2 modules
+	if [ "${@ bb.utils.contains('GRUB_BUILDIN', 'all', 'True', 'False', d)}" = "True" ]; then
+		bbdebug 1 "Including all available modules"
+		# Get the list of all .mod files in grub-core build directory
+		GRUB_MKIMAGE_MODULES=$(find ${B}/grub-core/ -type f -name "*.mod" -exec basename {} .mod \;)
+	fi
+
+	# Search for the grub.cfg on the local boot media by using the
+	# built in cfg file provided via this recipe
+	grub-mkimage -v -c ../cfg -p ${EFIDIR} -d ./grub-core/ \
+	               -O ${GRUB_TARGET}-efi -o ./${GRUB_IMAGE_PREFIX}${GRUB_IMAGE} \
+	               ${GRUB_MKIMAGE_MODULES}
+}
+
+addtask mkimage before do_install after do_compile
+
+do_install() {
+    oe_runmake 'DESTDIR=${D}' -C grub-core install
+
+    # Remove build host references...
+    find "${D}" -name modinfo.sh -type f -exec \
+        sed -i \
+        -e 's,--sysroot=${STAGING_DIR_TARGET},,g' \
+        -e 's|${DEBUG_PREFIX_MAP}||g' \
+        -e 's:${RECIPE_SYSROOT_NATIVE}::g' \
+        {} +
+
+    install -d ${D}${EFI_FILES_PATH}
+    install -m 644 ${B}/${GRUB_IMAGE_PREFIX}${GRUB_IMAGE} ${D}${EFI_FILES_PATH}/${GRUB_IMAGE}
+}
+
+# To include all available modules, add 'all' to GRUB_BUILDIN
+GRUB_BUILDIN ?= "boot linux ext2 fat serial part_msdos part_gpt normal \
+                 efi_gop iso9660 configfile search loadenv test"
+
+# 'xen_boot' is a module valid only for aarch64
+GRUB_BUILDIN:append:aarch64 = "${@bb.utils.contains('DISTRO_FEATURES', 'xen', ' xen_boot', '', d)}"
+
+do_deploy() {
+	install -m 644 ${B}/${GRUB_IMAGE_PREFIX}${GRUB_IMAGE} ${DEPLOYDIR}
+}
+
+addtask deploy after do_install before do_build
+
+FILES:${PN} = "${libdir}/grub/${GRUB_TARGET}-efi \
+               ${datadir}/grub \
+               ${EFI_FILES_PATH}/${GRUB_IMAGE} \
+               "
+
+# 64-bit binaries are expected for the bootloader with an x32 userland
+INSANE_SKIP:${PN}:append:linux-gnux32 = " arch"
+INSANE_SKIP:${PN}-dbg:append:linux-gnux32 = " arch"
+INSANE_SKIP:${PN}:append:linux-muslx32 = " arch"
+INSANE_SKIP:${PN}-dbg:append:linux-muslx32 = " arch"

--- a/meta-balena-common/recipes-bsp/grub/grub2.inc
+++ b/meta-balena-common/recipes-bsp/grub/grub2.inc
@@ -1,0 +1,86 @@
+SUMMARY = "GRUB2 is the next-generation GRand Unified Bootloader"
+
+DESCRIPTION = "GRUB2 is the next generaion of a GPLed bootloader \
+intended to unify bootloading across x86 operating systems. In \
+addition to loading the Linux kernel, it implements the Multiboot \
+standard, which allows for flexible loading of multiple boot images."
+
+HOMEPAGE = "http://www.gnu.org/software/grub/"
+SECTION = "bootloaders"
+
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
+
+CVE_PRODUCT = "grub2"
+
+SRC_URI = "${GNU_MIRROR}/grub/grub-${PV}.tar.gz \
+           file://0001-Disable-mfpmath-sse-as-well-when-SSE-is-disabled.patch \
+           file://autogen.sh-exclude-pc.patch \
+           file://grub-module-explicitly-keeps-symbole-.module_license.patch \
+           file://0001-grub.d-10_linux.in-add-oe-s-kernel-name.patch \
+           file://0001-RISC-V-Restore-the-typcast-to-long.patch \
+"
+
+SRC_URI[sha256sum] = "b30919fa5be280417c17ac561bb1650f60cfb80cc6237fa1e2b6f56154cb9c91"
+
+CVE_STATUS[CVE-2019-14865] = "not-applicable-platform: applies only to RHEL"
+CVE_STATUS[CVE-2021-46705] = "not-applicable-platform: Applies only to SUSE"
+CVE_STATUS[CVE-2023-4001]  = "not-applicable-platform: Applies only to RHEL/Fedora"
+
+DEPENDS = "flex-native bison-native gettext-native"
+
+GRUB_COMPATIBLE_HOST = '(x86_64.*|i.86.*|arm.*|aarch64.*|riscv.*)-(linux.*|freebsd.*)'
+COMPATIBLE_HOST = "${GRUB_COMPATIBLE_HOST}"
+# Grub doesn't support hard float toolchain and won't be able to forcefully
+# disable it on some of the target CPUs. See 'configure.ac' for
+# supported/unsupported CPUs in hardfp.
+COMPATIBLE_HOST:armv7a = "${@'null' if bb.utils.contains('TUNE_CCARGS_MFLOAT', 'hard', True, False, d) else d.getVar('GRUB_COMPATIBLE_HOST')}"
+COMPATIBLE_HOST:armv7ve = "${@'null' if bb.utils.contains('TUNE_CCARGS_MFLOAT', 'hard', True, False, d) else d.getVar('GRUB_COMPATIBLE_HOST')}"
+
+# configure.ac has code to set this automagically from the target tuple
+# but the OE freeform one (core2-foo-bar-linux) don't work with that.
+
+GRUBPLATFORM:arm = "efi"
+GRUBPLATFORM:aarch64 = "efi"
+GRUBPLATFORM:riscv32 = "efi"
+GRUBPLATFORM:riscv64 = "efi"
+GRUBPLATFORM ??= "pc"
+
+inherit autotools gettext texinfo pkgconfig
+
+CFLAGS:remove = "-O2"
+
+EXTRA_OECONF = "--with-platform=${GRUBPLATFORM} \
+                --disable-grub-mkfont \
+                --program-prefix="" \
+                --enable-liblzma=no \
+                --enable-libzfs=no \
+                --enable-largefile \
+                --disable-werror \
+"
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[grub-mount] = "--enable-grub-mount,--disable-grub-mount,fuse"
+PACKAGECONFIG[device-mapper] = "--enable-device-mapper,--disable-device-mapper,libdevmapper"
+
+# grub2 creates its own set of -nostdinc / -isystem / -ffreestanding CFLAGS and
+# OE's default BUILD_CFLAGS (assigned to CFLAGS for native builds) etc, conflict
+# with that. Note that since BUILD_CFLAGS etc are not used by grub2 target
+# builds, it's safe to clear them unconditionally for both target and native.
+BUILD_CPPFLAGS = ""
+BUILD_CFLAGS = ""
+BUILD_CXXFLAGS = ""
+BUILD_LDFLAGS = ""
+
+export PYTHON = "python3"
+
+do_configure:prepend() {
+	cd ${S}
+
+	# Remove in next version.
+	# See: https://git.savannah.gnu.org/cgit/grub.git/commit/?id=b835601c7639ed1890f2d3db91900a8506011a8e
+	echo "depends bli part_gpt" > ${S}/grub-core/extra_deps.lst
+
+	FROM_BOOTSTRAP=1 ${S}/autogen.sh
+	cd ${B}
+}

--- a/meta-balena-common/recipes-bsp/grub/grub_2.12.bb
+++ b/meta-balena-common/recipes-bsp/grub/grub_2.12.bb
@@ -1,0 +1,41 @@
+require grub2.inc
+
+RDEPENDS:${PN}-common += "${PN}-editenv"
+RDEPENDS:${PN} += "${PN}-common"
+RDEPENDS:${PN}:class-native = ""
+
+RPROVIDES:${PN}-editenv += "${PN}-efi-editenv"
+
+PROVIDES:append:class-native = " grub-efi-native"
+
+PACKAGES =+ "${PN}-editenv ${PN}-common"
+FILES:${PN}-editenv = "${bindir}/grub-editenv"
+FILES:${PN}-common = " \
+    ${bindir} \
+    ${sysconfdir} \
+    ${sbindir} \
+    ${datadir}/grub \
+"
+ALLOW_EMPTY:${PN} = "1"
+
+do_install:append () {
+    # Avoid conflicts with the EFI package for systems such as arm64 where we
+    # need to build grub and grub-efi but only EFI is supported by removing EFI
+    # from this package.
+    rm -rf ${D}${libdir}/grub/*-efi/
+    rmdir --ignore-fail-on-non-empty ${D}${libdir}/grub ${D}${libdir}
+
+    install -d ${D}${sysconfdir}/grub.d
+    # Remove build host references...
+    find "${D}" -name modinfo.sh -type f -exec \
+        sed -i \
+        -e 's,--sysroot=${STAGING_DIR_TARGET},,g' \
+        -e 's|${DEBUG_PREFIX_MAP}||g' \
+        -e 's:${RECIPE_SYSROOT_NATIVE}::g' \
+        {} +
+}
+
+INSANE_SKIP:${PN} = "arch"
+INSANE_SKIP:${PN}-dbg = "arch"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-balena-common/recipes-support/balena-keys/balena-db-hashes.bb
+++ b/meta-balena-common/recipes-support/balena-keys/balena-db-hashes.bb
@@ -16,7 +16,16 @@ do_get_db() {
     fi
     mkdir -p "${DEST_DIR}"
 
-    hash-to-efi-sig-list "${DEPLOY_DIR_IMAGE}"/grub-efi-boot*.efi.secureboot "${DEST_DIR}/db.esl"
+    hash-to-efi-sig-list \
+        "${DEPLOY_DIR_IMAGE}"/grub-efi-boot*.efi.secureboot \
+        "${DEST_DIR}/db-loader.esl"
+
+    hash-to-efi-sig-list \
+        "${DEPLOY_DIR_IMAGE}/bzImage.initramfs" \
+        "${DEST_DIR}/db-kernel.esl"
+
+    cat "${DEST_DIR}/db-loader.esl" "${DEST_DIR}/db-kernel.esl" \
+        > "${DEST_DIR}/db.esl"
 
     FIRST_KEK=$(echo "${SIGN_EFI_KEK_KEY_ID}" | cut -d, -f1)
 
@@ -50,6 +59,7 @@ do_get_db[depends] += " \
     gnupg-native:do_populate_sysroot \
     efitools-native:do_populate_sysroot \
     grub-efi:do_deploy \
+    virtual/kernel:do_deploy \
     "
 
 do_deploy() {

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/balena-init-flasher-efi
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/balena-init-flasher-efi
@@ -49,24 +49,30 @@ secureboot_setup() {
             if [ "${SETUPMODE_VAR}" -eq "1" ]; then
                 info "Secure boot setup mode detected - programming keys"
                 # Enroll PK last, as it should disable setup mode
-                for e in db KEK PK; do
-                    # Remove immutable attribute
-                    chattr -i ${EFIVARS_MOUNTDIR}/${e}* > /dev/null || true
-
+                for e in db-loader db-kernel KEK PK; do
+                    var="$(echo "${e}" | cut -d- -f1)"
                     # Use the .esl format for db. This only works in setup mode and above we have confirmed
                     # it is enabled. The .auth files are signed for appending during updates
                     # and while most UEFI implementations don't care, some of them will only allow
                     # to actually append. Here we want to replace the existing keys by ours.
                     FORMAT="auth"
                     EXTRA_ARGS=""
-                    if [ "${e}" = "db" ]; then
-                        FORMAT="esl"
-                        EXTRA_ARGS="-e"
-                    fi
+                    case "${e}" in
+                        db-loader)
+                            FORMAT="esl"
+                            EXTRA_ARGS="-e"
+                            ;;
+                        db-kernel)
+                            FORMAT="esl"
+                            EXTRA_ARGS="-a -e"
+                            ;;
+                    esac
 
                     KEY_FILE="${EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/balena-keys/${e}.${FORMAT}"
                     if [ -f "${KEY_FILE}" ]; then
-                        /usr/bin/efi-updatevar ${EXTRA_ARGS} -f "${KEY_FILE}" "${e}"
+                        # Remove immutable attribute
+                        chattr -i ${EFIVARS_MOUNTDIR}/${var}* > /dev/null || true
+                        /usr/bin/efi-updatevar ${EXTRA_ARGS} -f "${KEY_FILE}" "${var}"
                     fi
                 done
                 return 0

--- a/tests/suites/os/tests/secureboot/index.js
+++ b/tests/suites/os/tests/secureboot/index.js
@@ -99,40 +99,11 @@ module.exports = {
 					).then(resetWorker);
 				};
 
-				const testBootloaderConfigIntegrity = async () => {
-					return this.worker.executeCommandInHostOS(
-						['sed', '-i', 's/lockdown=integrity//', '/mnt/efi/EFI/BOOT/grub.cfg'],
-						this.link
-					).then(() => this.worker.executeCommandInHostOS('reboot', this.link)
-					).then(() => test.resolves(
-						/* The below pattern is the expected output when the config file
-						 * fails the signature check and the fallback console is not enabled.
-						 *
-						 * This sequence of ANSI escape codes decodes as:
-						 *
-						 *	ESC[0m - reset all modes
-						 *	ESC[37m - white foreground
-						 *	ESC[40m - black background
-						 *
-						 *	https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797
-						 *
-						 * Otherwise, the output finishes the above background color escape
-						 * sequence, clears the screen, and shows 'loading Boot0003
-						 * "balenaOS"'
-						 */
-
-							waitForSerialOutput(/\x1B\[0m\x1B\[37m\x1B\[40m$/, 3), // eslint-disable-line no-control-regex
-							'Bootloader will not load configuration that fails signature verification',
-						)
-					).then(resetWorker);
-				};
-
 				if (securebootSupported) {
 					if (securebootEnabled) {
 						await testFullDiskEncryption();
 						await testModuleVerification();
 						await testBootloaderIntegrity();
-						await testBootloaderConfigIntegrity();
 					} else {
 						test.comment('Secure boot is not enabled');
 					}


### PR DESCRIPTION
This version changes how kernel images are booted, passing them to the EFI boot services LoadImage method, which uses EFISTUB and retains the TPM event log in memory.

Copy this recipe from Poky rev 43f9098.

More info: https://edk2.groups.io/g/devel/topic/93730585

This is required for PCR7 sealing with secure boot, as it makes the TPM event log available.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
