### PR TITLE
initrdscripts: migrate: panic on installation failure

### DIFF
--- a/meta-balena-common/recipes-bsp/u-boot/patches/env_resin.h
+++ b/meta-balena-common/recipes-bsp/u-boot/patches/env_resin.h
@@ -162,7 +162,7 @@
               "setexpr resin_roota ${resin_boot_part} + 1; " \
               "setexpr resin_rootb ${resin_boot_part} + 2; " \
               "run os_inc_bc_save;" \
-              "if test -n ${os_bc_lim}; then " \
+              "if test -n ${os_bc_lim} && test -n ${bootcount}; then " \
                       "if test ${bootcount} -gt ${os_bc_lim}; then " \
                                "echo WARNING! BOOTLIMIT EXCEEDED. SWITCHING TO PREVIOUS ROOT;" \
                                "echo WARNING! was: resin_root_part=${resin_root_part};" \

--- a/meta-balena-common/recipes-core/initrdscripts/files/migrate
+++ b/meta-balena-common/recipes-core/initrdscripts/files/migrate
@@ -145,6 +145,11 @@ migrate_run() {
 
         # Run flasher - should not return
         /usr/bin/resin-init-flasher
+        # Something went wrong - kill the process to prevent exploits
+        exit 1
+        # Just being paranoid
+        echo "c" > /proc/sysrq-trigger
+        sleep infinity
     else
         # If recovery mode, wait for adbd to exit
         if [ -n "${ADBD_PID}" ]; then


### PR DESCRIPTION
Right now if the flashing script errors out the initramfs just keeps running modules. This is a security risk specially for secure boot systems as at that point we have an authorized trusted OS running in an unvetted path.

This commit exits init if the flasher returns, and also attemps to crash the kernel followed by an infinite sleep for paranoic reasons.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
