### PR TITLE
minor: Turn on kernel functionalities required for Pulsar

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -395,14 +395,16 @@ BALENA_CONFIGS[compress-kmodules] ?= " \
 # 
 # PULSAR (https://pulsar.sh/docs/faq/kernel-requirements)
 #
-CONFIG_DEBUG_INFO=y
-CONFIG_DEBUG_INFO_BTF=y
-CONFIG_SECURITY=y
-CONFIG_SECURITYFS=y
-CONFIG_SECURITY_NETWORK=y
-CONFIG_FUNCTION_TRACER=y
-CONFIG_FTRACE_SYSCALLS=y
-CONFIG_BPF_LSM=y
+BALENA_CONFIGS[pulsar] ?= " \
+    CONFIG_DEBUG_INFO=y \
+    CONFIG_DEBUG_INFO_BTF=y \
+    CONFIG_SECURITY=y \
+    CONFIG_SECURITYFS=y \
+    CONFIG_SECURITY_NETWORK=y \
+    CONFIG_FUNCTION_TRACER=y \
+    CONFIG_FTRACE_SYSCALLS=y \
+    CONFIG_BPF_LSM=y \
+"
 
 #
 # Do not include debugging info in kernel and modules

--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -406,6 +406,8 @@ BALENA_CONFIGS[pulsar] ?= " \
     CONFIG_BPF_LSM=y \
 "
 
+BALENA_CONFIGS:append = " pulsar"
+
 #
 # Do not include debugging info in kernel and modules
 #

--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -392,12 +392,24 @@ BALENA_CONFIGS[compress-kmodules] ?= " \
     CONFIG_MODULE_COMPRESS_GZIP=y \
     "
 
+# 
+# PULSAR (https://pulsar.sh/docs/faq/kernel-requirements)
+#
+CONFIG_DEBUG_INFO=y
+CONFIG_DEBUG_INFO_BTF=y
+CONFIG_SECURITY=y
+CONFIG_SECURITYFS=y
+CONFIG_SECURITY_NETWORK=y
+CONFIG_FUNCTION_TRACER=y
+CONFIG_FTRACE_SYSCALLS=y
+CONFIG_BPF_LSM=y
+
 #
 # Do not include debugging info in kernel and modules
 #
-BALENA_CONFIGS[no-debug-info] ?= " \
-    CONFIG_DEBUG_INFO=n \
-    "
+# BALENA_CONFIGS[no-debug-info] ?= " \
+#    CONFIG_DEBUG_INFO=n \1
+# "
 
 #
 # Support for touchscreens using generic multitouch driver


### PR DESCRIPTION
Testing Pulsar requires some specific kernel functionalities, see https://pulsar.sh/docs/faq/kernel-requirements
This is for testing purpose only