### PR TITLE
Override the default commit body for digest updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,9 @@
   ],
   "automerge": false,
   "commitBody": "Update {{depName}} from {{currentVersion}} to {{newVersion}}\n\nChange-type: patch",
+  "digest": {
+    "commitBody": "Update {{depName}} to {{newDigest}}\n\nChange-type: patch"
+  },
   "pinDigest": {
     "commitBody": "Update {{depName}}\n\nChange-type: patch",
     "automerge": true


### PR DESCRIPTION
A commit body is provided for digest updates in the top-level config here: https://github.com/balena-os/renovate-config

So we must override the digest setting explicitly at the repo level in order to use Change-type vs Changelog-entry

See these PRs that are blocked with the wrong commit message:
- https://github.com/balena-os/meta-balena/pull/3278/commits/5ffd99f4a66453ba20e777c13d990edf9fbb6c61
- https://github.com/balena-os/meta-balena/pull/3397/commits/7c9a2054e78c5206c69c61fad1ea70bcba316e4b

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
