### PR TITLE
hostapp-update-hooks: Soft include balena-config-defaults

### DIFF
--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/hostapp-update-hooks
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/hostapp-update-hooks
@@ -5,7 +5,7 @@ set -o errexit
 # shellcheck disable=SC1091
 . /usr/libexec/os-helpers-logging
 # shellcheck disable=SC1091
-. /usr/sbin/balena-config-defaults
+. /usr/sbin/balena-config-defaults || :
 
 old_os_before_hooks=0
 old_os_after_hooks=0
@@ -42,7 +42,10 @@ Options:
 EOF
 }
 
-DEBUG=$(jq -r '.debug // empty' "${CONFIG_PATH}")
+DEBUG="0"
+if [ -n "${CONFIG_PATH}" ]; then
+	DEBUG=$(jq -r '.debug // empty' "${CONFIG_PATH}")
+fi
 run_hook () {
 	if [ "${DEBUG}" = "1" ]; then
 		/bin/sh -x "$1"


### PR DESCRIPTION
a203bcdfd567c0cc4b4ed9de493513142cd7463f introduced a dependency on `/usr/sbin/balena-config-defaults` to `hostapp-update-hooks`, however during HUP the script is not only executed in the "new" OS container but directly in the context of the "old" OS as well, so `/usr/sbin/balena-config-defaults` needs to exist there. The file was introduced in balenaOS v2.99.28, so trying to HUP from anything before that will fail.

This patch changes this to a soft dependency so even if the file is missing HUP will continue.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
