### PR TITLE
Start os-config service after extracting CA

### DIFF
--- a/meta-balena-common/recipes-core/os-config/os-config/os-config.service
+++ b/meta-balena-common/recipes-core/os-config/os-config/os-config.service
@@ -2,8 +2,7 @@
 Description=OS configuration update service
 Requires=resin-boot.service
 Wants=os-config-devicekey.service NetworkManager.service
-Before=extract-balena-ca.service
-After=os-config-devicekey.service resin-boot.service NetworkManager.service
+After=os-config-devicekey.service resin-boot.service NetworkManager.service extract-balena-ca.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
OS-config should always run after extracting balena CA to prevent race conditions

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [x] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
