### PR TITLE
tests: hup: login with sdk before fetching image

### DIFF
--- a/tests/suites/hup/suite.js
+++ b/tests/suites/hup/suite.js
@@ -314,8 +314,6 @@ module.exports = {
 			),
 		});
 
-		console.log(this.suite.options)
-
 		// Network definitions
 		// If suites config.js has networkWired: true, override the device contract
 		if (this.suite.options.balenaOS.network.wired === true) {
@@ -361,7 +359,16 @@ module.exports = {
 			},
 		});
 
-		// Downloads the balenaOS image we hup from
+		// Authenticating balenaSDK
+		// Required for downloading private device type images from balenaCloud
+		// the token is locally stored so a subsequent login with fetchOs will work, despite being a different sdk instance
+		await this.context
+		.get()
+		.sdk.balena.auth.loginWithToken(this.suite.options.balena.apiKey);
+		this.log(`Logged in with ${await this.context.get().sdk.balena.auth.whoami()}'s account on ${this.suite.options.balena.apiUrl} using balenaSDK`);
+
+
+		// Downloads the balenaOS image we hup from		
 		// It can't accept invalid deviceType because we check contracts already in the start
 		// If there are no releases found for a deviceType then skip the HUP suite
 		if (((await this.sdk.balena.models.os.getAvailableOsVersions(this.suite.deviceType.slug)).length) === 0) {
@@ -378,12 +385,6 @@ module.exports = {
 		);
 
 		const keys = await this.utils.createSSHKey(this.sshKeyPath);
-
-		// Authenticating balenaSDK
-    await this.context
-    .get()
-    .sdk.balena.auth.loginWithToken(this.suite.options.balena.apiKey);
-    this.log(`Logged in with ${await this.context.get().sdk.balena.auth.whoami()}'s account on ${this.suite.options.balena.apiUrl} using balenaSDK`);
 
 		await this.sdk.balena.models.key.create(
 			this.sshKeyLabel,


### PR DESCRIPTION
This is to ensure we have an authenticated SDK before trying to get the last known production image - it needs to be authenticated in case the DT is private, otherwise it won't be able to fetch anything 

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
