### PR TITLE
tpm2: ensure auth session contexts are flushed after use

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup-efi-tpm
+++ b/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup-efi-tpm
@@ -106,6 +106,8 @@ cryptsetup_run() {
     tpm2_startauthsession --policy-session -S "${SESSION_CTX}"
     tpm2_policypcr -S "${SESSION_CTX}" -l "${PCRS}"
 
+    trap 'tpm2_flushcontext "${SESSION_CTX}"' EXIT
+
     # combined multiple policies with tpm2_policyor
     POLICIES="$(find "${POLICY_PATH}" -type f | sort | xargs)"
     if [ "$(echo "${POLICIES}" | wc -w)" -gt 1 ]; then
@@ -120,6 +122,8 @@ cryptsetup_run() {
         umount "$EFI_MOUNT_DIR"
         fail "Failed to unlock LUKS passphrase using the TPM"
     fi
+
+    tpm2_flushcontext "${SESSION_CTX}" >/dev/null 2>&1
 
     BOOT_DEVICE=$(lsblk -nlo pkname "${EFI_DEV}")
 

--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
@@ -124,7 +124,7 @@ updateKeys() {
     CURRENT_POLICY_PATH="$(find /mnt/efi -name "policies.*")"
     for UNLOCK_PCRS in  0,2,3,7 0,1,2,3; do
         {
-            [ -f "${SESSION_CTX}" ] && tpm2_flushcontext "${SESSION_CTX}"  2>&1 || true
+            tpm2_flushcontext "${SESSION_CTX}"  2>&1 || true
             tpm2_startauthsession --policy-session -S "${SESSION_CTX}"
             tpm2_policypcr -S "${SESSION_CTX}" -l "sha256:${UNLOCK_PCRS}"
             POLICIES="$(find "${CURRENT_POLICY_PATH}" -type f | sort | xargs)"
@@ -139,6 +139,8 @@ updateKeys() {
             break
         fi
     done
+
+    tpm2_flushcontext "${SESSION_CTX}"  >/dev/null 2>&1
 
     POLICY_UPDATED="${POLICY_PATH}/policy.updated"
     POLICY_EFIBIN="${POLICY_PATH}/policy.efibin"
@@ -186,7 +188,7 @@ updateKeys() {
         esac
 
         {
-            tpm2_flushcontext "${SESSION_CTX}"
+            tpm2_flushcontext "${SESSION_CTX}" 2>&1
 
             hw_encrypt_passphrase "$PASSPHRASE_FILE" "$POLICY" "$RESULT_DIR"
             rm -rf "${CURRENT_POLICY_PATH}"

--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/95-secureboot/2-fwd_commit_update-policy
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/95-secureboot/2-fwd_commit_update-policy
@@ -46,6 +46,8 @@ if [ "$(echo "${POLICIES}" | wc -w)" -gt 1 ]; then
 	update_reason="Combined policy in use"
 fi
 
+trap 'tpm2_flushcontext "${SESSION_CTX}"' EXIT
+
 if hw_decrypt_passphrase "${EFI_MOUNT_DIR}" "session:${SESSION_CTX}" "${PASSPHRASE_FILE}"; then
 	echo "Unlocked passphrase using pcr:sha256:0,2,3,7"
 elif hw_decrypt_passphrase "${EFI_MOUNT_DIR}" "pcr:sha256:0,1,2,3" "${PASSPHRASE_FILE}"; then
@@ -55,6 +57,8 @@ else
 	echo "Failed to unlock passphrase, abort"
 	exit 1
 fi
+
+tpm2_flushcontext "${SESSION_CTX}" >/dev/null 2>&1
 
 POLICY="$(mktemp -t)"
 PCRS="0,2,3,7"


### PR DESCRIPTION
The TPM is capable of storing a limited number of auth session handles. Ensure auth sessions are flushed after use, to prevent tpm2_startauthsession from failing with 'out of session handles'.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
