### PR TITLE
initrdscripts: Make cryptsetup fail hard in unexpected conditions

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup-efi-tpm
+++ b/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup-efi-tpm
@@ -1,5 +1,36 @@
 #!/bin/sh
 
+# This script unlocks encrypted partitions on UEFI systems
+# with secure boot enabled and encryption key protected by a TPM2.0
+#
+# The partition layout of such system is:
+# sda         // Boot device
+# |-sda1      // Unencrypted EFI partition, contains the bootloader and encrypted disk passphrase
+# |-sda2      // Encrypted boot partition
+# | `-dm-0    // Unlocked boot partition, contains balena-specifics, e.g. config.json
+# |-sda3      // Encrypted rootA partition
+# | `-dm-1    // Unlocked rootA partition
+# |-sda4      // Encrypted rootB partition
+# | `-dm-2    // Unlocked rootB partition
+# |-sda5      // Encrypted state partition
+# | `-dm-3    // Unlocked state partition
+# `-sda6      // Encrypted data partition
+#   `-dm-4    // Unlocked data partition
+#
+# When this script executes, it should only find the encrypted partitions.
+# The script unlocks the partitions using the metadata stored in the EFI
+# partition in combination with secrets stored in the TPM.
+# As a result the dm-0..dm-5 devices are created.
+#
+# After successfully unlocking a partition, the default udev rules will
+# in fact create two instances of the unlocked device:
+# * /dev/dm-X - the "dm-X" part is referred to as "KNAME".
+#   This is what the kernel uses internally to identify the device
+# * /dev/mapper/luks-$UUID - the "luks-$UUID" part is referred to as "NAME".
+#   This is a user-defined name, we chose "luks-$UUID", the same as Fedora.
+# The two devices are identical and can be used interchangeably, but this
+# script tries to prefer KNAME as it seems more practical for scripting.
+
 # shellcheck disable=SC1091
 . /usr/libexec/os-helpers-logging
 . /usr/libexec/os-helpers-fs
@@ -16,6 +47,8 @@
 wait4file "/dev/disk/by-state" "50"
 EFI_DEV=$(get_state_path_from_label "${BALENA_NONENC_BOOT_LABEL}")
 
+ENCRYPTED_PARTITIONS="boot rootA rootB state data"
+
 ensure_luks2() {
     LUKS_DEVICE="$1"
 
@@ -28,30 +61,27 @@ ensure_luks2() {
 }
 
 cryptsetup_enabled() {
-    # Flasher should not try to unlock the partitions
-    if [ "$bootparam_flasher" = "true" ]; then
-        return 1
+    # Force the hook to run when system is in secure boot user mode
+    if user_mode_enabled; then
+	    info "System is in secure boot user mode, enforce disk encryption"
+	    return 0
     fi
 
-    # Ensure that secure boot is enabled and in user mode before unlocking
-    if ! user_mode_enabled; then
-	    return 1
-    fi
+    return 1
+}
+
+cryptsetup_run() {
 
     # Only run if the EFI partition is split
     if [ ! -e "$EFI_DEV" ]; then
-        return 1
+        fail "Won't attempt to decrypt drives because the EFI partition is not split"
     fi
 
     # Check whether there are any LUKS partitions
     if ! lsblk -nlo fstype | grep -q crypto_LUKS; then
-        return 1
+        fail "There are no encrypted partitions"
     fi
 
-    return 0
-}
-
-cryptsetup_run() {
     # Die if anything fails here
     set -e
 
@@ -86,20 +116,86 @@ cryptsetup_run() {
 
     BOOT_DEVICE=$(lsblk -nlo pkname "${EFI_DEV}")
 
+    # Check that we have the expected amount of encrypted partitions on the boot device
+    LUKS_PARTITIONS=$(lsblk -nlo "kname,uuid,fstype,partlabel" "/dev/${BOOT_DEVICE}" | grep "crypto_LUKS")
+    if [ "$(echo "${LUKS_PARTITIONS}" | wc -l)" != "$(echo "${ENCRYPTED_PARTITIONS}" | wc -w)" ]; then
+        fail "An unexpected amount of encrypted partitions was found"
+    fi
+
     # Unlock all the partitions - cryptsetup luksOpen does not wait for udev processing
     # of the DM device to complete, it just kicks off the process and returns.
     # Since this is async, we can perform all the luksOpens here, note the device names
     # and wait for them in a separate loop later
     LUKS_UNLOCKED=""
-    for LUKS_UUID in $(lsblk -nlo uuid,fstype "/dev/${BOOT_DEVICE}" | grep crypto_LUKS | cut -d " " -f 1); do
+    for PART_NAME in ${ENCRYPTED_PARTITIONS}; do
+        LUKS_UUID=$(echo "${LUKS_PARTITIONS}" | grep " \(balena\|resin\)-${PART_NAME}$" | xargs | cut -d " " -f 2)
+
+        if [ -z "${LUKS_UUID}" ]; then
+            fail "Partition '${PART_NAME}' not found"
+        fi
+
+        if [ "$(echo "${LUKS_UUID}" | wc -l)" -gt 1 ]; then
+            fail "More than one '${PART_NAME}' partition found"
+        fi
+
         ensure_luks2 "/dev/disk/by-uuid/${LUKS_UUID}"
-        cryptsetup luksOpen --key-file $PASSPHRASE_FILE UUID="${LUKS_UUID}" luks-"${LUKS_UUID}"
+        cryptsetup luksOpen --key-file "${PASSPHRASE_FILE}" "UUID=${LUKS_UUID}" "luks-${LUKS_UUID}"
         LUKS_UNLOCKED="${LUKS_UNLOCKED} luks-${LUKS_UUID}"
     done
 
     # Wait for udev processing of each unlocked device
     for DM_NAME in ${LUKS_UNLOCKED}; do
         wait4udev "/dev/mapper/${DM_NAME}"
+    done
+
+    # Perform sanity checks after unlocking.
+    # We know what the system should look like after the partitions are unlocked.
+    # We want to make sure that the newly unlocked partitions are the ones
+    # we are going to actually use, there is nothing missing and nothing extra.
+    for PART_NAME in ${ENCRYPTED_PARTITIONS}; do
+        LUKS_LINE=$(echo "${LUKS_PARTITIONS}" | grep " \(balena\|resin\)-${PART_NAME}$")
+
+        # Effectively the same checks have been done in the previous loop
+        # We want to be defensive, so we don't mind double-checking
+        if [ -z "${LUKS_LINE}" ]; then
+            fail "Partition '${PART_NAME}' not found"
+        fi
+
+        if [ "$(echo "${LUKS_LINE}" | wc -l)" -gt 1 ]; then
+            fail "More than one '${PART_NAME}' partition found"
+        fi
+
+        LUKS_KNAME=$(echo "${PART_LINE}" | cut -d " " -f 1)
+        LUKS_LABEL=$(echo "${PART_LINE}" | cut -d " " -f 4)
+
+        # Even though the following lsblk could be restricted to just /dev/${LUKS_KNAME}
+        # we intentionally do not want to do that. If there are multiple filesystems with
+        # the correct label, even though we know which one to use, we prefer to bail out,
+        # as this should never happen.
+        FS_LINE=$(lsblk -nlo "kname,pkname,label" | grep "${LUKS_LABEL}")
+        if [ -z "${FS_LINE}" ]; then
+            fail "Filesystem '${LUKS_LABEL}' not found after decryption"
+        fi
+
+        if [ "$(echo "${FS_LINE}" | wc -l)" -gt 1 ]; then
+            fail "More than one '${LUKS_LABEL}' filesystems found after decryption"
+        fi
+
+        FS_KNAME=$(echo "${FS_LINE}" | cut -d " " -f 1)
+        FS_PKNAME=$(echo "${FS_LINE}" | cut -d " " -f 2)
+
+        # We have found an encrypted partition with partlabel=${LUKS_LABEL} and a filesystem
+        # with label=${LUKS_LABEL}. Check that these are parent/child.
+        if [ "${FS_PKNAME}" != "${LUKS_KNAME}" ]; then
+            fail "LUKS partition '${LUKS_LABEL}' does not provide the expected filesystem"
+        fi
+
+        # The original idea was to check the /dev/disk/by-state symlinks here,
+        # but they do not all exist at this point. Because resin_update_state_probe
+        # only creates the symlinks for partitions that are on the same physical drive
+        # as the root partition, no by-state symlinks are created until rootA or rootB
+        # is unlocked. This is not an issue here and all further scripts that actually
+        # want to use the symlinks will trigger udev and get them created.
     done
 
     rm -f "$PASSPHRASE_FILE"


### PR DESCRIPTION
This patch adds a set of checks that make sure that the partition layout is as expected on a system with encrypted disks. Namely it
* Forces the cryptsetup hook to run when in secure boot user mode
* Checks that the boot partition is split
* Checks that it can find the correct amount of encrypted partitions
* Checks that the label on the unlocked filesystem matches the label on the encrypted partition
* Checks that system is not mixing encrypted and unencrypted partitions
* Checks there are no ambiguities or duplicit partitions

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
