### PR TITLE
usb-modeswitch: Update to version 2.6.1

### DIFF
--- a/meta-balena-common/recipes-support/usb-modeswitch/files/use_local_libjim_static_library.patch
+++ b/meta-balena-common/recipes-support/usb-modeswitch/files/use_local_libjim_static_library.patch
@@ -1,0 +1,37 @@
+Index: usb-modeswitch-2.6.1/Makefile
+===================================================================
+--- usb-modeswitch-2.6.1.orig/Makefile
++++ usb-modeswitch-2.6.1/Makefile
+@@ -13,6 +13,9 @@ UDEVDIR     = $(DESTDIR)/lib/udev
+ SBINDIR     = $(PREFIX)/sbin
+ MANDIR      = $(PREFIX)/share/man/man1
+ 
++JIM_CONFIGURE_OPTS = --disable-lineedit \
++	--with-out-jim-ext="stdlib posix load signal syslog" --prefix=/usr
++
+ .PHONY: clean install install-common uninstall \
+ 	dispatcher-script dispatcher-dynlink dispatcher-statlink \
+ 	install-script install-dynlink install-statlink
+@@ -28,6 +31,10 @@ all-with-statlink-dispatcher: $(PROG) di
+ $(PROG): $(OBJS) usb_modeswitch.h
+ 	$(CC) -o $(PROG) $(OBJS) $(CFLAGS) $(LIBS) $(LDFLAGS)
+ 
++jim/libjim.a:
++	cd jim && CFLAGS="$(CFLAGS)" CC="$(CC)" ./configure $(JIM_CONFIGURE_OPTS)
++	$(MAKE) -C jim
++
+ dispatcher-script: usb_modeswitch_dispatcher.tcl
+ 	DISPATCH=dispatcher-script
+ 	cp -f usb_modeswitch_dispatcher.tcl usb_modeswitch_dispatcher
+@@ -36,9 +43,9 @@ dispatcher-dynlink: dispatcher.c dispatc
+ 	DISPATCH=dispatcher-dynlink
+ 	$(CC) dispatcher.c $(LDFLAGS) -Ljim -ljim -Ijim -o usb_modeswitch_dispatcher $(CFLAGS)
+ 
+-dispatcher-statlink: dispatcher.c dispatcher.h
++dispatcher-statlink: jim/libjim.a dispatcher.c dispatcher.h
+ 	DISPATCH=dispatcher-statlink
+-	$(CC) dispatcher.c $(LDFLAGS) -l:libjim.a -ldl -Ijim -o usb_modeswitch_dispatcher $(CFLAGS)
++	$(CC) dispatcher.c $(LDFLAGS) jim/libjim.a -Ijim -o usb_modeswitch_dispatcher $(CFLAGS)
+ 
+ dispatcher.h: usb_modeswitch_dispatcher.tcl
+ 	./make_string.sh usb_modeswitch_dispatcher.tcl > $@

--- a/meta-balena-common/recipes-support/usb-modeswitch/usb-modeswitch_%.bbappend
+++ b/meta-balena-common/recipes-support/usb-modeswitch/usb-modeswitch_%.bbappend
@@ -1,0 +1,9 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+# locally add jimtcl version 0.72 which is needed for building the statically linked version of the dispatcher
+SRC_URI:append = " \
+    git://repo.or.cz/r/jimtcl.git;protocol=http;destsuffix=${S}/jim;name=jimtcl;branch=master \
+    file://use_local_libjim_static_library.patch \
+"
+
+SRCREV = "dfbde800afdabc83efc9ebe087b1aed6a90136d8"

--- a/meta-balena-common/recipes-support/usb-modeswitch/usb-modeswitch_2.6.1.bb
+++ b/meta-balena-common/recipes-support/usb-modeswitch/usb-modeswitch_2.6.1.bb
@@ -1,12 +1,11 @@
 SUMMARY = "A mode switching tool for controlling 'flip flop' (multiple device) USB gear"
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
+LIC_FILES_CHKSUM = "file://COPYING;md5=091556bd6d0154cd4c2d17a1bfc7380a"
 
 DEPENDS = "libusb1"
 
 SRC_URI = "http://www.draisberghof.de/usb_modeswitch/${BP}.tar.bz2"
-SRC_URI[md5sum] = "16b9a8efa1bf8fbd7d5612757eae4f26"
-SRC_URI[sha256sum] = "abffac09c87eacd78e101545967dc25af7e989745b4276756d45dbf4008a2ea6"
+SRC_URI[sha256sum] = "5195d9e136e52f658f19e9f93e4f982b1b67bffac197d0a455cd8c2cd245fa34"
 
 inherit pkgconfig systemd
 
@@ -16,7 +15,7 @@ FILES:${PN} = "${bindir} ${sysconfdir} ${nonarch_base_libdir}/udev/usb_modeswitc
 RRECOMMENDS:${PN} = "usb-modeswitch-data"
 
 do_install() {
-    oe_runmake DESTDIR=${D} install-static
+    oe_runmake DESTDIR=${D} install-statlink
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
         install -d ${D}/${systemd_unitdir}/system
         install -m 644 ${S}/usb_modeswitch@.service ${D}/${systemd_unitdir}/system


### PR DESCRIPTION
Version 2.5.2 of usb-modeswitch contained a local 0.72 jimtcl copy which was used when the static version of the dispatcher was being compiled. Version 2.6.1 removed this copy of jimtcl from the source package so we add it back ourselves because it's easier to have libjim.a compiled here rather than add a whole new Yocto recipe just for it.

Change-type: minor
Changelog-entry: Update usb-modeswitch to version 2.6.1


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
