### PR TITLE
Add build-only GHA workflows for missing devices

### DIFF
--- a/.github/workflows/genericx86-64-ext.yml
+++ b/.github/workflows/genericx86-64-ext.yml
@@ -1,4 +1,4 @@
-name: Generic x86_64 (GPT)
+name: Generic x86_64 (legacy MBR)
 
 on:
   # With these triggers the Yocto jobs will run
@@ -27,8 +27,8 @@ jobs:
     if: (github.event.pull_request.head.repo.full_name == github.repository) == (github.event_name == 'pull_request')
     secrets: inherit
     with:
-      machine: generic-amd64
-      device-repo: balena-os/balena-generic
+      machine: genericx86-64-ext
+      device-repo: balena-os/balena-intel
       device-repo-ref: master
       # Pin to the current commit
       meta-balena-ref: ${{ github.sha }}

--- a/.github/workflows/genericx86-64.yml
+++ b/.github/workflows/genericx86-64.yml
@@ -1,4 +1,4 @@
-name: Generic x86_64 (legacy MBR)
+name: Intel NUC
 
 on:
   # With these triggers the Yocto jobs will run
@@ -13,19 +13,13 @@ on:
     branches:
       - "main"
       - "master"
-  # push:
-  #   tags:
-  #     - v[0-9]+.[0-9]+.[0-9]+\+?r?e?v?*
-  #     - v20[0-9][0-9].[0-1]?[1470].[0-9]+
-  # # Allows you to run this workflow manually from the Actions tab
-  # workflow_dispatch:
 
 jobs:
   yocto:
     name: Yocto
     # FIXME: This workflow has dependencies on scripts in the balena-yocto-scripts repository
     # which is pinned separately as a submodule in the device repo. Expect some drift but try to retain compatibility.
-    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@v1.25.3
+    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@v1.25.7
     # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
     # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
     # This condition will prevent the workflow from running twice for the same pull request while
@@ -33,9 +27,7 @@ jobs:
     if: (github.event.pull_request.head.repo.full_name == github.repository) == (github.event_name == 'pull_request')
     secrets: inherit
     with:
-      machine: genericx86-64-ext
-      # Needed for testing - defaults to production
-      environment: balena-staging.com
+      machine: genericx86-64
       device-repo: balena-os/balena-intel
       device-repo-ref: master
       # Pin to the current commit
@@ -44,11 +36,3 @@ jobs:
       deploy-s3: false
       deploy-hostapp: false
       deploy-ami: false
-      # Use qemu workers for testing
-      test_matrix: >
-        {
-          "test_suite": ["os","cloud","hup"],
-          "environment": ["bm.balena-dev.com"],
-          "worker_type": ["qemu"],
-          "runs_on": [["self-hosted", "X64", "kvm"]]
-        }

--- a/.github/workflows/raspberrypi3-64.yml
+++ b/.github/workflows/raspberrypi3-64.yml
@@ -1,4 +1,4 @@
-name: Generic x86_64 (GPT)
+name: Raspberry Pi 3 (using 64bit OS)
 
 on:
   # With these triggers the Yocto jobs will run
@@ -27,8 +27,8 @@ jobs:
     if: (github.event.pull_request.head.repo.full_name == github.repository) == (github.event_name == 'pull_request')
     secrets: inherit
     with:
-      machine: generic-amd64
-      device-repo: balena-os/balena-generic
+      machine: raspberrypi3-64
+      device-repo: balena-os/balena-raspberrypi
       device-repo-ref: master
       # Pin to the current commit
       meta-balena-ref: ${{ github.sha }}
@@ -36,11 +36,3 @@ jobs:
       deploy-s3: false
       deploy-hostapp: false
       deploy-ami: false
-      # Use QEMU workers for testing and run cloud suite against balenaCloud production
-      test_matrix: >
-        {
-          "test_suite": ["os","cloud","hup"],
-          "environment": ["balena-cloud.com"],
-          "worker_type": ["qemu"],
-          "runs_on": [["self-hosted", "X64", "kvm"]]
-        }

--- a/.github/workflows/raspberrypi3.yml
+++ b/.github/workflows/raspberrypi3.yml
@@ -1,4 +1,4 @@
-name: Intel NUC
+name: Raspberry Pi 3
 
 on:
   # With these triggers the Yocto jobs will run
@@ -13,19 +13,13 @@ on:
     branches:
       - "main"
       - "master"
-  # push:
-  #   tags:
-  #     - v[0-9]+.[0-9]+.[0-9]+\+?r?e?v?*
-  #     - v20[0-9][0-9].[0-1]?[1470].[0-9]+
-  # # Allows you to run this workflow manually from the Actions tab
-  # workflow_dispatch:
 
 jobs:
   yocto:
     name: Yocto
     # FIXME: This workflow has dependencies on scripts in the balena-yocto-scripts repository
     # which is pinned separately as a submodule in the device repo. Expect some drift but try to retain compatibility.
-    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@v1.25.3
+    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@v1.25.7
     # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
     # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
     # This condition will prevent the workflow from running twice for the same pull request while
@@ -33,10 +27,8 @@ jobs:
     if: (github.event.pull_request.head.repo.full_name == github.repository) == (github.event_name == 'pull_request')
     secrets: inherit
     with:
-      machine: genericx86-64
-      # Needed for testing - defaults to production
-      environment: balena-staging.com
-      device-repo: balena-os/balena-intel
+      machine: raspberrypi3
+      device-repo: balena-os/balena-raspberrypi
       device-repo-ref: master
       # Pin to the current commit
       meta-balena-ref: ${{ github.sha }}
@@ -44,11 +36,3 @@ jobs:
       deploy-s3: false
       deploy-hostapp: false
       deploy-ami: false
-      # Use autokit workers for testing and run on free hosted runners
-      test_matrix: >
-        {
-          "test_suite": ["os","cloud","hup"],
-          "environment": ["bm.balena-dev.com"],
-          "worker_type": ["testbot"],
-          "runs_on": [["ubuntu-latest"]]
-        }

--- a/.github/workflows/raspberrypi4-64.yml
+++ b/.github/workflows/raspberrypi4-64.yml
@@ -13,19 +13,13 @@ on:
     branches:
       - "main"
       - "master"
-  # push:
-  #   tags:
-  #     - v[0-9]+.[0-9]+.[0-9]+\+?r?e?v?*
-  #     - v20[0-9][0-9].[0-1]?[1470].[0-9]+
-  # # Allows you to run this workflow manually from the Actions tab
-  # workflow_dispatch:
 
 jobs:
   yocto:
     name: Yocto
     # FIXME: This workflow has dependencies on scripts in the balena-yocto-scripts repository
     # which is pinned separately as a submodule in the device repo. Expect some drift but try to retain compatibility.
-    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@v1.25.3
+    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@v1.25.7
     # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
     # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
     # This condition will prevent the workflow from running twice for the same pull request while
@@ -34,8 +28,6 @@ jobs:
     secrets: inherit
     with:
       machine: raspberrypi4-64
-      # Needed for testing - defaults to production
-      environment: balena-staging.com
       device-repo: balena-os/balena-raspberrypi
       device-repo-ref: master
       # Pin to the current commit
@@ -44,11 +36,3 @@ jobs:
       deploy-s3: false
       deploy-hostapp: false
       deploy-ami: false
-      # Use autokit workers for testing and run on free hosted runners
-      test_matrix: >
-        {
-          "test_suite": ["os","cloud","hup"],
-          "environment": ["bm.balena-dev.com"],
-          "worker_type": ["testbot"],
-          "runs_on": [["ubuntu-latest"]]
-        }


### PR DESCRIPTION
For meta-balena PRs we only want to test virtual devices,
but we will do a sanity build for many types.

Depends-on: https://github.com/balena-os/balena-yocto-scripts/pull/365
Depends-on: https://github.com/balena-os/balena-yocto-scripts/pull/367

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
