### PR TITLE
tests/device-tree: Rework to account for new form of setting dtoverla…

### DIFF
--- a/tests/suites/os/tests/device-tree/index.js
+++ b/tests/suites/os/tests/device-tree/index.js
@@ -92,8 +92,7 @@ module.exports = {
 							name: 'local',
 							config: {
 								HOST_CONFIG_dtoverlay: `"gpio-key,gpio=4,active_low=0,gpio_pull=${direction}"`,
-								HOST_CONFIG_dtparam:
-									'"i2c_arm=on","spi=on","audio=on","foo=bar","level=42"',
+								HOST_CONFIG_dtparam: '"i2c_arm=on","spi=on","audio=on","foo=bar","level=42"',
 								HOST_CONFIG_gpu_mem: '64',
 								SUPERVISOR_PERSISTENT_LOGGING: 'true',
 								SUPERVISOR_LOCAL_MODE: 'true',
@@ -206,7 +205,7 @@ module.exports = {
 
 				test.equal(
 					dtOverlayConfigTxt,
-					targetState.local.config.HOST_CONFIG_dtoverlay,
+					targetState.local.config.HOST_CONFIG_dtoverlay.split(",").slice(0,1).join() + '"',
 					'DToverlays successfully configured in config.txt',
 				);
 				const dtParamConfigTxt = await this.context
@@ -217,7 +216,7 @@ module.exports = {
 					);
 				test.equal(
 					dtParamConfigTxt,
-					targetState.local.config.HOST_CONFIG_dtparam,
+					targetState.local.config.HOST_CONFIG_dtparam + ',"' + targetState.local.config.HOST_CONFIG_dtoverlay.split(",").slice(1).join('","'),
 					'DTparams successfully configured in config.txt',
 				);
 				


### PR DESCRIPTION
…y in config.txt by the supervisor

The supervisor will now write the following dtoverlay setting

"gpio-key,gpio=4,active_low=0,gpio_pull=down"

into config.txt in the following form:

dtoverlay=gpio-key
dtparam=gpio=4
dtparam=active_low=0
dtparam=gpio_pull=down

So we need to rework the test to account for these changes.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
