### PR TITLE
README: Add fan profile and power mode info to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,41 @@ The following example contains two custom udev rules that will create `/etc/udev
 }
 ```
 
+#### fan
+
+An object that defines thermal related configuration. Available for Jetson Orin devices running Jetpack 6 or newer, balenaOS v6.1.24 or newer and Supervisor v16.10.0 or newer.
+
+##### fan.profile
+
+(string) A string which will be used to select the desired cooling profile. Supported values are "quiet" and "cool". At runtime, this
+configuration option should be set through the API or from your balenaCloud dashboard.
+
+```json
+"os": {
+ "fan": {
+  "profile":"cool"
+ }
+}
+```
+
+#### power
+
+An object that defines power consumption related configuration. Available for Jetson Orin devices running Jetpack 6 or newer, balenaOS v6.1.24 or newer and Supervisor v16.10.0 or newer.
+
+##### power.mode
+
+(string) A string which will be used to select the desired power mode. Supported values for Jetpack 6 and newer are "low", "mid" and "high", where "low"
+is the lowest power consumption mode while "high" corresponds to MAXN or the highest available power mode for your device type. At runtime, this
+configuration option should be set through the API or from your balenaCloud dashboard, and it will cause a device reboot.
+
+```json
+"os": {
+ "power": {
+  "mode":"high"
+ }
+}
+```
+
 ### installer
 
 An object that configures the behaviour of the balenaOS installer image.


### PR DESCRIPTION
This commit adds detailed information for the
new power and cooling configuration options
available for Jetson Orin devices.


Change-type: patch

Connects-to: https://github.com/balena-io/docs/pull/3099

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
