### PR TITLE
migrate/resin-init-flasher: Add changes for improving Jetson Orin provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,17 @@ is passed in the kernel command line.
 }
 ```
 
+#### target_devices
+
+(string) Overrides the default list of provisioning target mediums. May contain one or more
+devices, separated by spaces. The first one found will be used.
+
+```json
+"installer": {
+  "target_devices":"nvme0n1 sda"
+}
+```
+
 ## Yocto version support
 
 The following Yocto versions are supported:

--- a/meta-balena-common/recipes-core/initrdscripts/files/migrate
+++ b/meta-balena-common/recipes-core/initrdscripts/files/migrate
@@ -66,6 +66,11 @@ migrate_enabled() {
                 if [ "$bootparam_migrate" = "true" ] || jq -re '.installer.migrate.force' "${FLASH_BOOT_MOUNT}/config.json" > /dev/null; then
                     _migrate=1
                     info "Migration requested in configuration"
+                    if target_devices=$(jq -re '.installer.target_devices' "${FLASH_BOOT_MOUNT}/config.json"); then
+                        info "Configured target_devices: $target_devices"
+                        INTERNAL_DEVICE_KERNEL="${target_devices}"
+                        internal_dev=$(get_internal_device "${INTERNAL_DEVICE_KERNEL}")
+                    fi
                 fi
             else
                 fail "Flash boot partition not found in ${internal_dev}"

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -204,6 +204,11 @@ if [ -z "${INTERNAL_DEVICE_KERNEL}" ]; then
     fail "Undefined target programming device - make sure INTERNAL_DEVICE_KERNEL is defined"
 fi
 
+if target_devices=$(jq -re '.installer.target_devices' "$CONFIG_PATH"); then
+    info "Using updated target devices list from configuration file: $target_devices"
+    INTERNAL_DEVICE_KERNEL="${target_devices}"
+fi
+
 # Flash Resin image on internal device
 info "Flash internal device... will take around 5 minutes... "
 internal_dev=$(get_internal_device "${INTERNAL_DEVICE_KERNEL}")


### PR DESCRIPTION
This PR adds the possibility of overriding the list of target provisioning devices through config.json

This change is related to improving provisioning of Jetson Orin devices, but applies to other flasher devices as well

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
