### PR TITLE
os-helpers-sb: Silence command when checking for user_mode_enabled

### DIFF
--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-sb
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-sb
@@ -21,7 +21,7 @@
 [ -f "/usr/libexec/os-helpers-efi" ] && . /usr/libexec/os-helpers-efi
 
 is_secured() {
-	if ! command -v user_mode_enabled; then
+	if ! command -v user_mode_enabled > /dev/null 2>&1; then
 		return 1
 	fi
 


### PR DESCRIPTION
is_secured will use `command` to check whether `user_mode_enabled` is defined, which was added to prevent the error message `user_mode_enabled: command not found` as this is only defined on EFI systems. However now on EFI systems it echoes `user_mode_enabled` each time the command is found which is also not what we want.


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
