### PR TITLE
tests/os: Add Jetson Orin device-specific fan and power mode smoke tests

### DIFF
--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -445,6 +445,7 @@ module.exports = {
 		'./tests/secureboot',
 		'./tests/device-specific-tests/beaglebone-black',
 		'./tests/device-specific-tests/243390-rpi3',
+		'./tests/power-and-cooling',
 		'./tests/overlap_test/',
 		'./tests/fingerprint',
 		'./tests/fsck',

--- a/tests/suites/os/tests/power-and-cooling/assets/helpers.sh
+++ b/tests/suites/os/tests/power-and-cooling/assets/helpers.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+TARGET_POWER_MODE="0"
+CONFIG_JSON="/mnt/boot/config.json"
+
+target_fan_profile="quiet"
+
+get_power_mode_index() {
+    applied_power_mode=$(/usr/sbin/nvpmodel -q)
+    if [[ "$applied_power_mode" == null ]] || [[ -z "$applied_power_mode" ]]; then
+        echo "failed"
+    else
+        power_mode_index=$(echo "${applied_power_mode}" | sed -n 2p)
+        echo "$power_mode_index"
+    fi
+
+}
+
+get_fan_profile() {
+    running_profile=$(/usr/sbin/nvfancontrol -q | grep FAN_PROFILE | cut -d ":" -f3)
+    if [[ "$running_profile" == null ]] || [[ -z "$running_profile" ]]; then
+        echo "failed"
+    else
+        echo "$running_profile"
+    fi
+}
+
+set_power_mode() {
+    tmp=$(mktemp)
+    jq --arg TARGET_POWER_MODE $TARGET_POWER_MODE '.os.power.mode |= $TARGET_POWER_MODE' $CONFIG_JSON > ${tmp}
+    mv ${tmp} ${CONFIG_JSON}
+
+    added_mode=$(jq -c -M -e '.os.power.mode' $CONFIG_JSON)
+    if [[ "$added_mode" == "\"0\"" ]]; then
+        echo "set"
+    fi
+}
+
+set_fan_profile() {
+    tmp=$(mktemp)
+    jq --arg target_fan_profile $target_fan_profile '.os.fan.profile |= $target_fan_profile' $CONFIG_JSON > ${tmp}
+    mv ${tmp} ${CONFIG_JSON}
+}
+
+test_fan_profile() {
+    current_fan_profile=$(get_fan_profile)
+    if [[ "$current_fan_profile" == "$target_fan_profile" ]]; then
+        target_fan_profile="cool"
+    fi
+
+    set_fan_profile
+    sleep 5
+    applied_fan_profile=$(get_fan_profile)
+    if [[ "$applied_fan_profile" == "$target_fan_profile" ]]; then
+        echo "passed"
+    else
+        echo "failed"
+    fi
+}
+
+test_power_mode() {
+    current_power_mode=$(get_power_mode_index)
+    if [[ "$current_power_mode" == "$TARGET_POWER_MODE" ]]; then
+        echo "passed"
+    else
+        echo "failed"
+    fi
+}

--- a/tests/suites/os/tests/power-and-cooling/index.js
+++ b/tests/suites/os/tests/power-and-cooling/index.js
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require('fs');
+
+module.exports = {
+	deviceType: {
+		type: 'object',
+		required: ['slug'],
+		properties: {
+			slug: {
+				type: 'string',
+				enum: [
+					'jetson-agx-orin-devkit-64gb',
+					'jetson-agx-orin-devkit',
+					'jetson-orin-nano-devkit-nvme',
+					'jetson-orin-nano-seeed-j3010',
+					'jetson-orin-nx-seeed-j4012',
+					'jetson-orin-nx-xavier-nx-devkit'
+					],
+			},
+		},
+	},
+	title: 'Jetson Orin power mode and fan profile tests',
+	run: async function(test) {
+		const testHelpers = fs
+			.readFileSync(`${__dirname}/assets/helpers.sh`)
+			.toString();
+
+		let output = await this.context
+			.get()
+			.worker.executeCommandInHostOS(
+				`${testHelpers} test_fan_profile`,
+				this.link,
+			);
+
+		test.is(
+			output.includes('passed'),
+			true,
+			'Fan profile test passed',
+		);
+
+		output = await this.context
+			.get()
+			.worker.executeCommandInHostOS(
+				`${testHelpers} set_power_mode`,
+				this.link,
+			);
+
+		test.is(
+			output.includes('set'),
+			true,
+			'Power mode was set',
+		);
+
+		await this.worker.rebootDut(this.link);
+
+		await this.utils.waitUntil(
+			async () => {
+				output = await this.context.get().worker.executeCommandInHostOS(`${testHelpers} test_power_mode`, this.link);
+				return output.includes('passed');
+			},
+			true,
+			10,
+			5 * 1000
+		);
+
+		test.is(output.includes('passed'), true, 'Power mode test passed');
+	},
+};


### PR DESCRIPTION
These tests are the same for all public Orin device types and validate that the power mode and the fan profile can be changed by writing directly to the config.json file in the boot partition of an un-managed OS.


Change-type: patch

Locally triggered test on AGX Orin 64GB:
```
leviathan-client-1  | [2024-10-24T09:22:40.785Z][5882da3-os]     # Subtest: Jetson Orin power mode and fan profile tests
leviathan-client-1  |         ok 1 - Fan profile test passed
leviathan-client-1  | [2024-10-24T09:22:44.149Z][5882da3-os]         ok 2 - Power mode was set
leviathan-client-1  | [2024-10-24T09:22:44.149Z][5882da3-os] Rebooting the DUT
leviathan-client-1  | [2024-10-24T09:24:08.520Z][5882da3-os] DUT has rebooted & is back online
leviathan-client-1  | [2024-10-24T09:24:11.967Z][5882da3-os]         ok 3 - Power mode test passed
leviathan-client-1  | [2024-10-24T09:24:11.968Z][5882da3-os]         1..3
leviathan-client-1  | [2024-10-24T09:24:11.970Z][5882da3-os]     ok 6 - Jetson Orin power mode and fan profile tests # time=99382.143ms

```

Connects to:
- https://github.com/balena-os/balena-jetson-orin/pull/513
- https://github.com/balena-os/meta-balena/pull/3537
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested - locally, by triggering the leviathan suite on the AGX Orin 64GB
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
