### PR TITLE
initrdscripts: Wait for boot partition in the abroot script

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/abroot
+++ b/meta-balena-common/recipes-core/initrdscripts/files/abroot
@@ -45,9 +45,27 @@ abroot_enabled() {
 abroot_run() {
     BOOT_PART=$(find_boot_partition)
 
-    if [ "x${BOOT_PART}" = "x" ]; then
-        fail "Failed to identify boot partition"
-    fi
+    # Give the boot partition 5s to appear.
+    # This is necessary when the rootfs is on a device that takes
+    # a while to initialize, such as a USB disk.
+    # Similar waiting already happens in the rootfs script, because
+    # on most device types it is the first one that needs to access
+    # the root device. But in the case of balena bootloader, the abroot
+    # script is called before rootfs, so it needs to do the waiting.
+    C=0
+    delay=${bootparam_rootdelay:-1}
+    timeout=${bootparam_roottimeout:-5}
+    while [ -z "${BOOT_PART}" ]; do
+        C=$(( C + 1 ))
+
+        if [ $(( C * delay )) -gt "$timeout" ]; then
+            fail "Failed to identify boot partition"
+        fi
+
+        sleep "${delay}"
+
+        BOOT_PART=$(find_boot_partition)
+    done
 
     BOOT_DEV="/dev/$(lsblk -nlo pkname ${BOOT_PART})"
 


### PR DESCRIPTION
At this moment the abroot script assumes that the boot partition is already in place when it executes. This might not be true if the rootfs sits on a device that takes a while to initialize, such as a USB drive. The script fails hard if that is the case.

This patch replicates a waiting loop from the rootfs script, which addresses the same issue for systems that do not use the balena bootloader.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
