### PR TITLE
os-helpers-fs: add function to erase disks

### DIFF
--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
@@ -467,3 +467,22 @@ split_bootpartition() {
 
     # Do not umount - flasher script will still copy configuration files
 }
+
+erase_disk() {
+    tdisk="${1}"
+    info "Erasing disk ${tdisk}"
+    _sector_size=$(lsblk -nlbo NAME,PHY-SEC,TYPE "/dev/${tdisk}" | grep disk |  awk '{print $2}')
+    _size=$(lsblk -nlbo NAME,SIZE,TYPE "/dev/${tdisk}" | grep disk |  awk '{print $2}')
+    _size_in_sectors=$( expr ${_size} / ${_sector_size} )
+    # Overwrite default LUKS2 header size of 16 MiB
+    _erased_sectors=$( expr 16 \* 1024 \* 1024 / ${_sector_size} )
+    # Erase the first sectors in each partition
+    for _ss in $(parted "/dev/${tdisk}" unit s print | awk '/^[ 0-9]/ {sub("s", ""); print $2}'); do
+            dd if=/dev/urandom of="/dev/${tdisk}" bs="${_sector_size}" count="${_erased_sectors}" seek="${_ss}" conv=sync
+    done
+    # Erase partition table
+    # GPT reserves 34 sector at the start of disk and end of disk as backup
+    GPT_RESERVED_LBA=34
+    dd if=/dev/urandom of="/dev/${tdisk}" bs="${_sector_size}" count="${GPT_RESERVED_LBA}" conv=sync
+    dd if=/dev/urandom of="/dev/${tdisk}" bs="${_sector_size}" seek="$(expr "${_size_in_sectors}" - "${GPT_RESERVED_LBA}" )" count="${GPT_RESERVED_LBA}" conv=sync
+}


### PR DESCRIPTION
The function overwrites the first 16 MiB of each partition (the default LUKS2 header size), as well as the primary and backup GPT partition tables.

It's typically called from the cryptsetup flasher initramfs script when running on a locked device to close attack vectors that use the flasher images on locked devices, for example in https://github.com/balena-os/meta-balena-hab/pull/6/commits/e638c64c1ca24a28d827f3af33adab9a6d899d91

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
