### PR TITLE
initrdscripts: Allow passing extra kernel arguments to kexec

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/kexec
+++ b/meta-balena-common/recipes-core/initrdscripts/files/kexec
@@ -34,7 +34,7 @@ kexec_run() {
     # * root=XXX - will be replaced by the UUID
     # * maxcpus=0 - enable SMP after reboot if the 2nd stage bootloader has it disabled
     BOOT_PARAMS="$(cat /proc/cmdline | sed -e s,balena_stage2,, | sed -e s,root=[^\ ]*,, | sed -e s,maxcpus=0,, | sed -e s,nr_cpus=[^\ ]*,,)"
-    kexec -s -l "${KERNEL_IMAGE}" --append="${BOOT_PARAMS} root=UUID=${ROOT_UUID}"
+    kexec -s -l "${KERNEL_IMAGE}" --append="${BOOT_PARAMS} root=UUID=${ROOT_UUID} ${KEXEC_EXTRA_ARGS}"
 
     umount "${ROOTFS_DIR}"
 


### PR DESCRIPTION
At this moment the kexec initrd script just takes the original kernel command line, replaces root with UUID and removes bootloader args.

We have found at least one use-case (on the Pi4 and firmware GPIOs), where a different initrd script needs to pass extra arguments to the kexec'd kernel. With this patch it will append the contents of the KEXEC_EXTRA_ARGS variable to the kernel command line.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
