### PR TITLE
initrdscripts: replace cut by awk for parsing lsblk in cryptsetup hook

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup-efi-tpm
+++ b/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup-efi-tpm
@@ -135,7 +135,7 @@ cryptsetup_run() {
     # and wait for them in a separate loop later
     LUKS_UNLOCKED=""
     for PART_NAME in ${ENCRYPTED_PARTITIONS}; do
-        LUKS_UUID=$(echo "${LUKS_PARTITIONS}" | grep " \(balena\|resin\)-${PART_NAME}$" | cut -d " " -f 2)
+        LUKS_UUID=$(echo "${LUKS_PARTITIONS}" | grep " \(balena\|resin\)-${PART_NAME}$" | awk '{print $2}')
 
         if [ -z "${LUKS_UUID}" ]; then
             fail "Partition '${PART_NAME}' not found"
@@ -172,8 +172,8 @@ cryptsetup_run() {
             fail "More than one '${PART_NAME}' partition found"
         fi
 
-        LUKS_KNAME=$(echo "${PART_LINE}" | cut -d " " -f 1)
-        LUKS_LABEL=$(echo "${PART_LINE}" | cut -d " " -f 4)
+        LUKS_KNAME=$(echo "${LUKS_LINE}" | awk '{print $1}')
+        LUKS_LABEL=$(echo "${LUKS_LINE}" | awk '{print $4}')
 
         # Even though the following lsblk could be restricted to just /dev/${LUKS_KNAME}
         # we intentionally do not want to do that. If there are multiple filesystems with
@@ -188,8 +188,8 @@ cryptsetup_run() {
             fail "More than one '${LUKS_LABEL}' filesystems found after decryption"
         fi
 
-        FS_KNAME=$(echo "${FS_LINE}" | cut -d " " -f 1)
-        FS_PKNAME=$(echo "${FS_LINE}" | cut -d " " -f 2)
+        FS_KNAME=$(echo "${FS_LINE}" | awk '{print $1}')
+        FS_PKNAME=$(echo "${FS_LINE}" | awk '{print $2}')
 
         # We have found an encrypted partition with partlabel=${LUKS_LABEL} and a filesystem
         # with label=${LUKS_LABEL}. Check that these are parent/child.


### PR DESCRIPTION
`cut` is sensitive to the amount of delimiter characters when parsing output, so e.g. an additional space between two elements causes every field shift by one index.

This patch replaces the use of `cut` by `awk`, which should be more robust.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
