### PR TITLE
PCR 7 sealing fixes

### DIFF
--- a/meta-balena-common/recipes-containers/hostapp-update/files/hostapp-update
+++ b/meta-balena-common/recipes-containers/hostapp-update/files/hostapp-update
@@ -107,7 +107,7 @@ done
 # Load new hostapp
 if [ "$local_image" != "" ]; then
 	# bind mount the data partition for temporary extract/load files
-	if ! mountpoint "${SYSROOT}/balena/tmp"; then
+	if ! mountpoint "${SYSROOT}/balena/tmp" >/dev/null; then
 		mkdir -p "${LOADTMP}"
 		mount --bind "${LOADTMP}" "${SYSROOT}/balena/tmp"
 	fi

--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
@@ -182,14 +182,16 @@ updateKeys() {
         mv "${RESULT_DIR}/passphrase.enc" "${EFI_MOUNT_DIR}/balena-luks.enc"
     elif [ "${UNLOCK_PCRS_SUCCESS}" = "0,1,2,3" ]; then
         warn "Unlocked passphrase without PCR7, delaying policy update until rollback-health success"
-        # update the second stage bootloader kernel binary, as the hash of the
-        # original may not be present in the signature database
-        cp "${KERNEL_BIN}"{,.sig} "${EFI_MOUNT_DIR}/"
-        cp "${GRUB_BIN}" "${EFI_MOUNT_DIR}/EFI/BOOT/bootx64.efi"
     else
         fail "Failed to update policy sealing LUKS passphrase"
     fi
 
+    # update the second stage bootloader kernel binary, as the hash of the
+    # original may not be present in the signature database
+    rsync --checksum --inplace "${KERNEL_BIN}"{,.sig} "${EFI_MOUNT_DIR}/"
+
+    # update GRUB if necessary
+    rsync --checksum --inplace "${GRUB_BIN}" "${EFI_MOUNT_DIR}/EFI/BOOT/bootx64.efi"
     sync
 
     # This only updates db at this moment

--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
@@ -170,13 +170,12 @@ updateKeys() {
                               "sha256:$(find "${POLICY_PATH}" -type f | sort | xargs | sed 's/ /,/g')"
                 POLICY="${POLICY_COMBINED}"
                 cp -rf "${POLICY_PATH}" "${EFI_MOUNT_DIR}"
-                rm -rf "${CURRENT_POLICY_PATH}"
                 ;;
         esac
 
         tpm2_flushcontext "${SESSION_CTX}"
         hw_encrypt_passphrase "$PASSPHRASE_FILE" "$POLICY" "$RESULT_DIR"
-
+        rm -rf "${CURRENT_POLICY_PATH}"
 
         tpm2_evictcontrol -c "${EFI_MOUNT_DIR}/balena-luks.ctx"
         mv "${RESULT_DIR}/persistent.ctx" "${EFI_MOUNT_DIR}/balena-luks.ctx"

--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
@@ -155,10 +155,12 @@ updateKeys() {
             measured)
                 info "Using PCR7 digest with EFI binary measurements"
                 POLICY="${POLICY_EFIBIN}"
+                print_pcr_val_bin "${PCRS}" "${PCR_VAL_BIN_EFIBIN}"
                 ;;
             unmeasured)
                 info "Using PCR7 digest without EFI binary measurements"
                 POLICY="${POLICY_UPDATED}"
+                print_pcr_val_bin "${PCRS}" "${PCR_VAL_BIN_UPDATED}"
                 ;;
             unknown)
                 # we don't have access to the TPM event log, and can't
@@ -170,6 +172,10 @@ updateKeys() {
                               "sha256:$(find "${POLICY_PATH}" -type f | sort | xargs | sed 's/ /,/g')"
                 POLICY="${POLICY_COMBINED}"
                 cp -rf "${POLICY_PATH}" "${EFI_MOUNT_DIR}"
+
+                print_pcr_val_bin "${PCRS}" "${PCR_VAL_BIN_EFIBIN}"
+                printf "\nOR\n"
+                print_pcr_val_bin "${PCRS}" "${PCR_VAL_BIN_UPDATED}"
                 ;;
         esac
 

--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
@@ -123,13 +123,16 @@ updateKeys() {
     RESULT_DIR="$(mktemp -d)"
     CURRENT_POLICY_PATH="$(find /mnt/efi -name "policies.*")"
     for UNLOCK_PCRS in  0,2,3,7 0,1,2,3; do
-        [ -f "${SESSION_CTX}" ] && tpm2_flushcontext "${SESSION_CTX}" || true
-        tpm2_startauthsession --policy-session -S "${SESSION_CTX}"
-	    tpm2_policypcr -S "${SESSION_CTX}" -l "sha256:${UNLOCK_PCRS}"
-	    POLICIES="$(find "${CURRENT_POLICY_PATH}" -type f | sort | xargs)"
-	    if [ "$(echo "${POLICIES}" | wc -w)" -gt 1 ]; then
-            tpm2_policyor -S "${SESSION_CTX}" "sha256:$(echo "${POLICIES}" | sed 's/ /,/g')"
-	    fi
+        {
+            [ -f "${SESSION_CTX}" ] && tpm2_flushcontext "${SESSION_CTX}"  2>&1 || true
+            tpm2_startauthsession --policy-session -S "${SESSION_CTX}"
+            tpm2_policypcr -S "${SESSION_CTX}" -l "sha256:${UNLOCK_PCRS}"
+            POLICIES="$(find "${CURRENT_POLICY_PATH}" -type f | sort | xargs)"
+            if [ "$(echo "${POLICIES}" | wc -w)" -gt 1 ]; then
+                tpm2_policyor -S "${SESSION_CTX}" "sha256:$(echo "${POLICIES}" | sed 's/ /,/g')"
+            fi
+
+        } >/dev/null
 
         if hw_decrypt_passphrase "$EFI_MOUNT_DIR" "session:${SESSION_CTX}" "$PASSPHRASE_FILE"; then
             UNLOCK_PCRS_SUCCESS="${UNLOCK_PCRS}"
@@ -141,15 +144,17 @@ updateKeys() {
     POLICY_EFIBIN="${POLICY_PATH}/policy.efibin"
     POLICY_COMBINED="$(mktemp -t)"
     if [ "${UNLOCK_PCRS_SUCCESS}" = "0,2,3,7" ]; then
-        tpm2_createpolicy --policy-pcr \
-                          -l "sha256:${PCRS}" \
-                          -f "${PCR_VAL_BIN_UPDATED}" \
-                          -L "${POLICY_UPDATED}"
-        tpm2_createpolicy --policy-pcr \
-                          -l "sha256:${PCRS}" \
-                          -f "${PCR_VAL_BIN_EFIBIN}" \
-                          -L "${POLICY_EFIBIN}"
-        tpm2_startauthsession -S "${SESSION_CTX}"
+        {
+            tpm2_createpolicy --policy-pcr \
+                              -l "sha256:${PCRS}" \
+                              -f "${PCR_VAL_BIN_UPDATED}" \
+                              -L "${POLICY_UPDATED}"
+            tpm2_createpolicy --policy-pcr \
+                              -l "sha256:${PCRS}" \
+                              -f "${PCR_VAL_BIN_EFIBIN}" \
+                              -L "${POLICY_EFIBIN}"
+            tpm2_startauthsession -S "${SESSION_CTX}"
+        } >/dev/null
 
         case "$(firmware_measures_efibins)" in
             measured)
@@ -169,7 +174,8 @@ updateKeys() {
                 info "Creating combined policy"
                 tpm2_policyor -S "${SESSION_CTX}" \
                               -L "${POLICY_COMBINED}" \
-                              "sha256:$(find "${POLICY_PATH}" -type f | sort | xargs | sed 's/ /,/g')"
+                              "sha256:$(find "${POLICY_PATH}" -type f | sort | xargs | sed 's/ /,/g')" \
+                              >/dev/null
                 POLICY="${POLICY_COMBINED}"
                 cp -rf "${POLICY_PATH}" "${EFI_MOUNT_DIR}"
 
@@ -179,13 +185,17 @@ updateKeys() {
                 ;;
         esac
 
-        tpm2_flushcontext "${SESSION_CTX}"
-        hw_encrypt_passphrase "$PASSPHRASE_FILE" "$POLICY" "$RESULT_DIR"
-        rm -rf "${CURRENT_POLICY_PATH}"
+        {
+            tpm2_flushcontext "${SESSION_CTX}"
 
-        tpm2_evictcontrol -c "${EFI_MOUNT_DIR}/balena-luks.ctx"
-        mv "${RESULT_DIR}/persistent.ctx" "${EFI_MOUNT_DIR}/balena-luks.ctx"
-        mv "${RESULT_DIR}/passphrase.enc" "${EFI_MOUNT_DIR}/balena-luks.enc"
+            hw_encrypt_passphrase "$PASSPHRASE_FILE" "$POLICY" "$RESULT_DIR"
+            rm -rf "${CURRENT_POLICY_PATH}"
+
+            tpm2_evictcontrol -c "${EFI_MOUNT_DIR}/balena-luks.ctx"
+            mv "${RESULT_DIR}/persistent.ctx" "${EFI_MOUNT_DIR}/balena-luks.ctx"
+            mv "${RESULT_DIR}/passphrase.enc" "${EFI_MOUNT_DIR}/balena-luks.enc"
+        } >/dev/null
+
     elif [ "${UNLOCK_PCRS_SUCCESS}" = "0,1,2,3" ]; then
         warn "Unlocked passphrase without PCR7, delaying policy update until rollback-health success"
     else
@@ -218,7 +228,7 @@ updateKeys() {
 
     mkdir -p "${PENDING_DBX_DIR}"
     cp -a "${ACTIVE_DBX_FILE}" "${DEST_FILE}"
-    sig-list-to-certs "${ACTIVE_ESL_FILE}" "${DEST_FILE}"
+    sig-list-to-certs "${ACTIVE_ESL_FILE}" "${DEST_FILE}" >/dev/null
 }
 
 # Only applicable in the new OS container

--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
@@ -151,26 +151,28 @@ updateKeys() {
                           -L "${POLICY_EFIBIN}"
         tpm2_startauthsession -S "${SESSION_CTX}"
 
-	if firmware_measures_efibins; then
-		info "Using PCR7 digest with EFI binary measurements"
-		POLICY="${POLICY_EFIBIN}"
-	else
-		if [ $? = 1 ]; then
-			info "Using PCR7 digest without EFI binary measurements"
-			POLICY="${POLICY_UPDATED}"
-		# exit code 2 means we don't have access to the TPM event log,
-		# and can't definitively tell whether or not EFI binaries are
-		# measured into PCR7, so unlock with both digests
-		elif [ $? = 2 ]; then
-			info "Creating combined policy"
-			tpm2_policyor -S "${SESSION_CTX}" \
-				      -L "${POLICY_COMBINED}" \
-				      "sha256:$(find "${POLICY_PATH}" -type f | sort | xargs | sed 's/ /,/g')"
-			POLICY="${POLICY_COMBINED}"
-			cp -rf "${POLICY_PATH}" "${EFI_MOUNT_DIR}"
-			rm -rf "${CURRENT_POLICY_PATH}"
-		fi
-	fi
+        case "$(firmware_measures_efibins)" in
+            measured)
+                info "Using PCR7 digest with EFI binary measurements"
+                POLICY="${POLICY_EFIBIN}"
+                ;;
+            unmeasured)
+                info "Using PCR7 digest without EFI binary measurements"
+                POLICY="${POLICY_UPDATED}"
+                ;;
+            unknown)
+                # we don't have access to the TPM event log, and can't
+                # definitively tell whether or not EFI binaries are measured
+                # into PCR7, so unlock with both digests
+                info "Creating combined policy"
+                tpm2_policyor -S "${SESSION_CTX}" \
+                              -L "${POLICY_COMBINED}" \
+                              "sha256:$(find "${POLICY_PATH}" -type f | sort | xargs | sed 's/ /,/g')"
+                POLICY="${POLICY_COMBINED}"
+                cp -rf "${POLICY_PATH}" "${EFI_MOUNT_DIR}"
+                rm -rf "${CURRENT_POLICY_PATH}"
+                ;;
+        esac
 
         tpm2_flushcontext "${SESSION_CTX}"
         hw_encrypt_passphrase "$PASSPHRASE_FILE" "$POLICY" "$RESULT_DIR"

--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/95-secureboot/2-fwd_commit_update-policy
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/95-secureboot/2-fwd_commit_update-policy
@@ -70,7 +70,7 @@ for pcr in $(echo ${PCRS} | sed 's/,/ /g'); do
 		7)
 			digest="$(compute_pcr7)"
 
-			if firmware_measures_efibins; then
+			if [ "$(firmware_measures_efibins)" = "measured" ]; then
 				for bin in ${EFI_BINARIES}; do
 					extend="$(tcgtool -s "$bin" \
 						| tcgtool -e "db-${EFI_IMAGE_SECURITY_DATABASE_GUID}" \

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-sb
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-sb
@@ -23,7 +23,7 @@
 [ -f "/usr/libexec/os-helpers-tpm2" ] && . /usr/libexec/os-helpers-tpm2
 
 is_secured() {
-	if ! command -v user_mode_enabled; then
+	if ! command -v user_mode_enabled >/dev/null; then
 		return 1
 	fi
 

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-tpm2
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-tpm2
@@ -96,7 +96,7 @@ parse_pcr7_eventtypes() {
     awk '
         /PCRIndex: 7/ {flag=1; next}
         /EventNum:/ {flag=0}
-        flag && /EventType:/ {gsub("\"", "")print $2}'
+        flag && /EventType:/ {gsub("\"", ""); print $2}'
 }
 
 firmware_measures_efibins() {

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-tpm2
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-tpm2
@@ -23,6 +23,13 @@ EFI_GLOBAL_VARIABLE_GUID="8be4df61-93ca-11d2-aa0d-00e098032b8c"
 
 TPM_EVENTLOG_PATH="/sys/kernel/security/tpm0/binary_bios_measurements"
 
+# silence errors messages from trying unsupported TCTI backends
+#
+# tpmrm0 is for kernel managed access by multiple clients, and should be
+# preferred over the default tpm0 device, which can only be used by a single
+# process at a time
+export TPM2TOOLS_TCTI=device:/dev/tpmrm0
+
 # busybox's implementation of xxd lacks the -cols option, so remove line breaks
 _hexencode() {
     xxd -p | tr -d '[:space:]'

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-tpm2
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-tpm2
@@ -71,15 +71,21 @@ EOF
     done
 
     # Extend our digest with any additional random events that may have been logged
+    EV_SEPARATOR=$(dd if=/dev/zero bs=1 count=4 status=none | _sha256)
     if [ -f "${TPM_EVENTLOG_PATH}" ]; then
         for extend in $(tpm2_eventlog "${TPM_EVENTLOG_PATH}" \
                 | parse_pcr7_digests \
-                | sed '1,5d'); do
+                | sed '1,5d' \
+                | tr -d '"'); do
             digest=$(printf '%s%s' "$digest" "$extend" | _hexdecode | _sha256)
+
+            # stop merging before EV_EFI_VARIABLE_AUTHORITY events (EFI binary digests)
+            if [ "$extend" == "$EV_SEPARATOR" ]; then
+                break
+            fi
         done
     else
-        separator=$(dd if=/dev/zero bs=1 count=4 status=none | _sha256)
-        digest=$(printf '%s%s' "$digest" "$separator" | _hexdecode | _sha256)
+        digest=$(printf '%s%s' "$digest" "$EV_SEPARATOR" | _hexdecode | _sha256)
     fi
 
     printf '%s' "$digest"

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-tpm2
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-tpm2
@@ -117,7 +117,8 @@ firmware_measures_efibins() {
         echo "unknown"
     elif tpm2_eventlog "${TPM_EVENTLOG_PATH}" \
             | parse_pcr7_eventtypes \
-            | grep -e EV_EFI_VARIABLE_AUTHORITY; then
+            | grep -e EV_EFI_VARIABLE_AUTHORITY \
+            >/dev/null; then
         echo "measured"
     else
         echo "unmeasured"

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-tpm2
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-tpm2
@@ -125,7 +125,19 @@ firmware_measures_efibins() {
     fi
 }
 
-
+print_pcr_val_bin() {
+    PCRS=$1
+    PCR_VAL_BIN=$2
+    DIGEST_SIZE=32
+    SKIP=0
+    printf " %s:\n" "sha256"
+    for pcr in $(echo "${PCRS}" | sed 's/,/ /g'); do
+        digest=$(dd if="${PCR_VAL_BIN}" bs=1 count=$DIGEST_SIZE status=none skip=$SKIP | _hexencode)
+        SKIP=$((SKIP + DIGEST_SIZE))
+        printf "   %s : %s\n" "$pcr" "$digest"
+    done
+    printf "\n"
+}
 
 hw_gen_passphrase() {
     tpm2_getrandom 32

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-tpm2
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-tpm2
@@ -100,10 +100,15 @@ parse_pcr7_eventtypes() {
 }
 
 firmware_measures_efibins() {
-    [ -f "${TPM_EVENTLOG_PATH}" ] || exit 2
-    tpm2_eventlog "${TPM_EVENTLOG_PATH}" \
-        | parse_pcr7_eventtypes \
-        | grep -e EV_EFI_VARIABLE_AUTHORITY
+    if [ ! -f "${TPM_EVENTLOG_PATH}" ]; then
+        echo "unknown"
+    elif tpm2_eventlog "${TPM_EVENTLOG_PATH}" \
+            | parse_pcr7_eventtypes \
+            | grep -e EV_EFI_VARIABLE_AUTHORITY; then
+        echo "measured"
+    else
+        echo "unmeasured"
+    fi
 }
 
 


### PR DESCRIPTION
    A missing semi-colon caused the firmware_measures_efibins function to
    return an exit code of one, which the 0-signed-update hostapp-update
    hook interpreted as "this firmware does not measure EFI binaries into
    PCR 7", as opposed to zero, indicating "this firmware *does* measure EFI
    binaries into PCR 7", or two, indicating "the TPM event log is
    unavailable and it's impossible to tell."
    
    Taking the wrong branch in this conditional led to an inappropriate
    policy being created to seal the LUKS passphrase, which could not be
    unlocked on the next boot, as in QEMU with edk2, EFI binaries *are*
    measured into PCR 7.

Manual tests:
- [x] HUP from legacy to PCR 7 sealing, virtualized
- [x] HUP from legacy to PCR 7 sealing, real hw
- [x] HUP from PCR 7 sealing to PCR 7 sealing, virtualized
- [x] HUP from PCR 7 sealing to PCR 7 sealing, real hw
- [x] Fallback health, virtualized
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [x] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
