### PR TITLE
Don't log power mode and fan profile on unsupported devices, unless set in config.json

### DIFF
--- a/meta-balena-common/recipes-support/os-fan-profile/os-fan-profile/os-fan-profile
+++ b/meta-balena-common/recipes-support/os-fan-profile/os-fan-profile/os-fan-profile
@@ -3,5 +3,11 @@
 set -e
 
 . /usr/libexec/os-helpers-logging
+source /usr/sbin/balena-config-vars --no-cache
 
-info "Fan profile configuration is not supported for this device type."
+if [[ -z "$OS_FAN_PROFILE" ]]; then
+    # No fan profile configured
+    :
+else
+    info "Fan profile configuration is not supported for this device type."
+fi

--- a/meta-balena-common/recipes-support/os-power-mode/os-power-mode/os-power-mode
+++ b/meta-balena-common/recipes-support/os-power-mode/os-power-mode/os-power-mode
@@ -3,5 +3,11 @@
 set -e
 
 . /usr/libexec/os-helpers-logging
+source /usr/sbin/balena-config-vars --no-cache
 
-info "Power mode configuration is not supported for this device type."
+if [[ -z "$OS_POWER_MODE" ]]; then
+    # No power mode configured
+    :
+else
+    info "Power mode configuration is not supported for this device type."
+fi


### PR DESCRIPTION
Supervisor PR https://github.com/balena-os/balena-supervisor/pull/2382 adds log streaming support for os-fan-profile and os-power mode.

To avoid any potential confusion for users with devices which don't support configurable power modes or fan profiles, let's not print any logs from these services unless corresponding settings have been added to config.json

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
