### PR TITLE
resin-init-flasher: Allow building images for non-flasher devices tha…

### DIFF
--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher.bb
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher.bb
@@ -44,12 +44,7 @@ BALENA_IMAGE ?= "balena-image-${MACHINE}.balenaos-img"
 do_install[depends] += "jq-native:do_populate_sysroot"
 do_install() {
     if [ -z "${INTERNAL_DEVICE_KERNEL}" ]; then
-        # Make sure devices with internal storage, aka flasher device types define `INTERNAL_DEVICE_KERNEL` in integration layers.
-        if [ "$(jq -r '.data.storage.internal' "${TOPDIR}/../contracts/contracts/hw.device-type/${MACHINE}/contract.json")" = "true" ] && [ -z "${INTERNAL_DEVICE_KERNEL}" ]; then
-            bbfatal "INTERNAL_DEVICE_KERNEL must be defined for devices with internal storage."
-        else
-            bbwarn "INTERNAL_DEVICE_KERNEL is not defined - some features like migration will not work."
-        fi
+        bbwarn "INTERNAL_DEVICE_KERNEL is not defined - some features like migration will not work."
     fi
 
     if [ -n "${INTERNAL_DEVICE_BOOTLOADER_CONFIG}" ] && [ -z "${INTERNAL_DEVICE_BOOTLOADER_CONFIG_PATH}" ]; then


### PR DESCRIPTION
…t have internal storage

As per the internal thread: https://balena.zulipchat.com/#narrow/stream/360838-balena-io.2Fos.2Fdevices/topic/balena-raspberrypi.20jenkins.20build.20failures/near/423970246

Currently devices with on-board storage fail to build in jenkins, if they don't provide a flasher image. One example is the CM4. Since there are multiple devices using this configuration, let's re-enable builds for all of them.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
