### PR TITLE
patch: Add Test Suite specific config for GHA

### DIFF
--- a/tests/suites/cloud/config.js
+++ b/tests/suites/cloud/config.js
@@ -1,0 +1,32 @@
+module.exports = [
+  {
+    deviceType: process.env.DEVICE_TYPE,
+    suite: `${__dirname}/../suites/cloud`,
+    config: {
+      networkWired: false,
+      networkWireless: process.env.WORKER_TYPE === 'qemu' ? false : true,
+      balenaApiKey: process.env.BALENACLOUD_API_KEY,
+      balenaApiUrl: process.env.BALENACLOUD_API_URL,
+      organization: process.env.BALENACLOUD_ORG,
+      sshConfig: {
+        host: process.env.BALENACLOUD_SSH_URL,
+        port: process.env.BALENACLOUD_SSH_PORT,
+      }
+    },
+    image: `${__dirname}/balena.img.gz`,
+    debug: {
+      // Exit the ongoing test suite if a test fails
+      failFast: true,
+      // Exit the ongoing test run if a test fails
+      globalFailFast: false,
+      // Persist downloadeded artifacts
+      preserveDownloads: false,
+      // Mark unstable tests to be skipped
+      unstable: ['']
+    },
+    workers: process.env.WORKER_TYPE === 'qemu' ? ['http://worker'] : {
+      balenaApplication: process.env.BALENACLOUD_APP_NAME.split(','),
+      apiKey: process.env.BALENACLOUD_API_KEY,
+    },
+  }
+]

--- a/tests/suites/hup/config.js
+++ b/tests/suites/hup/config.js
@@ -1,0 +1,33 @@
+module.exports = [
+  {
+    deviceType: process.env.DEVICE_TYPE,
+    suite: `${__dirname}/../suites/hup`,
+    config: {
+      networkWired: false,
+      networkWireless: process.env.WORKER_TYPE === 'qemu' ? false : true,
+      downloadVersion: 'latest',
+      balenaApiKey: process.env.BALENACLOUD_API_KEY,
+      balenaApiUrl: process.env.BALENACLOUD_API_URL,
+      organization: process.env.BALENACLOUD_ORG,
+      sshConfig: {
+        host: process.env.BALENACLOUD_SSH_URL,
+        port: process.env.BALENACLOUD_SSH_PORT,
+      }
+    },
+    image: `${__dirname}/balena-image.docker`,
+    debug: {
+      // Exit the ongoing test suite if a test fails
+      failFast: true,
+      // Exit the ongoing test run if a test fails
+      globalFailFast: false,
+      // Persist downloadeded artifacts
+      preserveDownloads: false,
+      // Mark unstable tests to be skipped
+      unstable: ['']
+    },
+    workers: process.env.WORKER_TYPE === 'qemu' ? ['http://worker'] : {
+      balenaApplication: process.env.BALENACLOUD_APP_NAME.split(','),
+      apiKey: process.env.BALENACLOUD_API_KEY,
+    },
+  }
+]

--- a/tests/suites/os/config.js
+++ b/tests/suites/os/config.js
@@ -1,0 +1,32 @@
+module.exports = [
+  {
+    deviceType: process.env.DEVICE_TYPE,
+    suite: `${__dirname}/../suites/os`,
+    config: {
+      networkWired: false,
+      networkWireless: process.env.WORKER_TYPE === 'qemu' ? false : true,
+      balenaApiKey: process.env.BALENACLOUD_API_KEY,
+      balenaApiUrl: process.env.BALENACLOUD_API_URL,
+      organization: process.env.BALENACLOUD_ORG,
+      sshConfig: {
+        host: process.env.BALENACLOUD_SSH_URL,
+        port: process.env.BALENACLOUD_SSH_PORT,
+      }
+    },
+    image: `${__dirname}/balena.img.gz`,
+    debug: {
+      // Exit the ongoing test suite if a test fails
+      failFast: true,
+      // Exit the ongoing test run if a test fails
+      globalFailFast: false,
+      // Persist downloadeded artifacts
+      preserveDownloads: false,
+      // Mark unstable tests to be skipped
+      unstable: ['']
+    },
+    workers: process.env.WORKER_TYPE === 'qemu' ? ['http://worker'] : {
+      balenaApplication: process.env.BALENACLOUD_APP_NAME.split(','),
+      apiKey: process.env.BALENACLOUD_API_KEY,
+    },
+  }
+]


### PR DESCRIPTION
To parallelize test runs on GHA, having separate test suite-specific configs available would be the way to go. 
This change is backward compatible with the current Jenkins configuration.

Reasoning: Each matrix job of Leviathan will run one test suite using this one config modification made in this PR. This will allow us only to retry a single test suite and not all 3 again. 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
