### PR TITLE
Add DEVICE_TYPE

### DIFF
--- a/meta-balena-common/classes/image-balena.bbclass
+++ b/meta-balena-common/classes/image-balena.bbclass
@@ -4,6 +4,9 @@
 
 inherit image_types_balena kernel-balena-noimage
 
+# Override if the device-type.json file is not named as the machine
+DEVICE_TYPE ?= "${MACHINE}"
+
 # When building a Balena OS image, we also generate the kernel modules headers
 # and ship them in the deploy directory for out-of-tree kernel modules build
 DEPENDS += "coreutils-native jq-native ${@bb.utils.contains('BALENA_DISABLE_KERNEL_HEADERS', '1', '', 'kernel-devsrc kernel-headers-test', d)}"
@@ -51,7 +54,7 @@ init_config_json() {
    echo "$(cat ${1}/config.json | jq -S ".persistentLogging=false")" > ${1}/config.json
 
    # Find board json and extract slug
-   json_path=${BALENA_COREBASE}/../../../${MACHINE}.json
+   json_path=${BALENA_COREBASE}/../../../${DEVICE_TYPE}.json
    slug=$(jq .slug $json_path)
 
    # Set deviceType for supervisor
@@ -321,11 +324,12 @@ def get_rel_path(layers, rel, d):
 def get_slug(d):
     import json
     slug = "unknown"
+    device_type = d.getVar("DEVICE_TYPE", True)
     machine = d.getVar("MACHINE", True)
     resinboardpath = get_rel_path(['meta-resin-common','meta-balena-common'], '../../../', d)
     if not resinboardpath:
         return slug
-    jsonfile = os.path.normpath(os.path.join(resinboardpath, machine + ".json"))
+    jsonfile = os.path.normpath(os.path.join(resinboardpath, device_type + ".json"))
     try:
         with open(jsonfile, 'r') as fd:
             machinejson = json.load(fd)

--- a/meta-balena-common/recipes-containers/balena-supervisor/balena-supervisor.bb
+++ b/meta-balena-common/recipes-containers/balena-supervisor/balena-supervisor.bb
@@ -61,9 +61,12 @@ S = "${WORKDIR}"
 do_patch[noexec] = "1"
 do_compile[noexec] = "1"
 
+# Override if the device-type.json file is not named as the machine
+DEVICE_TYPE ?= "${MACHINE}"
+
 api_fetch_supervisor_image() {
 	_version=$1
-	_arch=$(jq --raw-output '.arch' "${TOPDIR}/../${MACHINE}.json")
+	_arch=$(jq --raw-output '.arch' "${TOPDIR}/../${DEVICE_TYPE}.json")
 	_api_env="${BALENA_API_ENV}"
 	_token="${BALENA_API_TOKEN}"
 	[ -z "${_token}" ] && [ -f "~/.balena/token" ] && _token=$(cat "~/.balena/token") || true

--- a/meta-balena-common/recipes-core/images/balena-image-flasher.bb
+++ b/meta-balena-common/recipes-core/images/balena-image-flasher.bb
@@ -54,8 +54,8 @@ BALENA_BOOT_PARTITION_FILES:append = "${@bb.utils.contains('MACHINE_FEATURES','e
 # Put the resin logo, uEnv.txt files inside the boot partition
 BALENA_BOOT_PARTITION_FILES:append = " balena-logo.png:/splash/balena-logo.png"
 
-# add the generated <machine-name>.json to the flash-boot partition, renamed as device-type.json
-BALENA_BOOT_PARTITION_FILES:append = " ${BALENA_COREBASE}/../../../${MACHINE}.json:/device-type.json"
+# add the generated <devicetype-name>.json to the flash-boot partition, renamed as device-type.json
+BALENA_BOOT_PARTITION_FILES:append = " ${BALENA_COREBASE}/../../../${DEVICE_TYPE}.json:/device-type.json"
 
 # Put balena-image in the flasher rootfs
 add_resin_image_to_flasher_rootfs() {

--- a/meta-balena-common/recipes-core/images/balena-image.bb
+++ b/meta-balena-common/recipes-core/images/balena-image.bb
@@ -74,8 +74,8 @@ BALENA_BOOT_PARTITION_FILES:append = "${@oe.utils.conditional('SIGN_API','','','
 # add the LUKS variant of GRUB config if needed
 BALENA_BOOT_PARTITION_FILES:append = "${@bb.utils.contains('MACHINE_FEATURES','efi',' grub.cfg_internal_luks:/EFI/BOOT/grub-luks.cfg','',d)}"
 
-# add the generated <machine-name>.json to the resin-boot partition, renamed as device-type.json
-BALENA_BOOT_PARTITION_FILES:append = " ${BALENA_COREBASE}/../../../${MACHINE}.json:/device-type.json"
+# add the generated <devicetype-name>.json to the resin-boot partition, renamed as device-type.json
+BALENA_BOOT_PARTITION_FILES:append = " ${BALENA_COREBASE}/../../../${DEVICE_TYPE}.json:/device-type.json"
 
 # example NetworkManager config file
 BALENA_BOOT_PARTITION_FILES:append = " \


### PR DESCRIPTION
Allow for device type names and machine to differ. Until know, the device type contract had to be named `$MACHINE.json`, and then the slug in it could be something else.

The DEVICE_TYPE variable that defaults to MACHINE for backwards compatibility allows for the same MACHINE to build several device types by passing a different DEVICE_TYPE to the build.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
