### PR TITLE
tests:os: Avoid setting apiEndpoint for unmanaged tests

### DIFF
--- a/tests/suites/hup/suite.js
+++ b/tests/suites/hup/suite.js
@@ -327,7 +327,7 @@ module.exports = {
 			this.suite.options.balenaOS.network.wired = {
 				nat: true,
 			};
-		} 
+		}
 		else {
 			// device has wifi, use wifi hotspot to connect to DUT
 			delete this.suite.options.balenaOS.network.wired;
@@ -347,7 +347,7 @@ module.exports = {
 				psk: `${this.suite.options.id}_psk`,
 				nat: true,
 			};
-		} 
+		}
 		else {
 			// no wifi on DUT
 			delete this.suite.options.balenaOS.network.wireless;
@@ -378,13 +378,13 @@ module.exports = {
 		);
 
 		const keys = await this.utils.createSSHKey(this.sshKeyPath);
-		
+
 		// Authenticating balenaSDK
     await this.context
     .get()
     .sdk.balena.auth.loginWithToken(this.suite.options.balena.apiKey);
     this.log(`Logged in with ${await this.context.get().sdk.balena.auth.whoami()}'s account on ${this.suite.options.balena.apiUrl} using balenaSDK`);
-		
+
 		await this.sdk.balena.models.key.create(
 			this.sshKeyLabel,
 			keys.pubKey
@@ -417,7 +417,6 @@ module.exports = {
 						persistentLogging: true,
 						// Set local mode so we can perform local pushes of containers to the DUT
 						localMode: true,
-						apiEndpoint: 'https://api.balena-cloud.com',
 						developmentMode: true,
 						installer: {
 							secureboot: ['1', 'true'].includes(process.env.FLASHER_SECUREBOOT),

--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -125,10 +125,10 @@ module.exports = {
 		const BalenaOS = this.require('components/os/balenaos');
 		const utils = this.require('common/utils');
 		const worker = new Worker(
-			this.suite.deviceType.slug, 
-			this.getLogger(), 
-			this.suite.options.workerUrl, 
-			this.suite.options.balena.organization, 
+			this.suite.deviceType.slug,
+			this.getLogger(),
+			this.suite.options.workerUrl,
+			this.suite.options.balena.organization,
 			join(homedir(), 'id'),
 			this.suite.options.config.sshConfig
 		);
@@ -205,7 +205,7 @@ module.exports = {
 						} else {
 							value = JSON.stringify(value);
 						}
-		
+
 						return t.resolves(
 							worker.executeCommandInHostOS(
 								[
@@ -260,7 +260,7 @@ module.exports = {
 			this.suite.options.balenaOS.network.wired = {
 				nat: true,
 			};
-		} 
+		}
 		else {
 			// device has wifi, use wifi hotspot to connect to DUT
 			delete this.suite.options.balenaOS.network.wired;
@@ -280,7 +280,7 @@ module.exports = {
 				psk: `${this.suite.options.id}_psk`,
 				nat: true,
 			};
-		} 
+		}
 		else {
 			// no wifi on DUT
 			delete this.suite.options.balenaOS.network.wireless;
@@ -299,12 +299,16 @@ module.exports = {
 					configJson: {
 						uuid: this.suite.options.balenaOS.config.uuid,
 						os: {
+              // Set a connectivity-check URI for HTTPS time sync service
+              network: {
+                connectivity: {
+                  uri: 'https://api.balena-cloud.com/connectivity-check'
+                }
+              },
 							sshKeys: [
 								keys.pubKey
 							],
 						},
-						// Set an API endpoint for the HTTPS time sync service.
-						apiEndpoint: 'https://api.balena-cloud.com',
 						// persistentLogging is managed by the supervisor and only read at first boot
 						persistentLogging: true,
 						// Set local mode so we can perform local pushes of containers to the DUT
@@ -359,7 +363,7 @@ module.exports = {
 			.get()
 			.cloud.balena.auth.loginWithToken(this.suite.options.balena.apiKey);
 			this.log(`Logged in with ${await this.context.get().cloud.balena.auth.whoami()}'s account on ${this.suite.options.balena.apiUrl} using balenaSDK`);
-			
+
 			await this.cloud.balena.models.key.create(
 				this.sshKeyLabel,
 				keys.pubKey
@@ -390,7 +394,7 @@ module.exports = {
 		await this.worker.off(); // Ensure DUT is off before starting tests
 		await this.worker.flash(this.os.image.path);
 		await this.worker.on();
-		
+
 		await this.worker.addSSHKey(this.sshKeyPath);
 
 		// create tunnels
@@ -412,11 +416,11 @@ module.exports = {
 			`Device ${this.link} should be reachable over local SSH connection`
 		)
 
-		await test.resolves( 
+		await test.resolves(
 			systemd.waitForServiceState('balena', 'active', this.link),
 			'balena Engine should be running and healthy'
 		)
-		
+
 		// we want to waitUntil here as the supervisor may take some time to come online.
 		await test.resolves(
 			this.utils.waitUntil(async () => {
@@ -429,7 +433,7 @@ module.exports = {
 			'Supervisor should be running and healthy'
 		)
 
-		
+
 		// Retrieving journalctl logs: register teardown after device is reachable
 		this.suite.teardown.register(async () => {
 			await this.context


### PR DESCRIPTION
When this config.json field has a value, the supervisor will treat the device as managed and will crash and start to boot loop.

On faster device-types we don't seem to notice and the tests pass by chance, but on Pi Zero and similar we consistently see ECONNRESET when hitting local SV endpoints.

Change-type: patch
See: https://github.com/balena-os/meta-balena/issues/3510
Added-in: https://github.com/balena-os/meta-balena/pull/2369 and https://github.com/balena-os/meta-balena/pull/3022

> [!WARNING]
> This REVERTS the changes made in https://github.com/balena-os/meta-balena/pull/3022 and we need to retest the flashing of Jetson TX2 devices.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
