### PR TITLE
os-helpers: tpm_nvram_store_passphrase: remove tpm2_shutdown

### DIFF
--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-tpm2
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-tpm2
@@ -290,8 +290,6 @@ tpm_nvram_store_passphrase() {
 	tpm2_nvwrite "${PASSPHRASE_NVINDEX}" --input "${passphrase_file}" \
 					     ${nvwrite_addl_args}
 	tpm2_flushcontext "${session_ctx}"
-	tpm2_shutdown
-
 	echo "${status}"
 }
 


### PR DESCRIPTION
This should only be called during machine shutdown

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
