### PR TITLE
tests:os: Use writeConfigJsonProp helper function

### DIFF
--- a/tests/suites/os/tests/engine-socket/index.js
+++ b/tests/suites/os/tests/engine-socket/index.js
@@ -24,12 +24,7 @@ module.exports = {
 				let ip = await this.worker.ip(this.link)
 				const docker = new Docker({host: `http://${ip}`, port: 2375})
 				test.comment(`Setting system in development mode...`)
-				await this.context
-					.get()
-					.worker.executeCommandInHostOS(
-						`tmp=$(mktemp)&&cat /mnt/boot/config.json | jq '.developmentMode="true"' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
-						this.link,
-				);
+        await this.systemd.writeConfigJsonProp(test, 'developmentMode', true, this.link);
 				test.comment(`Waiting for engine to restart...`)
 				await this.utils.waitUntil(async () => {
 					return (
@@ -69,12 +64,7 @@ module.exports = {
 				let ip = await this.worker.ip(this.link)
 				const docker = new Docker({host: `http://${ip}`, port: 2375})
 				test.comment(`Setting system in production mode...`)
-				await this.context
-					.get()
-					.worker.executeCommandInHostOS(
-						`tmp=$(mktemp)&&cat /mnt/boot/config.json | jq '.developmentMode="false"' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
-						this.link,
-				);
+				await this.systemd.writeConfigJsonProp(test, 'developmentMode', false, this.link);
 				test.comment(`Waiting for engine to restart...`)
 				await this.utils.waitUntil(async () => {
 					return (
@@ -97,12 +87,7 @@ module.exports = {
 					"Engine socket should not be exposed in production images"
 				);
 				test.comment(`Leaving system in development mode...`)
-				await this.context
-					.get()
-					.worker.executeCommandInHostOS(
-						`tmp=$(mktemp)&&cat /mnt/boot/config.json | jq '.developmentMode="true"' > $tmp&&mv "$tmp" /mnt/boot/config.json`,
-						this.link,
-				);
+				await this.systemd.writeConfigJsonProp(test, 'developmentMode', true, this.link);
 			},
 		},
 	],


### PR DESCRIPTION
Use the existing helper function to write changes to config.json.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
