### PR TITLE
kernel-resin.bbclass: Enable in-tree rtl8192cu driver

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -300,7 +300,7 @@ BALENA_CONFIGS[systemd] ?= " \
 # one
 #
 BALENA_CONFIGS[rtl8192cu] ?= "\
-    CONFIG_RTL8192CU=n \
+    CONFIG_RTL8192CU=m \
     CONFIG_HOSTAP=m \
     CONFIG_WIRELESS=y \
     CONFIG_USB=y \


### PR DESCRIPTION
We can switch back to the in-tree driver since it's become stable now.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
