### PR TITLE
tests: secureboot: remove preload test for secureboot enabled DUTs

### DIFF
--- a/docs/secure-boot-abstractions.md
+++ b/docs/secure-boot-abstractions.md
@@ -100,3 +100,7 @@ files are updated to, calling the hook twice with different names and using
 the `do_skip` function to decide whether to install a file or not.
 
 See examples in device integration layers like meta-balena-raspberrypi.
+
+# Preloading
+
+Preloading of secure boot enabled balenaOS images is currently not supported

--- a/tests/suites/cloud/tests/preload/index.js
+++ b/tests/suites/cloud/tests/preload/index.js
@@ -5,42 +5,46 @@ const request = require('request-promise');
 module.exports = {
   title: "Image preload test",
   run: async function (test) {
+    // While secureboot flasher + preloading not implemented, skip the preload test.
+    if(this.config.installer.secureboot){
+      console.log('Secure boot enabled, skipping preload test...')
+    } else {
+      // if test is being done on physical DUT via the testbot, check that the preloaded application is working
+      if(this.workerContract.workerType !== `qemu`){
+        // we should be able to see the app starting.
+    
+        await this.utils.waitUntil(
+          async () => {
+            console.log(`Checking preloaded app has started`)
+            let result = await this.worker.executeCommandInHostOS(
+              'journalctl -a | grep ": HELLO_WORLD"',
+              this.link);
+            console.log(`Result: ${result}`);
+            return result !== '';
+          }, false, 10, 5*1000);
 
-    // if test is being done on physical DUT via the testbot, check that the preloaded application is working
-    if(this.workerContract.workerType !== `qemu`){
-      // we should be able to see the app starting.
-  
-      await this.utils.waitUntil(
-        async () => {
-          console.log(`Checking preloaded app has started`)
-          let result = await this.worker.executeCommandInHostOS(
-            'journalctl -a | grep ": HELLO_WORLD"',
-            this.link);
-          console.log(`Result: ${result}`);
-          return result !== '';
-        }, false, 10, 5*1000);
+        test.ok(true, `preloaded app should be running without api access`)
+        // When we confirm the app has started, then re-enable internet access to DUT
+        await this.worker.executeCommandInWorker('sh -c "echo 1 > /proc/sys/net/ipv4/ip_forward"');
+      }
 
-      test.ok(true, `preloaded app should be running without api access`)
-      // When we confirm the app has started, then re-enable internet access to DUT
-      await this.worker.executeCommandInWorker('sh -c "echo 1 > /proc/sys/net/ipv4/ip_forward"');
+      // make sure DUT is online
+      console.log(`Waiting for DUT to be online in dashboard`)
+      await this.utils.waitUntil(() => {
+        return this.cloud.balena.models.device.isOnline(this.balena.uuid);
+      }, false, 60, 5 * 1000);
+
+      // wait until the service is running
+      await this.cloud.waitUntilServicesRunning(
+        this.balena.uuid, 
+        [this.appServiceName], 
+        this.balena.initialCommit
+      )
+
+      test.ok(true, `Preload commit hash should be ${this.balena.initialCommit}`);
     }
 
-    // make sure DUT is online
-    console.log(`Waiting for DUT to be online in dashboard`)
-    await this.utils.waitUntil(() => {
-      return this.cloud.balena.models.device.isOnline(this.balena.uuid);
-    }, false, 60, 5 * 1000);
-
-    // wait until the service is running
-    await this.cloud.waitUntilServicesRunning(
-      this.balena.uuid, 
-      [this.appServiceName], 
-      this.balena.initialCommit
-    )
-
-    test.ok(true, `Preload commit hash should be ${this.balena.initialCommit}`);
-
-
+    // Cleanup at the end of the preload test regardless - ensuring that there is a known state before the next test, regardless of whether this test ran or not
     this.log("Unpinning device from release");
     await this.cloud.balena.models.device.trackApplicationRelease(
       this.balena.uuid


### PR DESCRIPTION
Since 1ae37ac158b93df836126030abec8c3d3f69d92b using the flasher image with secureboot and preloading doesn't work. Skipping preloading tests will unblock users not using this combination with the signed images.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
