### PR TITLE
hostapp-update-hooks: Re-add check for UEFI to signed-update hook

### DIFF
--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
@@ -236,6 +236,11 @@ if [ "${DURING_UPDATE}" != 1 ]; then
     exit 0
 fi
 
+# Only applicable on UEFI systems
+if [ ! -d "/sys/firmware/efi" ]; then
+    exit 0
+fi
+
 mountEfiVars
 
 # Read EFI variables


### PR DESCRIPTION
In 328222014146f0116e0208443f3e255d0e85ef15 we have removed the `signed-update` hook from systems that do not have `EFI` in `MACHINE_FEATURES`. This on its own makes sense, however together with it we have also removed the runtime check for whether the running system is actually booted in UEFI mode.

This effectively means it is no longer possible to update the host OS on a device type able to boot in both UEFI and BIOS modes (`intel-nuc` and `genericx86-64-ext`) when booted in BIOS mode, as the signed-update hook is executed unconditionally and fails if the device is not running UEFI.

This patch re-adds the runtime check to only execute the hook if the system is actually booted in UEFI mode.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
