### PR TITLE
balena-config-vars: protect configuration cache with lock

### DIFF
--- a/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/balena-config-vars
+++ b/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/balena-config-vars
@@ -130,6 +130,13 @@ if [ "${USE_CACHE}" -eq "1" ] && [ -n "${BALENA_CONFIG_VARS_CACHE}" ] && [ -f "$
 else
     [ -n "${BALENA_CONFIG_VARS_CACHE}" ] && [ -f "${BALENA_CONFIG_VARS_CACHE}" ] && rm -f "${BALENA_CONFIG_VARS_CACHE}"
 
+    # Grab lock
+    exec 120> "$(dirname ${BALENA_CONFIG_VARS_CACHE})/lock"
+    if ! flock -w 20 120; then
+        echo "[ERROR] $0: Failed to acquire lock." >&2
+        exit 1
+    fi
+
     # If config.json provides redefinitions for our vars let us rewrite their
     # runtime value
     if ! read_config; then


### PR DESCRIPTION
This prevents multiple processes trying to write the configuration cache simultaneouly which might lead to file busy errors on move.

Change-type: patch
Relates-to: https://balena.zendesk.com/agent/tickets/4187


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
