### PR TITLE
flasher: improve logging with secure boot

### DIFF
--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/balena-init-flasher-tpm
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/balena-init-flasher-tpm
@@ -78,6 +78,11 @@ diskenc_setup() {
 			     seek="$(du -b "${PCR_VAL_BIN_PRIMARY}" | cut -f1)"
 	done
 
+	info "Creating combined policy for PCRs ${PCRS}"
+
+	print_pcr_val_bin "$PCRS" "$PCR_VAL_BIN_PRIMARY"
+	print_pcr_val_bin "$PCRS" "$PCR_VAL_BIN_SECONDARY"
+
 	tpm2_createpolicy --policy-pcr \
 		-l "sha256:${PCRS}" \
 		-f "${PCR_VAL_BIN_PRIMARY}" \


### PR DESCRIPTION
Print the PCR digest values used to create the PCR policy used to seal the LUKS passphrase during flashing. These values can be cross referenced with the logs during secure boot to diagnose policy check failures.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
