### PR TITLE
init: always run cryptsetup hook with secure boot

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup-efi-tpm
+++ b/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup-efi-tpm
@@ -28,27 +28,12 @@ ensure_luks2() {
 }
 
 cryptsetup_enabled() {
-    # Flasher should not try to unlock the partitions
-    if [ "$bootparam_flasher" = "true" ]; then
-        return 1
+    # Ensure that hook runs when in user mode
+    if user_mode_enabled; then
+	    return 0
     fi
 
-    # Ensure that secure boot is enabled and in user mode before unlocking
-    if ! user_mode_enabled; then
-	    return 1
-    fi
-
-    # Only run if the EFI partition is split
-    if [ ! -e "$EFI_DEV" ]; then
-        return 1
-    fi
-
-    # Check whether there are any LUKS partitions
-    if ! lsblk -nlo fstype | grep -q crypto_LUKS; then
-        return 1
-    fi
-
-    return 0
+    return 1
 }
 
 cryptsetup_run() {


### PR DESCRIPTION
Init hooks specify an *_enabled function that determines whether or not the hook is skipped during boot. Hooks are run by the "init" script, shipped as part of the initramfs-framework poky recipe.

Several conditions were checked in the cryptsetup-efi-tpm enablement function, some of which could cause the hook to be improperly skipped.

Force the hook to run when in secure boot user mode, as we want any failure in the hook's run function to be detected and abort the boot.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
