### PR TITLE
Extend renovate config from balena-io/renovate-config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,6 @@
 {
   "extends": [
-    "github>balena-os/renovate-config",
-    ":automergeStableNonMajor",
-    ":automergePatch",
-    ":automergeDigest",
-    ":automergeTypes"
+    "github>balena-io/renovate-config"
   ],
   "ignorePaths": [
     "**/node_modules/**",
@@ -17,11 +13,6 @@
     "**/__fixtures__/**"
   ],
   "automerge": false,
-  "commitBody": "Update {{depName}} from {{currentVersion}} to {{newVersion}}\n\nChange-type: patch",
-  "pinDigest": {
-    "commitBody": "Update {{depName}}\n\nChange-type: patch",
-    "automerge": true
-  },
   "regexManagers": [
     {
       "fileMatch": ["(^|/)balena-supervisor.inc$"],
@@ -41,10 +32,6 @@
     }
   ],
   "packageRules": [
-    {
-      "matchManagers": ["git-submodules"],
-      "commitBody": "Update {{depName}}\nChange-type: patch"
-    },
     {
       "matchManagers": ["regex"],
       "matchPackagePatterns": [".*balena-engine"],


### PR DESCRIPTION
meta-balena is more like a generic repo,
and less like a yocto-device-type repo,
so extending the common balena-io config means
we need fewer overrides at the repo level to
get the preferred behaviour

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
