### PR TITLE
resin-init-flasher: with secure boot, authenticate the inner image

### DIFF
--- a/meta-balena-common/classes/sign-digest.bbclass
+++ b/meta-balena-common/classes/sign-digest.bbclass
@@ -1,0 +1,40 @@
+do_sign_digest () {
+    if [ "x${SIGN_API}" = "x" ]; then
+        bbnote "Signing API not defined"
+        return 0
+    fi
+    if [ "x${SIGN_API_KEY}" = "x" ]; then
+        bbfatal "Signing API key must be defined"
+    fi
+
+    for SIGNING_ARTIFACT in ${SIGNING_ARTIFACTS}
+    do
+        if [ -z "${SIGNING_ARTIFACT}" ] || [ ! -f "${SIGNING_ARTIFACT}" ]; then
+            bbfatal "Nothing to sign"
+        fi
+
+        DIGEST=$(openssl dgst -hex -sha256 "${SIGNING_ARTIFACT}" | awk '{print $2}')
+
+        REQUEST_FILE=$(mktemp)
+        RESPONSE_FILE=$(mktemp)
+        echo "{\"cert_id\": \"${SIGN_KMOD_KEY_ID}\", \"digest\": \"${DIGEST}\"}" > "${REQUEST_FILE}"
+        CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt" curl --retry 5 --fail --silent "${SIGN_API}/cert/sign" -X POST -H "Content-Type: application/json" -H "X-API-Key: ${SIGN_API_KEY}" -d "@${REQUEST_FILE}" > "${RESPONSE_FILE}"
+        jq -r ".signature" < "${RESPONSE_FILE}" | base64 -d > "${SIGNING_ARTIFACT}.sig"
+        rm -f "${REQUEST_FILE}" "${RESPONSE_FILE}"
+    done
+}
+
+do_sign_digest[network] = "1"
+do_sign_digest[depends] += " \
+    openssl-native:do_populate_sysroot \
+    curl-native:do_populate_sysroot \
+    jq-native:do_populate_sysroot \
+    ca-certificates-native:do_populate_sysroot \
+    coreutils-native:do_populate_sysroot \
+    gnupg-native:do_populate_sysroot \
+    "
+
+do_sign_digest[vardeps] += " \
+    SIGN_API \
+    SIGN_KMOD_KEY_ID \
+    "

--- a/meta-balena-common/recipes-core/images/balena-image-flasher.bb
+++ b/meta-balena-common/recipes-core/images/balena-image-flasher.bb
@@ -13,7 +13,7 @@ IMAGE_FSTYPES = "balenaos-img"
 BALENA_ROOT_FSTYPE = "ext4"
 
 # Make sure you have the resin image ready
-do_image_balenaos_img[depends] += "balena-image:do_rootfs"
+do_image_balenaos_img[depends] += "balena-image:do_rootfs balena-image:do_sign_digest"
 
 # Ensure we have the raw balena image ready in DEPLOY_DIR_IMAGE
 do_image[depends] += "balena-image:do_image_complete"
@@ -61,6 +61,9 @@ BALENA_BOOT_PARTITION_FILES:append = " ${BALENA_COREBASE}/../../../${MACHINE}.js
 add_resin_image_to_flasher_rootfs() {
     mkdir -p ${WORKDIR}/rootfs/opt
     cp ${DEPLOY_DIR_IMAGE}/balena-image-${MACHINE}.balenaos-img ${WORKDIR}/rootfs/opt
+    if [ -n "${SIGN_API}" ]; then
+        cp "${DEPLOY_DIR_IMAGE}/balena-image-${MACHINE}.balenaos-img.sig" "${WORKDIR}/rootfs/opt/"
+    fi
 }
 
 IMAGE_PREPROCESS_COMMAND += " add_resin_image_to_flasher_rootfs; "

--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -130,6 +130,67 @@ function dd_with_progress {
     done
 }
 
+function verify_image_signature() {
+    IMAGE="$1"
+
+    # The original idea was to use `keyctl pkey_verify` against a trusted key
+    # that we add into the kernel trust store at build time, but this does
+    # not work. The key ends up in the .builtin_trusted_keys keyring,
+    # and even though it is a public key, it is somehow protected by the kernel
+    # and even root is not able to use it. The only information that the kernel
+    # provides about the certificate is the OCSP hash of the public key.
+    # Since we ship the certificate in plain form in the boot partition, we can
+    # use the hash to confirm that the key is the same, and use it to verify
+    # the signature from userspace.
+    IMAGE_SIG="${IMAGE}.sig"
+    BOOT_PART_CERT="/mnt/boot/balena-keys/kmod.crt"
+
+    if [ ! -f "${IMAGE_SIG}" ]; then
+        fail "No signature found for image '${IMAGE}'"
+    fi
+
+    if [ ! -f "${BOOT_PART_CERT}" ]; then
+        fail "Signing certificate not found in the boot partition"
+    fi
+
+    # `openssl x509 -ocspid` returns multiple hashes, we are looking
+    # for the hash of the public key
+    BOOT_PART_CERT_HASH=$(openssl x509 -noout -ocspid -in "${BOOT_PART_CERT}" | grep "key" | sed -e "s,^[^:]*: *,,")
+
+    # We expect a SHA1 hash, make sure we got 40 characters as a sanity check
+    if [ $(echo -n "${BOOT_PART_CERT_HASH}" | wc -c) != "40" ]; then
+        fail "Unable to get OCSP hash of the public key from '${BOOT_PART_CERT}'"
+    fi
+
+    # The same certificate should be enrolled in the kernel trust store
+    # Let's see if we can find it, we want
+    # * The same hash (case insensitive)
+    # * The key must be asymmetric
+    # * The key must contain "balenaOS" in the subject
+    # * Flags must be "I------" - TL;DR the key is loaded and not revoked,
+    #   this is what built-in keys have, see `man keyrings` for semantics.
+    KERNEL_CERT=$(cat /proc/keys | grep -i "${BOOT_PART_CERT_HASH}" | grep "asymmetri" | grep "balenaOS" | grep "I------")
+
+    if [ $(echo "${KERNEL_CERT}" | wc -l) != "1" ]; then
+        fail "Unable to match '${BOOT_PART_CERT}' against the kernel trust store"
+    fi
+
+    # At this point we are confident that the certificate in the boot
+    # partition matches the one loaded into the kernel at build time.
+
+    # Calculate a SHA256 digest of the image file
+    DIGEST_FILE=$(mktemp)
+    openssl dgst --sha256 -binary -out "${DIGEST_FILE}" "${IMAGE}"
+
+    # Finally verify the signature.
+    if ! openssl pkeyutl -verify -in "${DIGEST_FILE}" -certin -inkey "${BOOT_PART_CERT}" -sigfile "${IMAGE_SIG}"; then
+        rm -f "${DIGEST_FILE}"
+        fail "Unable to verify signature of '${IMAGE}'"
+    fi
+
+    rm -f "${DIGEST_FILE}"
+}
+
 if [ -f /usr/libexec/balena-init-flasher-secureboot ]; then
     . /usr/libexec/balena-init-flasher-secureboot
 fi
@@ -235,6 +296,12 @@ if type secureboot_setup >/dev/null 2>&1 && secureboot_setup; then
 fi
 
 if [ "$CRYPT" = "1" ]; then
+    # If we are going for the encryption, first of all verify that the image
+    # we are about to flash is correctly signed.
+    if ! verify_image_signature "${BALENA_IMAGE}"; then
+        fail "Failed to verify signature of '${BALENA_IMAGE}'"
+    fi
+
     if type diskenc_setup >/dev/null 2>&1 && ! diskenc_setup; then
         fail "Failed to setup disk encryption"
     fi


### PR DESCRIPTION
At this moment `resin-init-flasher` just takes whatever image lies in `/opt` and dd's it to the target drive. This is fine for general use, but with secure boot enabled, we want to perform at least basic authentication of the image being written.

This patch gets the image signed at build time and makes flasher verify the signature against a key built-in the kernel trust store. At this very moment it fails hard if the signature does not match, but this may change in the future. Technically we only want to know if we are about to flash a balena-provided image or not, we might want to support both but behave slightly differently in each scenario.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
