### PR TITLE
Work around uuid file corruption in balenaEngine health check

### DIFF
--- a/meta-balena-common/recipes-containers/balena/balena/balena-healthcheck
+++ b/meta-balena-common/recipes-containers/balena/balena/balena-healthcheck
@@ -7,24 +7,46 @@ set -o errexit
 BALENAD_SOCKET="/run/balena.sock"
 CONTAINERD_SOCKET="/run/balena-engine/containerd/balena-engine-containerd.sock"
 
+# Checks if the file $1 contains an UUID in any of the formats described here:
+# https://github.com/google/uuid/blob/6e10cd1027e225e3ad7bfcc13c896abd165b02ef/uuid.go#L189
+contains_valid_uuid()
+{
+    # This matches xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx, which is the one format
+    # we have seen in practice, and is also the base for most other supported
+    # formats.
+    BASE_UUID_REGEX="[[:xdigit:]]{8}-([[:xdigit:]]{4}-){3}[[:xdigit:]]{12}"
+
+    # Check for all the possible formats, starting with the most common one, to
+    # benefit from the short-circuited evaluation. The contents of the uuid file
+    # must match these formats exactly, so we anchor the regexes both at the
+    # beginning (^) and the end ($).
+    grep -E          "^${BASE_UUID_REGEX}$"   "$1" > /dev/null || \
+    grep -E        "^\{${BASE_UUID_REGEX}\}$" "$1" > /dev/null || \
+    grep -E "^urn:uuid:${BASE_UUID_REGEX}$"   "$1" > /dev/null || \
+    grep -E "^[[:xdigit:]]{32}$"              "$1" > /dev/null
+}
+
+
 # Check if balena-engine-daemon is responding.
 curl --fail --unix-socket $BALENAD_SOCKET http:/v1.40/_ping > /dev/null 2>&1
 
 # Due to a non-atomic file creation and writing operation in containerd, we
-# sometimes end up with an empty `uuid` file. This causes `ctr version` (and
-# hence the health check) to fail. We therefore remove this file if it is
-# present and empty. See https://github.com/balena-os/balena-engine/issues/322
+# sometimes end up with an empty or corrupted `uuid` file. This causes
+# `ctr version` (and hence the health check) to fail. We therefore remove this
+# file if it is present not valid. See
+# https://github.com/balena-os/balena-engine/issues/322
+
 UUID_FILE="/mnt/data/docker/containerd/daemon/io.containerd.grpc.v1.introspection/uuid"
-if [ -f "$UUID_FILE" -a ! -s "$UUID_FILE" ]; then
-    warn "removing empty $UUID_FILE"
+if [ -f "$UUID_FILE" ] && ! contains_valid_uuid "$UUID_FILE"; then
+    warn "removing invalid $UUID_FILE"
     rm -f "$UUID_FILE"
 fi
 
 # Check if balena-engine-containerd is responding.
 balena-engine-containerd-ctr --address $CONTAINERD_SOCKET version > /dev/null 2>&1
 
-# The uuid file is expected to exist and be non-empty after `ctr version`. If
+# The uuid file is expected to exist and be valid after `ctr version`. If
 # this is not the case, log the event.
-if [ -f "$UUID_FILE" -a ! -s "$UUID_FILE" ]; then
-    warn "$UUID_FILE empty after 'ctr version'"
+if [ -f "$UUID_FILE" ] && ! contains_valid_uuid "$UUID_FILE"; then
+    warn "$UUID_FILE invalid after 'ctr version'"
 fi


### PR DESCRIPTION
We have detected one more way in which the uuid file used by containerd can get corrupted. This time, the file is not empty, but doesn't contain a valid UUID either.

This commit thus extends the existing workaround to also handle this case.

See https://github.com/balena-os/balena-engine/issues/322

### Testing

I tested this manually only. I built balenaOS for raspberrypi3-64 using my branch of meta-balena and flashed it to a device. Then I tried to manually change the contents of the `uuid` file and run the health check to see the results:

* When changing it to one of the formats accepted by containerd, the healthcheck passed and the `uuid` file remained unchanged.
* When changing it to an invalid format (including making it an empty file), or removing it altogether, the healthcheck passed and and new, valid `uuid` file was created.

In other words, no form of bad `uuid` should not cause the Engine healthcheck to fail after this change.

**Regarding automated tests:** I believe it should be possible to add some automated test cases for that -- basically automate the kind of manual testing I described above. I am not so sure this would add significant value, though. (FWIW, we don't have automated tests for the current version of this workaround)

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
