### PR TITLE
tests: secureboot: refactor to facilitate extension

### DIFF
--- a/tests/suites/os/tests/secureboot/index.js
+++ b/tests/suites/os/tests/secureboot/index.js
@@ -1,145 +1,221 @@
 'use strict';
 
+const fs = require('fs');
+const fse = require('fs-extra');
+const securebootEfiVarPath = '/sys/firmware/efi/efivars/SecureBoot-*';
+
+class secureBoot {
+	constructor(test, worker, suite, imagePath, module = {"name": "", "headersVersion": ""}) {
+		this.test = test;
+		this.worker = worker;
+		this.link = suite.context.get().link;
+		this.imagePath = imagePath;
+		this.sshKeyPath = suite.context.get().sshKeyPath;
+		this.utils = suite.context.get().utils;
+		this.module = module;
+		this.tmpDir = suite.options.tmpdir;
+	}
+
+	async resetWorker() {
+		await this.worker.off();
+		await this.worker.flash(this.imagePath);
+		await this.worker.on();
+
+		await this.worker.addSSHKey(this.sshKeyPath);
+	}
+
+	async waitForSerialOutput(pattern, slice=0, retries=60, delay=1000) {
+		await this.utils.waitUntil(
+			async () => this.worker.fetchSerial().then(
+				serialLogs => {
+					return serialLogs.split('\n')
+					.slice(slice)
+					.join('\n')
+					.match(pattern)
+				}), false, retries, delay
+		);
+	}
+
+	async isSecureBootSupported() {
+		throw new Error("Method isSecureBootSupported() must be implemented");
+	}
+
+	async isSecureBootEnabled() {
+		throw new Error("Method isSecureBootEnabled() must be implemented");
+	}
+
+	async testFullDiskEncryption() {
+			Promise.all(
+				[
+					{ pattern: '/^\\/mnt\\/boot$/', name: 'Boot partition' },
+					{ pattern: '/^\\/mnt\\/sysroot\\/active$/', name: 'Root partition' },
+					{ pattern: '/^\\/mnt\\/state$/', name: 'State partition' },
+					{ pattern: '/^\\/mnt\\/data$/', name: 'Data partition' },
+				].map(args => this.test.resolveMatch(
+						this.worker.executeCommandInHostOS(
+							[
+								'lsblk', '-nlo', 'MOUNTPOINT,TYPE',
+								'|', 'awk', `'$1 ~ ${args.pattern} { print $2 }'`
+							],
+							this.link,
+						),
+						/crypt/,
+						`${args.name} is encrypted`,
+					)
+				)
+			);
+	}
+
+	async testModuleVerification() {
+		if (this.module.name.length != 0) {
+			await this.test.resolves(
+				this.worker.executeCommandInHostOS(`modprobe ${this.module.name}`, this.link),
+				`Module ${this.module.name} with valid signature loads`,
+			);
+		} else {
+			this.test.comment("No module with valid signature specified - skipping")
+		}
+
+		if (this.module.headersVersion.length != 0) {
+			const srcDir = `${__dirname}/kernel-module-build/`
+			await fse.copy(srcDir, this.tmpDir);
+			fs.readFile(`${this.tmpDir}/docker-compose.yml`, 'utf-8', (err,data) => {
+				if (err) {
+					throw new Error(`Unable to find ${this.tmpDir}/docker-compose.yml`)
+				}
+				const result = data.replace(/os_version:\s*\S+/, `os_version: ${this.module.headersVersion}`);
+				fs.writeFile( `${this.tmpDir}/docker-compose.yaml`, result, 'utf-8', (err) => {
+					if (err) {
+						throw new Error(`Unable to write ${this.tmpDir}/docker-compose.yml`)
+					}
+				})
+			})
+			this.test.comment(`Using kernel headers version ${this.module.headersVersion}`)
+		}
+
+		await this.worker.pushContainerToDUT(
+			this.link,
+			`${this.tmpDir}`,
+			'load',
+		);
+
+		return this.test.resolveMatch(
+			this.worker.executeCommandInHostOS(
+				'balena logs $(balena ps -aqf NAME=load)',
+				this.link,
+			),
+			/Key was rejected by service/,
+			'Unsigned module does not load',
+		);
+	}
+
+	async testBootloaderIntegrity() {
+		throw new Error("Method testBootloaderIntegrity() must be implemented");
+	}
+
+	async testBootloaderConfigIntegrity() {
+		throw new Error("Method testBootloaderConfigIntegrity() must be implemented");
+	}
+}
+
+class uefiSecureBoot extends secureBoot {
+	async isSecureBootSupported() {
+			return this.worker.executeCommandInHostOS(
+				['ls', securebootEfiVarPath, '&>/dev/null',
+					'&&', 'echo', 'true',
+					'||', 'echo', 'false'
+				],
+				this.link,
+			).then(output => { return output === 'true'});
+	}
+
+	async isSecureBootEnabled() {
+			// https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface/Secure_Boot#Checking_Secure_Boot_status
+			return this.worker.executeCommandInHostOS(
+					[
+						'od', '--address-radix=n', '--format=u1', securebootEfiVarPath,
+							'|', 'tr', '-s', "' '",
+							'|', 'cut', "-d' '", '-f6'
+					],
+					this.link,
+			).then(output => output === '1' );
+	}
+
+	async testBootloaderIntegrity() {
+		return this.worker.executeCommandInHostOS(
+			['balena', 'run', '--rm', '-v', '/mnt:/mnt', 'alpine', '/bin/sh', '-c',
+				'"apk add --update --no-cache binutils && strip /mnt/boot/EFI/BOOT/bootx64.efi"'],
+			this.link,
+		).then(() => this.worker.executeCommandInHostOS('reboot', this.link)
+		).then(() => this.test.resolves(
+			this.waitForSerialOutput(/bootx64.efi: Access Denied/),
+			'Firmware will not load bootloader that fails verification',
+		)
+		).then( () => this.resetWorker() );
+	};
+
+	async testBootloaderConfigIntegrity() {
+		return this.worker.executeCommandInHostOS(
+			['sed', '-i', 's/lockdown=integrity//', '/mnt/efi/EFI/BOOT/grub.cfg'],
+			this.link
+		).then(() => this.worker.executeCommandInHostOS('reboot', this.link)
+		).then(() => this.test.resolves(
+			/* The below pattern is the expected output when the config file
+			 * fails the signature check and the fallback console is not enabled.
+			 *
+			 * This sequence of ANSI escape codes decodes as:
+			 *
+			 *	ESC[0m - reset all modes
+			 *	ESC[37m - white foreground
+			 *	ESC[40m - black background
+			 *
+			 *	https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797
+			 *
+			 * Otherwise, the output finishes the above background color escape
+			 * sequence, clears the screen, and shows 'loading Boot0003
+			 * "balenaOS"'
+			 */
+
+			this.waitForSerialOutput(/\x1B\[0m\x1B\[37m\x1B\[40m$/, 3), // eslint-disable-line no-control-regex
+			'Bootloader will not load configuration that fails signature verification',
+			{ todo: 'This needs reworked for GRUB 2.12' },
+		)
+		).then( () => this.resetWorker() );
+	};
+}
+
+class testSecureBoot {
+	constructor(impl) {
+		this.impl = impl;
+	}
+
+	async run(test) {
+		if ( await this.impl.isSecureBootSupported() ) {
+			if ( await this.impl.isSecureBootEnabled() ) {
+				await this.impl.testFullDiskEncryption();
+				await this.impl.testModuleVerification();
+				await this.impl.testBootloaderIntegrity();
+				await this.impl.testBootloaderConfigIntegrity();
+			} else {
+				test.comment('Secure boot is not enabled');
+			}
+		} else {
+			test.comment('Secure boot is not supported by firmware');
+		}
+	}
+}
+
 module.exports = {
 	title: 'secure boot tests',
 	tests: [
 		{
-			title: 'check secure boot',
+			title: 'check UEFI secure boot',
 			run: async function(test) {
-				const securebootEfiVarPath = '/sys/firmware/efi/efivars/SecureBoot-*';
-
-				const securebootSupported = await this.worker.executeCommandInHostOS(
-					['ls', securebootEfiVarPath, '&>/dev/null',
-						'&&', 'echo', 'true',
-						'||', 'echo', 'false'
-					],
-					this.link,
-				).then(output => { return output === 'true'});
-
-				// https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface/Secure_Boot#Checking_Secure_Boot_status
-				const securebootEnabled = await this.worker.executeCommandInHostOS(
-						[
-							'od', '--address-radix=n', '--format=u1', securebootEfiVarPath,
-								'|', 'tr', '-s', "' '",
-								'|', 'cut', "-d' '", '-f6'
-						],
-						this.link,
-				).then(output => output === '1' );
-
-				// Used after tampering with verified boot files
-				const resetWorker = async () => {
-					await this.worker.off();
-					await this.worker.flash(this.os.image.path);
-					await this.worker.on();
-
-					await this.worker.addSSHKey(this.sshKeyPath);
-				}
-
-				const waitForSerialOutput = async(pattern, slice=0, retries=60, delay=1000) => this.utils.waitUntil(
-					async () => this.worker.fetchSerial().then(
-						serialLogs => serialLogs.split('\n')
-																		.slice(slice)
-																		.join('\n')
-																		.match(pattern)
-					), false, retries, delay
-				);
-
-				const testFullDiskEncryption = async () => Promise.all(
-					[
-						{ pattern: '/^\\/mnt\\/boot$/', name: 'Boot partition' },
-						{ pattern: '/^\\/mnt\\/sysroot\\/active$/', name: 'Root partition' },
-						{ pattern: '/^\\/mnt\\/state$/', name: 'State partition' },
-						{ pattern: '/^\\/mnt\\/data$/', name: 'Data partition' },
-					].map(args => test.resolveMatch(
-							this.worker.executeCommandInHostOS(
-								[
-									'lsblk', '-nlo', 'MOUNTPOINT,TYPE',
-									'|', 'awk', `'$1 ~ ${args.pattern} { print $2 }'`
-								],
-								this.link,
-							),
-							/crypt/,
-							`${args.name} is encrypted`,
-						)
-					)
-				);
-
-				const testModuleVerification = async() => {
-					await test.resolves(
-						this.worker.executeCommandInHostOS('modprobe pcan_netdev', this.link),
-						'Module with valid signature loads',
-					);
-
-					await this.worker.pushContainerToDUT(
-						this.link,
-						`${__dirname}/kernel-module-build`,
-						'load',
-					);
-
-					return test.resolveMatch(
-						this.worker.executeCommandInHostOS(
-							'balena logs $(balena ps -aqf NAME=load)',
-							this.link,
-						),
-						/Key was rejected by service/,
-						'Unsigned module does not load',
-					);
-				}
-
-				const testBootloaderIntegrity = async() => {
-					return this.worker.executeCommandInHostOS(
-						['balena', 'run', '--rm', '-v', '/mnt:/mnt', 'alpine', '/bin/sh', '-c',
-							'"apk add --update --no-cache binutils && strip /mnt/boot/EFI/BOOT/bootx64.efi"'],
-						this.link,
-					).then(() => this.worker.executeCommandInHostOS('reboot', this.link)
-					).then(() => test.resolves(
-							waitForSerialOutput(/bootx64.efi: Access Denied/),
-							'Firmware will not load bootloader that fails verification',
-						)
-					).then(resetWorker);
-				};
-
-				const testBootloaderConfigIntegrity = async () => {
-					return this.worker.executeCommandInHostOS(
-						['sed', '-i', 's/lockdown=integrity//', '/mnt/efi/EFI/BOOT/grub.cfg'],
-						this.link
-					).then(() => this.worker.executeCommandInHostOS('reboot', this.link)
-					).then(() => test.resolves(
-						/* The below pattern is the expected output when the config file
-						 * fails the signature check and the fallback console is not enabled.
-						 *
-						 * This sequence of ANSI escape codes decodes as:
-						 *
-						 *	ESC[0m - reset all modes
-						 *	ESC[37m - white foreground
-						 *	ESC[40m - black background
-						 *
-						 *	https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797
-						 *
-						 * Otherwise, the output finishes the above background color escape
-						 * sequence, clears the screen, and shows 'loading Boot0003
-						 * "balenaOS"'
-						 */
-
-							waitForSerialOutput(/\x1B\[0m\x1B\[37m\x1B\[40m$/, 3), // eslint-disable-line no-control-regex
-							'Bootloader will not load configuration that fails signature verification',
-						{ todo: 'This needs reworked for GRUB 2.12' },
-						)
-					).then(resetWorker);
-				};
-
-				if (securebootSupported) {
-					if (securebootEnabled) {
-						await testFullDiskEncryption();
-						await testModuleVerification();
-						await testBootloaderIntegrity();
-						await testBootloaderConfigIntegrity();
-					} else {
-						test.comment('Secure boot is not enabled');
-					}
-				} else {
-					test.comment('Secure boot is not supported by firmware');
-				}
+				const impl = new testSecureBoot(new uefiSecureBoot(test,
+					this.worker,
+					this.suite, this.os.image.path,
+					{"name": "pcan_netdev", "headersVersion": "2.108.6"}));
+				await impl.run(test);
 			},
 		},
 	]

--- a/tests/suites/os/tests/secureboot/index.js
+++ b/tests/suites/os/tests/secureboot/index.js
@@ -16,7 +16,7 @@ class secureBoot {
 		this.tmpDir = suite.options.tmpdir;
 	}
 
-	async resetWorker() {
+	async resetDUT() {
 		await this.worker.off();
 		await this.worker.flash(this.imagePath);
 		await this.worker.on();
@@ -151,7 +151,7 @@ class uefiSecureBoot extends secureBoot {
 			this.waitForSerialOutput(/bootx64.efi: Access Denied/),
 			'Firmware will not load bootloader that fails verification',
 		)
-		).then( () => this.resetWorker() );
+		).then( () => this.resetDUT() );
 	};
 
 	async testBootloaderConfigIntegrity() {
@@ -180,7 +180,7 @@ class uefiSecureBoot extends secureBoot {
 			'Bootloader will not load configuration that fails signature verification',
 			{ todo: 'This needs reworked for GRUB 2.12' },
 		)
-		).then( () => this.resetWorker() );
+		).then( () => this.resetDUT() );
 	};
 }
 


### PR DESCRIPTION
As the secure boot feature is extended to more device types, the test needs to be easy to extend.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
