### PR TITLE
Jakogut/fix by state links

### DIFF
--- a/meta-balena-common/recipes-core/systemd/systemd/resin_update_state_probe
+++ b/meta-balena-common/recipes-core/systemd/systemd/resin_update_state_probe
@@ -88,7 +88,10 @@ if [ "${rpdev}" = "${parent}" ] || valid_device "${part}"; then
 	# UUID is passed by the bootloader in the kernel command line
 	case $label in
 		resin-root*)
-			rdev=$(lsblk -nlo kname,uuid | grep "${ruuid}" | cut -d " " -f1)
+			rdev=$(lsblk -nlo kname,uuid \
+				| grep "${parent}" \
+				| grep "${ruuid}" \
+				| cut -d " " -f1)
 			if [ "/dev/${rdev}" = "${part}" ]; then
 				echo "BALENA_UPDATE_STATE=active"
 			else

--- a/tests/suites/os/tests/udev/index.js
+++ b/tests/suites/os/tests/udev/index.js
@@ -66,6 +66,18 @@ module.exports = {
 					'All required by-state links have been created'
 				);
 			}
-		}
+		},
+		{
+			title: 'rootfs by-state links are unique',
+			run: async function(test) {
+				return test.resolves(
+					this.worker.executeCommandInHostOS(
+						`test /dev/disk/by-state/active != /dev/disk/by-state/inactive`,
+						this.link
+					),
+					'Links are unique'
+				);
+			},
+		},
 	],
 };


### PR DESCRIPTION
Fixes: https://balena.fibery.io/Inputs/Pattern/Generic-x86_64-GPT-with-sw-RAID1-fails-HUP-4508

https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/Several-self-hosted-GitHub-runners-unresponsive-after-failed-HUP-23

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
