### PR TITLE
tests: secureboot: adapt kernel modules test to private device types

### DIFF
--- a/tests/suites/os/config.js
+++ b/tests/suites/os/config.js
@@ -14,6 +14,7 @@ module.exports = [
       }
     },
     image: `${__dirname}/balena.img.gz`,
+    kernelHeaders: `${__dirname}/kernel_modules_headers.tar.gz`,
     debug: {
       // Exit the ongoing test suite if a test fails
       failFast: true,


### PR DESCRIPTION
If a kernel headers file is provided, use it for the kernel module test.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
