### PR TITLE
networkmanager: remove race condition from shared dispatcher script

### DIFF
--- a/meta-balena-common/recipes-connectivity/networkmanager/balena-files/90shared
+++ b/meta-balena-common/recipes-connectivity/networkmanager/balena-files/90shared
@@ -35,6 +35,7 @@
 
 set -e
 
+# shellcheck disable=SC1091
 . /usr/libexec/os-helpers-logging
 
 if [ "$2" != "up" ]
@@ -52,26 +53,50 @@ IPTABLES="iptables -w 5"
 # Look for the FORWARD rule that NetworkManager adds for interfaces
 # configured as shared. This will have a comment "nm-shared-$IFNAME"
 # and jump into a chain named "sh-fw-$IFNAME"
-FW_RULE_NO=$(${IPTABLES} -L FORWARD --line-number | grep "sh-fw-${IFNAME}" | grep "nm-shared-${IFNAME}" | cut -d " " -f 1)
-if [ "x${FW_RULE_NO}" = "x" ]
+get_rule_no() {
+  ${IPTABLES} -L FORWARD --line-number | grep "sh-fw-${IFNAME}" | grep "nm-shared-${IFNAME}" | cut -d " " -f 1
+}
+
+# Move the rule to the bottom of the forward chain
+demote_rule() {
+  local _last_rule_no
+  local _fw_rule_args
+
+  # Safeguard, this should never happen
+  # Exactly 0 or 1 rule should match, bail out if there are more & investigate
+  if [ "$(get_rule_no | wc -w)" -gt 1 ]; then
+    fail "More than one rule matched when looking for 'nm-shared-${IFNAME}', bailing out"
+  fi
+
+  _fw_rule_args="$(${IPTABLES} -S FORWARD "$(get_rule_no)")"
+
+  # Remove the rule
+  # shellcheck disable=SC2086
+  ${IPTABLES} -D ${_fw_rule_args#-A }
+
+  # Append the rule to the bottom
+  # Do not quote ${_fw_rule_args}, this needs to expand
+  # shellcheck disable=SC2086
+  ${IPTABLES} ${_fw_rule_args}
+
+  _last_rule_no=$(${IPTABLES} -L FORWARD --line-number | tail -1 | cut -d " " -f 1)
+  if [ "$(get_rule_no)" != "${_last_rule_no}" ]; then
+    return 1
+  fi
+}
+
+if [ -z "$(get_rule_no)" ]
 then
   exit 0
 fi
 
-# Safeguard, this should never happen
-# Exactly 0 or 1 rule should match, bail out if there are more & investigate
-if [ "$(echo ${FW_RULE_NO} | wc -w)" -gt 1 ]
-then
-  fail "More than one rule matched when looking for 'nm-shared-${IFNAME}', bailing out"
-fi
+_ctr=0
+until demote_rule; do
+  sleep 1
+  _ctr=$((_ctr + 1))
+  if [ "${_ctr}" -ge 10 ]; then
+    fail "Failed to demote rule 'nm-shared-${IFNAME}'"
+  fi
+done
 
 info "Found shared FORWARD rule 'nm-shared-${IFNAME}' at index ${FW_RULE_NO}, moving down"
-
-FW_RULE_ARGS="$(${IPTABLES} -S FORWARD ${FW_RULE_NO})"
-
-# Append the rule to the bottom
-# Do not quote ${FW_RULE_ARGS}, this needs to expand
-${IPTABLES} ${FW_RULE_ARGS}
-
-# Remove the rule from its original position
-${IPTABLES} -D FORWARD "${FW_RULE_NO}"


### PR DESCRIPTION
The shared dispatcher script runs when a shared iptables rules is identified and it moves it to the last place in the forward chain to avoid race conditions with the engine rule addition.

This commit refactors the script to remove the possibility of a rule changing positions between being identified by line number and removing it.

The script now only fetches the rule line number once and then uses its description to both append and remove.

It also has a final check to make sure the rule has been moved to the last position of the forward chain, and tries a series of times if that is not the case.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
