### PR TITLE
modemmanager: Fix SIM7100E crash

### DIFF
--- a/meta-balena-common/recipes-connectivity/modemmanager/balena-files/0004-bearer-qmi-Fix-SIM7100E-crash.patch
+++ b/meta-balena-common/recipes-connectivity/modemmanager/balena-files/0004-bearer-qmi-Fix-SIM7100E-crash.patch
@@ -1,0 +1,29 @@
+From 2505748e9b71ceaf290da40f767dc4b90238576a Mon Sep 17 00:00:00 2001
+From: Florin Sarbu <florin@balena.io>
+Date: Fri, 13 Sep 2024 09:36:49 +0000
+Subject: [PATCH] bearer-qmi: Fix SIM7100E crash
+
+As per https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/issues/842#note_2521001
+
+Signed-off-by: Florin Sarbu <florin@balena.io>
+---
+ src/mm-bearer-qmi.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src/mm-bearer-qmi.c b/src/mm-bearer-qmi.c
+index 54f2e934..d8e52f5c 100644
+--- a/src/mm-bearer-qmi.c
++++ b/src/mm-bearer-qmi.c
+@@ -1116,8 +1116,7 @@ get_current_settings (GTask *task, QmiClientWds *client)
+                 QMI_WDS_REQUESTED_SETTINGS_GATEWAY_INFO |
+                 QMI_WDS_REQUESTED_SETTINGS_MTU |
+                 QMI_WDS_REQUESTED_SETTINGS_DOMAIN_NAME_LIST |
+-                QMI_WDS_REQUESTED_SETTINGS_IP_FAMILY |
+-                QMI_WDS_REQUESTED_SETTINGS_OPERATOR_RESERVED_PCO;
++                QMI_WDS_REQUESTED_SETTINGS_IP_FAMILY;
+ 
+     input = qmi_message_wds_get_current_settings_input_new ();
+     qmi_message_wds_get_current_settings_input_set_requested_settings (input, requested, NULL);
+-- 
+2.34.1
+

--- a/meta-balena-common/recipes-connectivity/modemmanager/modemmanager_%.bbappend
+++ b/meta-balena-common/recipes-connectivity/modemmanager/modemmanager_%.bbappend
@@ -11,6 +11,7 @@ SRC_URI:append = " \
     file://0001-increase-qmi-port-open-timeout.patch \
     file://0002-quectel-disable-qmi-unsolicited-profile-manager-even.patch \
     file://0003-broadband-modem-qmi-quectel-fix-task-completion-when.patch \
+    file://0004-bearer-qmi-Fix-SIM7100E-crash.patch \
 "
 
 PACKAGECONFIG:remove = "polkit"


### PR DESCRIPTION
With the update to MM 1.22.0 we have received reports that SIM7100E is not functioning correctly.
Followed up with ModemManager devs and it was discovered the issue is related to a PCO setting:
https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/issues/884

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
