### PR TITLE
Add port types rules for ALAS5

### DIFF
--- a/meta-balena-common/recipes-connectivity/modemmanager/balena-files/0005-Update-Cinterion-port-types.patch
+++ b/meta-balena-common/recipes-connectivity/modemmanager/balena-files/0005-Update-Cinterion-port-types.patch
@@ -1,0 +1,45 @@
+From 0932fb447b5cc8ac029e70b5caf860f879038a5f Mon Sep 17 00:00:00 2001
+From: Kirill Zabelin <zabelinkirillv@gmail.com>
+Date: Wed, 19 Feb 2025 15:16:03 +0000
+Subject: [PATCH] Update Cinterion port types
+
+---
+ .../77-mm-cinterion-port-types.rules          | 24 +++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/src/plugins/cinterion/77-mm-cinterion-port-types.rules b/src/plugins/cinterion/77-mm-cinterion-port-types.rules
+index c1a9bc4a..bb9dceab 100644
+--- a/src/plugins/cinterion/77-mm-cinterion-port-types.rules
++++ b/src/plugins/cinterion/77-mm-cinterion-port-types.rules
+@@ -68,4 +68,28 @@ ATTRS{idVendor}=="1e2d", ATTRS{idProduct}=="006F", ENV{.MM_USBIFNUM}=="02", SUBS
+ ATTRS{idVendor}=="1e2d", ATTRS{idProduct}=="006F", ENV{.MM_USBIFNUM}=="04", SUBSYSTEM=="tty", ENV{ID_MM_PORT_TYPE_GPS}="1"
+ ATTRS{idVendor}=="1e2d", ATTRS{idProduct}=="006F", ENV{.MM_USBIFNUM}=="06", SUBSYSTEM=="tty", ENV{ID_MM_PORT_TYPE_QCDM}="1"
+ 
++# ALAS5
++#  ttyACM0 (if #0): AT port
++#  ttyACM1 (if #1): AT port
++#  ttyACM2 (if #2): GNSS port
++#  ttyACM3 (if #6): AT port (but just ignore)
++#  ttyACM4 (if #8): DIAG/QCDM
++#ATTRS{idVendor}=="1e2d", ATTRS{idProduct}=="0065", ENV{.MM_USBIFNUM}=="00", SUBSYSTEM=="tty", ENV{ID_MM_PORT_TYPE_AT_PRIMARY}="1"
++#ATTRS{idVendor}=="1e2d", ATTRS{idProduct}=="0065", ENV{.MM_USBIFNUM}=="02", SUBSYSTEM=="tty", ENV{ID_MM_PORT_TYPE_AT_SECONDARY}="1"
++#ATTRS{idVendor}=="1e2d", ATTRS{idProduct}=="0065", ENV{.MM_USBIFNUM}=="04", SUBSYSTEM=="tty", ENV{ID_MM_PORT_TYPE_GPS}="1"
++#ATTRS{idVendor}=="1e2d", ATTRS{idProduct}=="0065", ENV{.MM_USBIFNUM}=="06", ENV{ID_MM_PORT_IGNORE}="1"
++#ATTRS{idVendor}=="1e2d", ATTRS{idProduct}=="0065", ENV{.MM_USBIFNUM}=="08", SUBSYSTEM=="tty", ENV{ID_MM_PORT_TYPE_QCDM}="1"
++
++ATTRS{idVendor}=="1e2d", ATTRS{idProduct}=="0065", ENV{.MM_USBIFNUM}=="00", SUBSYSTEM=="tty", ENV{ID_MM_PORT_IGNORE}="1"
++ATTRS{idVendor}=="1e2d", ATTRS{idProduct}=="0065", ENV{.MM_USBIFNUM}=="02", SUBSYSTEM=="tty", ENV{ID_MM_PORT_IGNORE}="1"
++ATTRS{idVendor}=="1e2d", ATTRS{idProduct}=="0065", ENV{.MM_USBIFNUM}=="04", SUBSYSTEM=="tty", ENV{ID_MM_PORT_IGNORE}="1"
++ATTRS{idVendor}=="1e2d", ATTRS{idProduct}=="0065", ENV{.MM_USBIFNUM}=="06", SUBSYSTEM=="tty", ENV{ID_MM_PORT_IGNORE}="1"
++ATTRS{idVendor}=="1e2d", ATTRS{idProduct}=="0065", ENV{.MM_USBIFNUM}=="08", SUBSYSTEM=="tty", ENV{ID_MM_PORT_IGNORE}="1"
++
+ LABEL="mm_cinterion_port_types_end"
++
++# ignore KBox
++ATTRS{idVendor}=="208b", ATTRS{idProduct}=="0035", ENV{ID_MM_DEVICE_IGNORE}="1"
++
++
++
+-- 
+2.34.1
+

--- a/meta-balena-common/recipes-connectivity/modemmanager/modemmanager_%.bbappend
+++ b/meta-balena-common/recipes-connectivity/modemmanager/modemmanager_%.bbappend
@@ -12,6 +12,7 @@ SRC_URI:append = " \
     file://0002-quectel-disable-qmi-unsolicited-profile-manager-even.patch \
     file://0003-broadband-modem-qmi-quectel-fix-task-completion-when.patch \
     file://0004-bearer-qmi-Fix-SIM7100E-crash.patch \
+    file://0005-Update-Cinterion-port-types.patch \
 "
 
 PACKAGECONFIG:remove = "polkit"


### PR DESCRIPTION
- new rules file 77-mm-cinterion-port-types.rules for ModemManager

Moved here from - https://github.com/balena-os/balena-generic/pull/551

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
