### PR TITLE
packagegroup-balena-connectivity: Install linux-firmware-ath10k by de…

### DIFF
--- a/meta-balena-common/recipes-core/packagegroups/packagegroup-balena-connectivity.bb
+++ b/meta-balena-common/recipes-core/packagegroups/packagegroup-balena-connectivity.bb
@@ -12,6 +12,7 @@ CONNECTIVITY_MODULES = ""
 
 CONNECTIVITY_FIRMWARES ?= " \
     linux-firmware-ath9k \
+    linux-firmware-ath10k \
     linux-firmware-mt7601u \
     linux-firmware-ralink \
     linux-firmware-rtl8192cu \


### PR DESCRIPTION
…fault

Some devices may use wifi chips which need this firmware. Let's include it by default and then remove it for those boards that currently don't have sufficient rootfs space for now, or already include this package from the device repository.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
