### PR TITLE
balena-image-flasher: depend on balena-image:do_image_complete

### DIFF
--- a/meta-balena-common/recipes-core/images/balena-image-flasher.bb
+++ b/meta-balena-common/recipes-core/images/balena-image-flasher.bb
@@ -13,7 +13,7 @@ IMAGE_FSTYPES = "balenaos-img"
 BALENA_ROOT_FSTYPE = "ext4"
 
 # Make sure you have the resin image ready
-do_image_balenaos_img[depends] += "balena-image:do_rootfs balena-image:do_sign_digest"
+do_image_balenaos_img[depends] += "balena-image:do_image_complete"
 
 # Ensure we have the raw balena image ready in DEPLOY_DIR_IMAGE
 do_image[depends] += "balena-image:do_image_complete"


### PR DESCRIPTION
At this moment `balena-image-flasher` depends on `do_image_sign_digest` and do_rootfs of `balena-image`, but this is not enough, as the signature symlink is only created by a postprocess script.

This patch replaces the two existing dependencies by `do_image_complete`, which should cover everything.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
