### PR TITLE
Test: Unmanaged: Replace ping command in tests with curl

### DIFF
--- a/tests/suites/os/tests/connectivity/index.js
+++ b/tests/suites/os/tests/connectivity/index.js
@@ -53,12 +53,12 @@ module.exports = {
 
 							test.comment(`Attempting to connect to ${URL_TEST} over interface ${iface}`)
 							return this.worker.executeCommandInHostOS(
-								`ping -c 10 -i 0.002 -I ${iface} ${URL_TEST}`,
+								`curl -I -sS -o /dev/null -w "%{http_code}" --keepalive-time 5 --connect-timeout 5 --interface ${iface} ${URL_TEST}`,
 								this.link,
 							);
-						}).then((ping) => {
+						}).then((curl) => {
 							test.ok(
-								ping.includes('10 packets transmitted, 10 packets received'),
+								curl.includes(200),
 								`${URL_TEST} should respond over ${connection}`,
 							);
 						});


### PR DESCRIPTION
This change is required to migrate existing tests to run QEMU worker tests on GitHub Actions.
GitHub hosted runners can't run the `ping` command: https://github.com/actions/runner-images/issues/1519 by design. If we still intend to use `ping`, the solution would be running QEMU worker tests on self-hosted runners which allow ICMP packets

This change is intended to be backwards compatible and shouldn't affect tests running on Jenkins or for the autokit

Change-type: patch
Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
