### PR TITLE
Fix symlink for image signature

### DIFF
--- a/meta-balena-common/recipes-core/images/balena-image.bb
+++ b/meta-balena-common/recipes-core/images/balena-image.bb
@@ -59,14 +59,9 @@ generate_hostos_version () {
 }
 
 symlink_image_signature () {
-    # This is probably not the correct way to do it, but it works.
-    # We sign BALENA_RAW_IMG, which ends up in IMGDEPLOYDIR
-    # and has a timestamp in the file name. We need to get rid
-    # of the timestamp for the final deploy, so that the file
-    # ends up in a predictable location.
-
     if [ -n "${SIGN_API}" ]; then
-        ln -sf "${BALENA_RAW_IMG}.sig" "${DEPLOY_DIR_IMAGE}/balena-image-${MACHINE}.balenaos-img.sig"
+        ln -sf "${IMAGE_NAME}.rootfs.balenaos-img.sig" \
+            "${DEPLOY_DIR_IMAGE}/balena-image-${MACHINE}.balenaos-img.sig"
     fi
 }
 


### PR DESCRIPTION
When linking the image signature without the timestamp, the image name suffix is omitted from the link target, leading to a broken link.

```
$ ls -la build/tmp/deploy/images/generic-amd64/balena-image-generic-amd64*.sig 
.rw-r--r-- 512 joseph 10 Jan 10:55 build/tmp/deploy/images/generic-amd64/balena-image-generic-amd64-20250110185124.rootfs.balenaos-img.sig
lrwxrwxrwx   - joseph 10 Jan 10:55 build/tmp/deploy/images/generic-amd64/balena-image-generic-amd64.balenaos-img.sig -> balena-image-generic-amd64-20250110185124.rootfs.sig
```

Build the link target with the appropriate full name of the image.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
