### PR TITLE
modemmanager: Update patches

### DIFF
--- a/meta-balena-common/recipes-connectivity/modemmanager/balena-files/0001-increase-qmi-port-open-timeout.patch
+++ b/meta-balena-common/recipes-connectivity/modemmanager/balena-files/0001-increase-qmi-port-open-timeout.patch
@@ -1,4 +1,4 @@
-From 0376210a81c19b48499fc613fe3dbe49855e5264 Mon Sep 17 00:00:00 2001
+From 4a3ae22417d9ee92ed1ad326d304d7e5a82f8136 Mon Sep 17 00:00:00 2001
 From: Alexandru Costache <alexandru@balena.io>
 Date: Wed, 12 Jul 2023 11:08:54 +0200
 Subject: [PATCH] increase qmi port open timeout
@@ -10,16 +10,15 @@ with this modem connected over pcie is 95s.
 
 Upstream-status: Inappropriate [configuration]
 Signed-off-by: Alexandru Costache <alexandru@balena.io>
-
 ---
  src/mm-port-qmi.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/mm-port-qmi.c b/src/mm-port-qmi.c
-index fa09f32df..31e762527 100644
+index 4d79a43b..439dfd53 100644
 --- a/src/mm-port-qmi.c
 +++ b/src/mm-port-qmi.c
-@@ -2438,7 +2438,7 @@ port_open_step (GTask *task)
+@@ -2509,7 +2509,7 @@ port_open_step (GTask *task)
              mm_obj_dbg (self, "Opening device with flags: %s...", open_flags_str);
              qmi_device_open (ctx->device,
                               open_flags,
@@ -28,6 +27,3 @@ index fa09f32df..31e762527 100644
                               g_task_get_cancellable (task),
                               (GAsyncReadyCallback) qmi_device_open_first_ready,
                               task);
--- 
-2.37.2
-

--- a/meta-balena-common/recipes-connectivity/modemmanager/balena-files/0002-quectel-disable-qmi-unsolicited-profile-manager-even.patch
+++ b/meta-balena-common/recipes-connectivity/modemmanager/balena-files/0002-quectel-disable-qmi-unsolicited-profile-manager-even.patch
@@ -1,4 +1,4 @@
-From e3024ec620f2d4087c1d03579c8575b6cb988503 Mon Sep 17 00:00:00 2001
+From 7414f61a3e674f51f003efaf279839de7387802a Mon Sep 17 00:00:00 2001
 From: Lukas Voegl <lvoegl@tdt.de>
 Date: Fri, 19 Apr 2024 11:33:06 +0200
 Subject: [PATCH] quectel: disable qmi unsolicited profile manager events
@@ -12,10 +12,10 @@ Signed-off-by: Lukas Voegl <lvoegl@tdt.de>
  4 files changed, 193 insertions(+), 7 deletions(-)
 
 diff --git a/src/plugins/quectel/mm-broadband-modem-qmi-quectel.c b/src/plugins/quectel/mm-broadband-modem-qmi-quectel.c
-index 4b4e0c96..c6f706a5 100644
+index a1342e64..8d872dc5 100644
 --- a/src/plugins/quectel/mm-broadband-modem-qmi-quectel.c
 +++ b/src/plugins/quectel/mm-broadband-modem-qmi-quectel.c
-@@ -20,26 +20,108 @@
+@@ -19,26 +19,108 @@
  #include "mm-iface-modem-firmware.h"
  #include "mm-iface-modem-location.h"
  #include "mm-iface-modem-time.h"
@@ -131,8 +131,8 @@ index 4b4e0c96..c6f706a5 100644
  MMBroadbandModemQmiQuectel *
  mm_broadband_modem_qmi_quectel_new (const gchar  *device,
                                      const gchar  *physdev,
-@@ -124,6 +206,15 @@ peek_parent_modem_location_interface (MMSharedQuectel *self)
-     return iface_modem_location_parent;
+@@ -123,6 +205,15 @@ iface_modem_time_init (MMIfaceModemTime *iface)
+     iface->check_support_finish = mm_shared_quectel_time_check_support_finish;
  }
  
 +static void
@@ -148,12 +148,12 @@ index 4b4e0c96..c6f706a5 100644
  shared_quectel_init (MMSharedQuectel *iface)
  {
 diff --git a/src/plugins/quectel/mm-modem-helpers-quectel.c b/src/plugins/quectel/mm-modem-helpers-quectel.c
-index 4335e506..7b0fe96d 100644
+index 262d9794..ed2cc713 100644
 --- a/src/plugins/quectel/mm-modem-helpers-quectel.c
 +++ b/src/plugins/quectel/mm-modem-helpers-quectel.c
-@@ -138,3 +138,63 @@ mm_quectel_check_standard_firmware_version_valid (const gchar *std_str)
-     }
-     return valid;
+@@ -89,3 +89,63 @@ mm_quectel_parse_ctzu_test_response (const gchar  *response,
+ 
+     return TRUE;
  }
 +
 +gboolean
@@ -216,12 +216,12 @@ index 4335e506..7b0fe96d 100644
 +    return TRUE;
 +}
 diff --git a/src/plugins/quectel/mm-modem-helpers-quectel.h b/src/plugins/quectel/mm-modem-helpers-quectel.h
-index ea9ff5c1..e4bc63b9 100644
+index d4ec0eae..84701417 100644
 --- a/src/plugins/quectel/mm-modem-helpers-quectel.h
 +++ b/src/plugins/quectel/mm-modem-helpers-quectel.h
-@@ -31,4 +31,13 @@ gboolean mm_quectel_parse_ctzu_test_response (const gchar  *response,
- 
- gboolean mm_quectel_check_standard_firmware_version_valid (const gchar *std_str);
+@@ -29,4 +29,13 @@ gboolean mm_quectel_parse_ctzu_test_response (const gchar  *response,
+                                               gboolean     *supports_enable_update_rtc,
+                                               GError      **error);
  
 +gboolean mm_quectel_get_version_from_revision (const gchar  *revision,
 +                                               guint        *release,
@@ -234,11 +234,11 @@ index ea9ff5c1..e4bc63b9 100644
 +
  #endif  /* MM_MODEM_HELPERS_QUECTEL_H */
 diff --git a/src/plugins/quectel/tests/test-modem-helpers-quectel.c b/src/plugins/quectel/tests/test-modem-helpers-quectel.c
-index dee01865..6c695f00 100644
+index 0e2c7420..1ef73a46 100644
 --- a/src/plugins/quectel/tests/test-modem-helpers-quectel.c
 +++ b/src/plugins/quectel/tests/test-modem-helpers-quectel.c
-@@ -93,6 +93,30 @@ test_firmversion (void)
-     g_assert_cmpuint (valid, ==, FALSE);
+@@ -79,6 +79,30 @@ test_ctzu (void)
+                           test_ctzu_response[i].expect_supports_enable_update_rtc);
  }
  
 +static void
@@ -268,14 +268,11 @@ index dee01865..6c695f00 100644
  /*****************************************************************************/
  
  int main (int argc, char **argv)
-@@ -105,5 +129,7 @@ int main (int argc, char **argv)
+@@ -89,5 +113,7 @@ int main (int argc, char **argv)
  
-     g_test_add_func ("/MM/quectel/firmversion", test_firmversion);
+     g_test_add_func ("/MM/quectel/ctzu", test_ctzu);
  
 +    g_test_add_func ("/MM/quectel/parse_revision", test_parse_revision);
 +
      return g_test_run ();
  }
--- 
-2.34.1
-

--- a/meta-balena-common/recipes-connectivity/modemmanager/balena-files/0003-broadband-modem-qmi-quectel-fix-task-completion-when.patch
+++ b/meta-balena-common/recipes-connectivity/modemmanager/balena-files/0003-broadband-modem-qmi-quectel-fix-task-completion-when.patch
@@ -1,4 +1,4 @@
-From 1e26e16168d4815a48ab77610e1c282dfc345567 Mon Sep 17 00:00:00 2001
+From 32ffe06de8ccfe49dd76b0934a4ecf9c07c7f810 Mon Sep 17 00:00:00 2001
 From: Aleksander Morgado <aleksandermj@chromium.org>
 Date: Mon, 6 May 2024 13:23:30 +0000
 Subject: [PATCH] broadband-modem-qmi-quectel: fix task completion when not
@@ -10,10 +10,10 @@ Fixes e3024ec620f2d4087c1d03579c8575b6cb988503
  1 file changed, 1 insertion(+)
 
 diff --git a/src/plugins/quectel/mm-broadband-modem-qmi-quectel.c b/src/plugins/quectel/mm-broadband-modem-qmi-quectel.c
-index c6f706a5..df990f3f 100644
+index 8d872dc5..01ddb290 100644
 --- a/src/plugins/quectel/mm-broadband-modem-qmi-quectel.c
 +++ b/src/plugins/quectel/mm-broadband-modem-qmi-quectel.c
-@@ -114,6 +114,7 @@ profile_manager_enable_unsolicited_events (MMIfaceModem3gppProfileManager *self,
+@@ -113,6 +113,7 @@ profile_manager_enable_unsolicited_events (MMIfaceModem3gppProfileManager *self,
          mm_obj_warn (self, "continuing without enabling profile manager events");
          g_task_return_boolean (task, TRUE);
          g_object_unref (task);
@@ -21,6 +21,3 @@ index c6f706a5..df990f3f 100644
      }
  
      iface_modem_3gpp_profile_manager_parent->enable_unsolicited_events (
--- 
-2.34.1
-

--- a/meta-balena-common/recipes-connectivity/modemmanager/balena-files/0004-bearer-qmi-Fix-SIM7100E-crash.patch
+++ b/meta-balena-common/recipes-connectivity/modemmanager/balena-files/0004-bearer-qmi-Fix-SIM7100E-crash.patch
@@ -1,4 +1,4 @@
-From 2505748e9b71ceaf290da40f767dc4b90238576a Mon Sep 17 00:00:00 2001
+From 8a40020f5c4b9a1e5c7c03e315b1082208a06c14 Mon Sep 17 00:00:00 2001
 From: Florin Sarbu <florin@balena.io>
 Date: Fri, 13 Sep 2024 09:36:49 +0000
 Subject: [PATCH] bearer-qmi: Fix SIM7100E crash
@@ -24,6 +24,3 @@ index 54f2e934..d8e52f5c 100644
  
      input = qmi_message_wds_get_current_settings_input_new ();
      qmi_message_wds_get_current_settings_input_set_requested_settings (input, requested, NULL);
--- 
-2.34.1
-


### PR DESCRIPTION
We do this in preparation for the Scarthgap update because with newer Yocto versions the patches with outdated context will trigger fatal build errors.

Changelog-entry: Update outdated context for modemmanager patches


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
