### PR TITLE
kernel-balena: enable CONFIG_MODULE_COMPRESS as needed

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -226,6 +226,7 @@ BALENA_CONFIGS[firmware_compress] = " \
 
 MODULE_COMPRESS = "${@configure_from_version("5.13", "module_compress", "", d)}"
 BALENA_CONFIGS[module_compress] = " \
+    CONFIG_MODULE_COMPRESS=y \
     CONFIG_MODULE_COMPRESS_ZSTD=y \
 "
 


### PR DESCRIPTION
CONFIG_MODULE_COMPRESS_ZSTD requires CONFIG_MODULE_COMPRESS in kernel v6.12. Enable it when necessary.

Required by: https://github.com/balena-os/balena-generic/pull/541

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
