### PR TITLE
tests: secureboot: fix reference to unavailable kernel-module-headers

### DIFF
--- a/tests/suites/os/tests/secureboot/index.js
+++ b/tests/suites/os/tests/secureboot/index.js
@@ -538,7 +538,7 @@ module.exports = {
 					this.worker,
 					this.suite,
 					this.os.image.path,
-					{ name: "pcan_netdev", headersVersion: "2.108.6" },
+					{ name: "pcan_netdev", headersVersion: "2.108.27" },
 				));
 				return impl.run(test);
 			}
@@ -549,7 +549,7 @@ module.exports = {
 				const impl = new testSecureBoot(new uefiSecureBoot(test,
 					this.worker,
 					this.suite, this.os.image.path,
-					{"name": "pcan_netdev", "headersVersion": "2.108.6"}));
+					{"name": "pcan_netdev", "headersVersion": "2.108.27"}));
 				await impl.run(test);
 			},
 		},


### PR DESCRIPTION
`2.108.6` doesn't exist for generic-amd64. The tests used to still work, because we werent acually passing the version to kernel-module-build correctly, meaning that it would default to the one in the kernel-module-build project. That was fixed in 4484c59fc924100232cc10303a4636ed0082760a , and now we are passing the version correctly, we're looking for a nonexistant version. Changing version to match the default.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
