### PR TITLE
classes/kernel-balena: Add aufs patches for 6.1 kernels

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -830,6 +830,7 @@ def aufs_kernel_select(kernelversion):
         ('5.15.5','c2ce6a805f301e939724e9a48e523c7298b797e6'),
         ('5.15.36','8c2481e91182fc6959cb3ad56858c66d7a0c97fd'),
         ('5.15.41','5e018961ad499fc74e750ae857c33fbfc7641cfd'),
+        ('6.1','bfd38ec481836d86de5686dadca02e072b4f0584'),
     ])
 
 
@@ -938,8 +939,8 @@ python do_kernel_resin_aufs_fetch_and_unpack() {
         srcuri = "git://git.code.sf.net/p/aufs/aufs3-standalone.git;protocol=https;branch=aufs%s;name=aufs;destsuffix=aufs_standalone" % aufsbranch
     elif kernelversion.split('.')[0] is '4':
         srcuri = "git://github.com/sfjro/aufs4-standalone.git;protocol=https;branch=aufs%s;name=aufs;destsuffix=aufs_standalone" % aufsbranch
-    elif kernelversion.split('.')[0] is '5':
-        srcuri = "git://github.com/sfjro/aufs5-standalone.git;protocol=https;branch=aufs%s;name=aufs;destsuffix=aufs_standalone" % aufsbranch
+    elif kernelversion.split('.')[0] is '5' or kernelversion.split('.')[0] is '6':
+        srcuri = "git://github.com/sfjro/aufs-standalone.git;protocol=https;branch=aufs%s;name=aufs;destsuffix=aufs_standalone" % aufsbranch
 
     d.setVar('SRCREV_aufs', aufscommit)
     aufsgit = Git()


### PR DESCRIPTION
Also, aufs5 and aufs6 patches are in the same git repo now.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
