### PR TITLE
Remove unneeded kernel image from initramfs

### DIFF
--- a/meta-balena-common/recipes-core/images/balena-image-initramfs.bb
+++ b/meta-balena-common/recipes-core/images/balena-image-initramfs.bb
@@ -46,7 +46,7 @@ IMAGE_FSTYPES = "${@bb.utils.contains_any( \
                         '${INITRAMFS_FSTYPES}', \
                  d)}"
 
-inherit core-image
+inherit core-image kernel-balena-noimage
 
 IMAGE_ROOTFS_SIZE = "8192"
 IMAGE_OVERHEAD_FACTOR = "1.0"

--- a/meta-balena-kirkstone/classes/kernel-balena-noimage.bbclass
+++ b/meta-balena-kirkstone/classes/kernel-balena-noimage.bbclass
@@ -5,5 +5,5 @@
 #    the initramfs bundled kernel image
 python __anonymous() {
     kernel_image_type = d.getVar('KERNEL_IMAGETYPE')
-    d.appendVar('PACKAGE_EXCLUDE', 'kernel-image-%s-*' % kernel_image_type.lower())
+    d.appendVar('PACKAGE_EXCLUDE', ' kernel-image-%s-*' % kernel_image_type.lower())
 }


### PR DESCRIPTION
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
