### PR TITLE
initrdscripts: Add cryptsetup module only when required

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-balena-common/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -52,12 +52,12 @@ PACKAGES:append = " \
     initramfs-module-rorootfs \
     initramfs-module-prepare \
     initramfs-module-fsuuidsinit \
-    initramfs-module-cryptsetup \
     initramfs-module-kexec \
     initramfs-module-udevcleanup \
     initramfs-module-recovery \
     initramfs-module-migrate \
     "
+PACKAGES:append = "${@oe.utils.conditional('SIGN_API','','',' initramfs-module-cryptsetup',d)}"
 
 RRECOMMENDS:${PN}-base += "initramfs-module-rootfs"
 


### PR DESCRIPTION
Unsigned builds do not require to mount encrypted drives.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
