### PR TITLE
workflows: iot-gate-imx8plus: add custom template path

### DIFF
--- a/.github/workflows/iot-gate-imx8plus.yml
+++ b/.github/workflows/iot-gate-imx8plus.yml
@@ -35,6 +35,7 @@ jobs:
       # Needed for testing - defaults to production
       deploy-environment: balena-staging.com
       machine: iot-gate-imx8plus
+      build-args: '--templates-path layers/meta-balena-imx8mplus'
       device-repo: balena-os/balena-iot-gate-imx8plus
       device-repo-ref: master
       # Pin to the current commit


### PR DESCRIPTION
A custom template path has originally been added in https://github.com/balena-os/meta-balena/pull/3599 for the iot-gate-imx8. The iot-gate-imx8plus needs one as well because it's now using the meta-balena-hab submodule.

Change-type: patch

Needed for merging https://github.com/balena-os/meta-balena/pull/3602 

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
