### PR TITLE
networkmanager: Wait for iptables lock in shared dispatcher script

### DIFF
--- a/meta-balena-common/recipes-connectivity/networkmanager/balena-files/90shared
+++ b/meta-balena-common/recipes-connectivity/networkmanager/balena-files/90shared
@@ -33,6 +33,8 @@
 # the race condition and always sets the FORWARD rules
 # as if balenaEngine came up last.
 
+set -e
+
 . /usr/libexec/os-helpers-logging
 
 if [ "$2" != "up" ]
@@ -42,10 +44,15 @@ fi
 
 IFNAME="$1"
 
+# Use -w 5 to wait for the lock file if necessary
+# 5 seconds is ridiculously high but this is just a sanity limit
+# to prevent it from hanging infinitely if nothing removes the lock
+IPTABLES="iptables -w 5"
+
 # Look for the FORWARD rule that NetworkManager adds for interfaces
 # configured as shared. This will have a comment "nm-shared-$IFNAME"
 # and jump into a chain named "sh-fw-$IFNAME"
-FW_RULE_NO=$(iptables -L FORWARD --line-number | grep "sh-fw-${IFNAME}" | grep "nm-shared-${IFNAME}" | cut -d " " -f 1)
+FW_RULE_NO=$(${IPTABLES} -L FORWARD --line-number | grep "sh-fw-${IFNAME}" | grep "nm-shared-${IFNAME}" | cut -d " " -f 1)
 if [ "x${FW_RULE_NO}" = "x" ]
 then
   exit 0
@@ -60,11 +67,11 @@ fi
 
 info "Found shared FORWARD rule 'nm-shared-${IFNAME}' at index ${FW_RULE_NO}, moving down"
 
-FW_RULE_ARGS="$(iptables -S FORWARD ${FW_RULE_NO})"
+FW_RULE_ARGS="$(${IPTABLES} -S FORWARD ${FW_RULE_NO})"
 
 # Append the rule to the bottom
 # Do not quote ${FW_RULE_ARGS}, this needs to expand
-iptables ${FW_RULE_ARGS}
+${IPTABLES} ${FW_RULE_ARGS}
 
 # Remove the rule from its original position
-iptables -D FORWARD "${FW_RULE_NO}"
+${IPTABLES} -D FORWARD "${FW_RULE_NO}"


### PR DESCRIPTION
The dispatcher script that moves around FORWARD rules of shared interfaces currently calls iptables assuming it will always work but in practice two iptables commands can not run in parallel and we have occasionally seen the script fail with:

Another app is currently holding the xtables lock. Perhaps you want to use the -w option?

This patch adds the -w option to make the script wait for the lock when necessary.

It also makes the script exit with an error code if anything fails, which will log the output as WARN instead of INFO as the errors are easy to overlook at this moment.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
