### PR TITLE
initrdscripts: make the kexec script fail hard in unexpected states

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/kexec
+++ b/meta-balena-common/recipes-core/initrdscripts/files/kexec
@@ -6,27 +6,31 @@
 KERNEL_IMAGE="${ROOTFS_DIR}/boot/@@KERNEL_IMAGETYPE@@"
 
 kexec_enabled() {
-    if [ "$bootparam_balena_stage2" != "true" ]
+    # The script is enabled if and only if we are in balena bootloader.
+    # Any additional pre-conditions should be handled by runtime checks
+    # in kexec_run(). This is because this script serves as exit point
+    # for the balena bootloader, regardless of whether the actual kexec
+    # call succeeds or not. Running any further initrd scripts
+    # is undesirable and considered undefined behavior.
+    if [ "$bootparam_balena_stage2" = "true" ]
     then
-        return 1
+        return 0
     fi
 
-    if [ "x${ROOTFS_DIR}" = "x" ]
+    return 1
+}
+
+kexec_run() {
+    if [ -z "${ROOTFS_DIR}" ]
     then
-        info "ROOTFS_DIR undefined, skipping kexec"
-        return 1
+        fail "ROOTFS_DIR undefined, can not kexec"
     fi
 
     if [ ! -f "${KERNEL_IMAGE}" ]
     then
-        info "${KERNEL_IMAGE} not found, skipping kexec"
-        return 1
+        fail "${KERNEL_IMAGE} not found, can not kexec"
     fi
 
-    return 0
-}
-
-kexec_run() {
     ROOT_UUID=$(findmnt "${ROOTFS_DIR}" -n -o UUID)
 
     # Remove the following kernel arguments:
@@ -38,5 +42,10 @@ kexec_run() {
 
     umount "${ROOTFS_DIR}"
 
-    kexec -e || fail "kexec failed with $?, abort"
+    kexec -e
+
+    # The `kexec -e` above should be the only exit point from this script
+    # If the code has somehow reached all the way down here, it means
+    # kexec had failed and we must bail out immediately.
+    fail "kexec failed with $?, abort"
 }


### PR DESCRIPTION
At this moment the kexec initrd script is skipped when `ROOTFS_DIR` is not defined or if the new rootfs is mounted, but does not contain a kernel image in the expected place. This is undesirable as we assume this is the last script executed by the balena bootloader.

This patch makes the kexec script always execute in the balena bootloader and makes it fail hard in unexpected states, which means the script is always an exit point for the balena bootloader, whether the actual kexec call succeeds or not.


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
