### PR TITLE
tests: os: modem: fix curl command

### DIFF
--- a/tests/suites/os/tests/modem/index.js
+++ b/tests/suites/os/tests/modem/index.js
@@ -204,7 +204,7 @@ module.exports = {
 
                     await this.utils.waitUntil(async () => {
                         curl = await this.worker.executeCommandInHostOS(
-                            `curl -I -sS -o /dev/null -w "%{http_code}" --keepalive-time 5 --connect-timeout 5 --interface ${iface} ${URL_TEST}`,
+                            `curl -I -sS -o /dev/null -w "%{http_code}" --keepalive-time 5 --connect-timeout 5 --interface ${iface} ${config.network.testUrl}`,
                             this.link,
                         );
                         return curl.includes(200);

--- a/tests/suites/os/tests/modem/modems.json
+++ b/tests/suites/os/tests/modem/modems.json
@@ -4,7 +4,7 @@
         "ipType": "ipv4",
         "user": "sora",
         "password": "sora",
-        "testUrl": "8.8.8.8"
+        "testUrl": "ipv4.google.com"
     },
     "skip": []
 }


### PR DESCRIPTION
The modem test was broken when changing from ping to curl as part of 071c018. Here it is fixed

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
