### PR TITLE
tests: enable revpi-connect-4 in automated tests

### DIFF
--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -34,6 +34,14 @@ const supportsBootConfig = (deviceType) => {
 	);
 };
 
+const externalAnt = (deviceType) => {
+	return (
+		[
+			'revpi-connect-4'
+		]
+	).includes(deviceType)
+}
+
 const flasherConfig = (deviceType) => {
 	return (
 		[
@@ -64,6 +72,30 @@ const enableSerialConsole = async (imagePath) => {
 			await util.promisify(_fs.writeFile)(
 				'/config.txt',
 				newConfig.concat(`\n\n${value}\n\n`),
+			);
+		});
+	}
+};
+
+// For use with device types (e.g revpi connect 4) where an external antenna needs to be configured throuhg config.txt to work
+const enableExternalAntenna  = async (imagePath) => {
+	const bootConfig = await imagefs.interact(imagePath, 1, async (_fs) => {
+		return util
+			.promisify(_fs.readFile)('/config.txt')
+			.catch((err) => {
+				return undefined;
+			});
+	});
+
+	if (bootConfig) {
+		await imagefs.interact(imagePath, 1, async (_fs) => {
+			const value = 'dtparam=ant2';
+
+			console.log(`Setting ${value} in config.txt...`);
+
+			await util.promisify(_fs.writeFile)(
+				'/config.txt',
+				bootConfig.toString().concat(`\n\n${value}\n\n`),
 			);
 		});
 	}
@@ -315,6 +347,10 @@ module.exports = {
 
 		if(flasherConfig(this.suite.deviceType.slug)){
 			await setFlasher(this.os.image.path);
+		}
+
+		if(externalAnt(this.suite.deviceType.slug)){
+			await enableExternalAntenna(this.os.image.path);
 		}
 
 		if (this.suite.options?.balena?.apiKey) {


### PR DESCRIPTION
The revpi-connect-4 was found to have connectivity issues with the autokit wifi AP - which were resolved by configuring it to use the external antenna - even if no antenna was connected. It is thought that there was EMI or signal power issues.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
