### PR TITLE
resin-init: flasher: add interface to purge encryption keys

### DIFF
--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -58,6 +58,8 @@
 #  * balena-init-flasher-diskenc: Function hooks related to the disk encryption setup.
 #     * diskenc_setup
 #       * Generate and encrypt disk encryption keys
+#     * diskenc_purge
+#       * Wipe disk encryption keys
 #
 
 set -e
@@ -221,6 +223,11 @@ if type secureboot_setup >/dev/null 2>&1 && secureboot_setup; then
         # shellcheck disable=SC1091
         # Re-source after secureboot setup
         . /usr/sbin/balena-config-defaults
+fi
+
+# Make sure old encrypted partitions are no longer usable
+if type diskenc_purge >/dev/null 2>&1 && ! diskenc_purge; then
+    fail "Failed to purge disk encryption keys"
 fi
 
 if [ "$CRYPT" = "1" ]; then


### PR DESCRIPTION
When re-flashing, make sure old encryption secrets are not available on the new system so they are not exploitable.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
