### PR TITLE
classes: kernel-balena: configure reset on oops

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -130,6 +130,7 @@ BALENA_CONFIGS ?= " \
     mbim \
     qmi \
     misc \
+    panic \
     redsocks \
     reduce-size \
     security \
@@ -500,7 +501,6 @@ BALENA_CONFIGS[qmi] = " \
 # various other configurations
 BALENA_CONFIGS[misc] = " \
     CONFIG_USB_SERIAL_CP210X=m \
-    CONFIG_PANIC_TIMEOUT=1 \
     CONFIG_DEBUG_FS=y \
     "
 
@@ -510,6 +510,12 @@ BALENA_CONFIGS_DEPS[misc] = " \
     CONFIG_IP_NF_TARGET_LOG=m \
     CONFIG_NETFILTER_XT_TARGET_LOG=m \
     CONFIG_NF_NAT_REDIRECT=m \
+"
+
+# Reset on oops
+BALENA_CONFIGS[panic] = " \
+    CONFIG_PANIC_ON_OOPS=y \
+    CONFIG_PANIC_TIMEOUT=1 \
 "
 
 # configs needed for our usage of redsocks


### PR DESCRIPTION
This is specially useful to prevent devices freezing at boot on errors, for example when the initramfs fail() is called allowing the device to reboot and rollback.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
