### PR TITLE
balena-init-flasher-efi: look for kernel in both / and /tmp

### DIFF
--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/balena-init-flasher-efi
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/balena-init-flasher-efi
@@ -166,7 +166,7 @@ bootpart_split() {
     # Emulate a stage2 bootloader
     # At this point just copy the flasher kernel to EFI partition
     # TODO: Remove or replace by a proper stage2 bootloader when that is ready
-    find / -xdev -type f -name "@@KERNEL_IMAGETYPE@@*" -exec cp -a {} "${NONENC_BOOT_MOUNT_DIR}" +
+    find / /tmp -xdev -type f -name "@@KERNEL_IMAGETYPE@@*" -exec cp -a {} "${NONENC_BOOT_MOUNT_DIR}" +
 
     # We have a separate grub.cfg for encrypted devices, use it
     if [ -f "$EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT/$INTERNAL_DEVICE_BOOTLOADER_CONFIG_LUKS" ]; then


### PR DESCRIPTION
One of the things that balena-init-flasher-efi does is that it copies the currently running kernel to the EFI partition to serve as 2nd stage bootloader when secure boot is enabled and the boot partition is split. Right now it looks for the kernel in /, which works for provisioning from an external drive, but not for the migrator. The migrator copies the kernel into /tmp before running flasher, but that directory would be skipped by flasher, as it is a different filesystem.

This patch makes flasher look for the kernel in both / and /tmp.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
