### PR TITLE
hostapp-update-hooks: remove alternative bootloader environment files

### DIFF
--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/99-balena-bootloader
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/99-balena-bootloader
@@ -25,6 +25,10 @@ info "Switching root partition to ${NEW_ROOT}"
 
 BOOTENV_FILE="${BALENA_NONENC_BOOT_MOUNTPOINT}/bootenv"
 
+# When migrating to balena bootloader make sure no alternative is present
+rm -f "${BALENA_NONENC_BOOT_MOUNTPOINT}/resinOS_uEnv.txt"
+rm -f "${BALENA_NONENC_BOOT_MOUNTPOINT}/grubenv"
+
 grub-editenv "${BOOTENV_FILE}" set "resin_root_part=${NEW_ROOT}"
 grub-editenv "${BOOTENV_FILE}" set "upgrade_available=${DURING_UPDATE}"
 


### PR DESCRIPTION
The rollback-parse-bootloader script will give priority to resinOS_uEnv.txt so make sure there are no U-Boot leftovers when migrating to a balena-bootloader enabled system which needs to read the bootenv environment file on rollbacks.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
