### PR TITLE
tests: hup: rollback-altboot: replace while loop over SSH to speed up…

### DIFF
--- a/tests/suites/hup/tests/rollbacks.js
+++ b/tests/suites/hup/tests/rollbacks.js
@@ -258,14 +258,26 @@ module.exports = {
 
 				await this.worker.rebootDut(this.link);
 
-				// system.waitForServiceState times out here for some reason, so just use shell
-				await this.worker.executeCommandInHostOS(
-					['while [ "$(systemctl is-active rollback-altboot)" != "inactive" ]',
-						'|| [ "$(systemctl is-active rollback-health)" != "inactive" ]; do sleep 1; done'
-					],
-					this.link,
-				);
+				await this.utils.waitUntil(async () => {
+					console.log(`Waiting for rollback-altboot service to be inactive...`)	
+					let state = await this.worker.executeCommandInHostOS(
+						`systemctl is-active rollback-altboot || true`,
+						this.link
+					)
+					console.log(state)
+					return (state === "inactive");
+				})
 
+				await this.utils.waitUntil(async () => {
+					console.log(`Waiting for rollback-health service to be inactive...`)	
+					let state = await this.worker.executeCommandInHostOS(
+						`systemctl is-active rollback-health || true`,
+						this.link
+					)
+					console.log(state)
+					return (state === "inactive");
+				})
+				
 				await test.resolves(
 					this.utils.waitUntil(async () => {
 						return this.worker.executeCommandInHostOS(


### PR DESCRIPTION
… tests

The altboot test often hangs for a long time during the altboot test, after the DUT has booted into the old OS after the altboot failure - the check to see if the rollback systemd services have stopped hangs. This is an attempt to fix that, as I think there's some strange interaction going on with the while loop over ssh

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
