### PR TITLE
hostapp-update-hooks: fix path for grub_extraenv in blacklist

### DIFF
--- a/meta-balena-common/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bb
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bb
@@ -31,13 +31,15 @@ HOSTAPP_HOOKS:append = "${@bb.utils.contains('MACHINE_FEATURES', 'efi', '${SECUR
 HOSTAPP_HOOKS_DIRS = "75-supervisor-db 76-supervisor-db"
 HOSTAPP_HOOKS_DIRS:append = "${@bb.utils.contains('MACHINE_FEATURES', 'efi', '${SECUREBOOT_HOOK_DIRS}', '', d)}"
 
+GRUB_INSTALL_DIR = "${@bb.utils.contains('MACHINE_FEATURES','efi','/EFI/BOOT','/grub',d)}"
+
 BALENA_BOOT_FINGERPRINT = "${BALENA_FINGERPRINT_FILENAME}.${BALENA_FINGERPRINT_EXT}"
 BALENA_BOOTFILES_BLACKLIST="\
 	/config.json \
 	/config.txt \
 	/splash/balena-logo.png \
 	/extra_uEnv.txt \
-	/grub_extraenv \
+	/${GRUB_INSTALL_DIR}/grub_extraenv \
 	/configfs.json \
 	/hw_intfc.conf \
 	/bootenv \


### PR DESCRIPTION
The `grub_extraenv` file is actually either installed under `/grub` for MBR systems or `/EFI/BOOT` for EFI ones.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
