### PR TITLE
workflows: meta-balena-esr: fix array creation

### DIFF
--- a/.github/workflows/meta-balena-esr.yml
+++ b/.github/workflows/meta-balena-esr.yml
@@ -94,7 +94,7 @@ jobs:
           git fetch --tags origin
           current_os_version=$(git describe --abbrev=0 "$(git rev-list --tags --max-count=1)")
           current_os_version="${current_os_version:1}"
-          va=("${current_os_version//./ }")
+          va=( ${current_os_version//./ } )
           if [ ${#va[@]} -ne 3 ]; then
             echo "Invalid current version: ${current_os_version}"
             exit 1
@@ -107,7 +107,7 @@ jobs:
             os_version=$(git tag --sort -version:refname | grep "v${va[0]}\." | head -n1)
           fi
           os_version="${os_version:1}"
-          ov_arr=( "${os_version//./ }" )
+          ov_arr=( ${os_version//./ } )
           os_esr_branch=${ov_arr[0]}.${ov_arr[1]}.x
           if git ls-remote --exit-code --heads origin "${os_esr_branch}" > /dev/null; then
             echo "Branch ${os_esr_branch} already exists"


### PR DESCRIPTION
By removing linter errors and adding quotes inside the array, its contents become a single element string which is not the intention, as it should become a semver array.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
