### PR TITLE
tests: cloud: env vars: restart supervisor to speed up tests

### DIFF
--- a/tests/suites/cloud/tests/multicontainer/index.js
+++ b/tests/suites/cloud/tests/multicontainer/index.js
@@ -34,6 +34,12 @@ module.exports = {
             value
           );
 
+        // The supervisor might not pick up this change immediately - restart the supervisor to force this and save time
+        await this.cloud.executeCommandInHostOS(
+          `systemctl restart balena-supervisor`,
+          this.balena.uuid
+        )
+        
         // Check that device env variable is present in each service
         let services  = [`containerA`, `containerB`];
         await this.utils.waitUntil(async () => {


### PR DESCRIPTION
Tests can get stuck here for 15 to 20 minutes if the timings are unlucky. Forcing a supervisor restart ensures a clean slate and ensures that the variables are included as quickly as possible

Saves 15+ minutes in some cases 

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
