### PR TITLE
tests: os: swap: increase wiggle room in swap check

### DIFF
--- a/tests/suites/os/tests/swap/index.js
+++ b/tests/suites/os/tests/swap/index.js
@@ -44,10 +44,11 @@ module.exports = {
 
 		const maxSwap = 4096000;
 		const expectedSwap = Math.min(totalMem / 2, maxSwap);
-		// Swap size is calculated as a percentage, so allow a little wiggle room
+		// Swap size is calculated as a percentage, so allow a little wiggle room to account for HW differences. 
+		// This value is derived from the current worst case we have seen
 		const delta = Math.abs(expectedSwap - swap.size);
 		test.ok(
-			delta < 10,
+			delta < 50,
 			'Swap should be the lesser of either half the total memory, or 4 GB'
 		);
 	},


### PR DESCRIPTION
We encountered the variance in expected and measured swap in the rpi5 to be higher than the allowed value of 10 - to make this safe and allowing of more device types, changed the allowed variation - still small enough to actually check the value is right, but should reduce false negatives

required to unblock raspberrypi5 work
https://balena.fibery.io/search/Yc6vY#Work/Project/Support-new-raspberry-Pi-CM5-device-type-949

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
