### PR TITLE
packagegroup-resin: Install ldd script in balenaOS images

### DIFF
--- a/meta-balena-common/recipes-core/packagegroups/packagegroup-resin.inc
+++ b/meta-balena-common/recipes-core/packagegroups/packagegroup-resin.inc
@@ -21,4 +21,5 @@ RDEPENDS:${PN} = " \
     less \
     development-features \
     resin-device-progress \
+    ldd \
     "


### PR DESCRIPTION
The takeover project currently relies on the ldd script being present in the hostOS pre-migration.

While takeover can be adapted to use this script from a different location, it wouldn't hurt to have ldd in the hostOS from this point on.

Change-type: patch

Related discussion in takeover: https://github.com/balena-os/takeover/pull/66#discussion_r1526661273

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
