### PR TITLE
hostapp-update-hooks: check for logging helper

### DIFF
--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/hostapp-update-hooks
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/hostapp-update-hooks
@@ -2,8 +2,33 @@
 
 set -o errexit
 
-# shellcheck disable=SC1091
-. /usr/libexec/os-helpers-logging
+if [ -f "/usr/libexec/os-helpers-logging" ]; then
+	# shellcheck disable=SC1091
+	. /usr/libexec/os-helpers-logging
+else
+	log () {
+		_level="$1"
+		_message="$2"
+		printf "[%s][%s] %s\n" "$ME" "$_level" "$_message" >&2
+		echo "$@"
+	}
+	fail () {
+		error "$1"
+		exit 1
+	}
+
+	error () {
+		log "ERROR" "$1"
+	}
+
+	warn () {
+		log "WARN" "$1"
+	}
+
+	info () {
+		log "INFO" "$1"
+	}
+fi
 # shellcheck disable=SC1091
 [ -f "/usr/sbin/balena-config-defaults" ] && . /usr/sbin/balena-config-defaults
 


### PR DESCRIPTION
Older balenaOS version (before v2.58) do not contain the logging helper in the rootfs and the new OS hooks fail to execute.

This commit checks for the file existence before using it, and defines the logging functions when not detected.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
