### PR TITLE
workflows: iot-gate-imx8: add custom template path

### DIFF
--- a/.github/workflows/iot-gate-imx8.yml
+++ b/.github/workflows/iot-gate-imx8.yml
@@ -35,6 +35,7 @@ jobs:
       # Needed for testing - defaults to production
       deploy-environment: balena-staging.com
       machine: iot-gate-imx8
+      build-args: '--templates-path layers/meta-balena-imx8mm'
       device-repo: balena-os/balena-iot-gate-imx8
       device-repo-ref: master
       # Pin to the current commit


### PR DESCRIPTION
With the addition of the meta-balena-hab submodule there are multiple balena layers with custom templates - specify which one to use to avoid a build error.

Changelog-entry: add custom template path to iot-gate-imx8


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
