### PR TITLE
NetworkManager: remove duplicate rules in shared dispatcher script

### DIFF
--- a/meta-balena-common/recipes-connectivity/networkmanager/balena-files/90shared
+++ b/meta-balena-common/recipes-connectivity/networkmanager/balena-files/90shared
@@ -58,11 +58,21 @@ then
   exit 0
 fi
 
-# Safeguard, this should never happen
-# Exactly 0 or 1 rule should match, bail out if there are more & investigate
-if [ "$(echo "${FW_RULE_ARGS}" | wc -l)" -gt 1 ]
+# Sometimes on NetworkManager restart a new rule is added
+# but the old one is not properly cleand up
+# Remove the duplicates here as the rules are all the same
+DUPS=0
+while [ "$(echo "${FW_RULE_ARGS}" | wc -l)" -gt 1 ]
+do
+  DUPS=$(("${DUPS}" + 1))
+  FIRST_FW_RULE_ARGS="$(echo "${FW_RULE_ARGS}" | head -n 1)"
+  ${IPTABLES} -D ${FIRST_FW_RULE_ARGS#-A }
+  FW_RULE_ARGS=$(${IPTABLES} -S FORWARD | grep "sh-fw-${IFNAME}" | grep "${FW_RULE_COMMENT}")
+done
+
+if [ "${DUPS}" -gt 0 ]
 then
-  fail "More than one rule matched when looking for '${FW_RULE_COMMENT}', bailing out"
+  info "Removed ${DUPS} duplicate '${FW_RULE_COMMENT}' rules"
 fi
 
 # If the rule is already last, this will do nothing


### PR DESCRIPTION
Sometimes on NetworkManager restart a new rule for a shared interface is added, but the old rule is not cleaned up properly, so the rules are just piling up. This patch makes the shared dispatcher script clean up duplicates if it finds any.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
