### PR TITLE
initrdscripts: Force migration with secure boot enabled

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/migrate
+++ b/meta-balena-common/recipes-core/initrdscripts/files/migrate
@@ -66,11 +66,15 @@ migrate_enabled() {
                 if [ "$bootparam_migrate" = "true" ] || jq -re '.installer.migrate.force' "${FLASH_BOOT_MOUNT}/config.json" > /dev/null; then
                     _migrate=1
                     info "Migration requested in configuration"
-                    if target_devices=$(jq -re '.installer.target_devices' "${FLASH_BOOT_MOUNT}/config.json"); then
-                        info "Configured target_devices: $target_devices"
-                        INTERNAL_DEVICE_KERNEL="${target_devices}"
-                        internal_dev=$(get_internal_device "${INTERNAL_DEVICE_KERNEL}")
-                    fi
+                elif jq -re '.installer.secureboot' "${FLASH_BOOT_MOUNT}/config.json" > /dev/null; then
+                    _migrate=1
+                    info "Migration forced because secure boot is enabled"
+                fi
+
+                if [ "${_migrate}" = "1" ] && target_devices=$(jq -re '.installer.target_devices' "${FLASH_BOOT_MOUNT}/config.json"); then
+                    info "Configured target_devices: $target_devices"
+                    INTERNAL_DEVICE_KERNEL="${target_devices}"
+                    internal_dev=$(get_internal_device "${INTERNAL_DEVICE_KERNEL}")
                 fi
             else
                 fail "Flash boot partition not found in ${internal_dev}"


### PR DESCRIPTION
As a part of secure boot hardening, we want to avoid flasher running userspace from an external drive, and always provision from memory.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
