### PR TITLE
NetworkManager: do not use FW rule numbers in shared dispatcher script

### DIFF
--- a/meta-balena-common/recipes-connectivity/networkmanager/balena-files/90shared
+++ b/meta-balena-common/recipes-connectivity/networkmanager/balena-files/90shared
@@ -33,8 +33,7 @@
 # the race condition and always sets the FORWARD rules
 # as if balenaEngine came up last.
 
-set -e
-
+# shellcheck disable=SC1091
 . /usr/libexec/os-helpers-logging
 
 if [ "$2" != "up" ]
@@ -52,26 +51,48 @@ IPTABLES="iptables -w 5"
 # Look for the FORWARD rule that NetworkManager adds for interfaces
 # configured as shared. This will have a comment "nm-shared-$IFNAME"
 # and jump into a chain named "sh-fw-$IFNAME"
-FW_RULE_NO=$(${IPTABLES} -L FORWARD --line-number | grep "sh-fw-${IFNAME}" | grep "nm-shared-${IFNAME}" | cut -d " " -f 1)
-if [ "x${FW_RULE_NO}" = "x" ]
+FW_RULE_COMMENT="nm-shared-${IFNAME}"
+FW_RULE_ARGS=$(${IPTABLES} -S FORWARD | grep "sh-fw-${IFNAME}" | grep "${FW_RULE_COMMENT}")
+if [ -z "${FW_RULE_ARGS}" ]
 then
   exit 0
 fi
 
 # Safeguard, this should never happen
 # Exactly 0 or 1 rule should match, bail out if there are more & investigate
-if [ "$(echo ${FW_RULE_NO} | wc -w)" -gt 1 ]
+if [ "$(echo "${FW_RULE_ARGS}" | wc -l)" -gt 1 ]
 then
-  fail "More than one rule matched when looking for 'nm-shared-${IFNAME}', bailing out"
+  fail "More than one rule matched when looking for '${FW_RULE_COMMENT}', bailing out"
 fi
 
-info "Found shared FORWARD rule 'nm-shared-${IFNAME}' at index ${FW_RULE_NO}, moving down"
+# If the rule is already last, this will do nothing
+# If the rule is not last, the first run through the loop should move it
+# If that does not work for any reason, try a few more times before bailing out
+I=0
+while [ "$(${IPTABLES} -S FORWARD | tail -n 1)" != "${FW_RULE_ARGS}" ]
+do
+  I=$(("${I}" + 1))
 
-FW_RULE_ARGS="$(${IPTABLES} -S FORWARD ${FW_RULE_NO})"
+  if [ "${I}" -gt 5 ]
+  then
+    fail "5 attempts to move the '${FW_RULE_COMMENT}' firewall rule to the last position have failed, bailing out"
+  fi
 
-# Append the rule to the bottom
-# Do not quote ${FW_RULE_ARGS}, this needs to expand
-${IPTABLES} ${FW_RULE_ARGS}
+  # Append the rule to the bottom
+  # Do not quote ${FW_RULE_ARGS}, this needs to expand
+  ${IPTABLES} ${FW_RULE_ARGS}
 
-# Remove the rule from its original position
-${IPTABLES} -D FORWARD "${FW_RULE_NO}"
+  # Remove the rule from its original position
+  ${IPTABLES} -D ${FW_RULE_ARGS#-A }
+done
+
+if [ "${I}" = 0 ]
+then
+  info "Rule '${FW_RULE_COMMENT}' was already in the last position"
+else
+  info "Moved the '${FW_RULE_COMMENT}' rule to the last position"
+  if [ "${I}" -gt 1 ]
+  then
+    warn "It took ${I} attempts to move the rule"
+  fi
+fi


### PR DESCRIPTION
Manipulating the firewall rules by index introduces a race condition. Both NetworkManager and balenaEngine add the rules to the top of the `FORWARD` chain instead of appending, so if we first look up a rule by number and then use the number to refer to it, we can not guarantee that the rule number has not changed (iow the rule has not been moved down) in the meantime.

This patch removes the use of rule numbers completely and makes the "shared" dispatcher script refer to the rules by definition.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
