### PR TITLE
tests: os: modem: Skip modem test if no SIM detected

### DIFF
--- a/tests/suites/os/tests/modem/index.js
+++ b/tests/suites/os/tests/modem/index.js
@@ -106,6 +106,23 @@ module.exports = {
                         }
                     });
 
+                    // Check for SIM - and skip the remainder of the test if not present
+                    // Contains the following if there is a missing sim:
+                    /*
+                      Status   |           state: failed
+                               |           failed reason: sim-missing
+                               |           power state: on
+                    */
+                    const checkSim = await this.worker.executeCommandInHostOS(
+                        `mmcli --modem=${targetAddress}`,
+                        this.link,
+                    );
+                    console.log(checkSim)
+                    if (checkSim.includes('sim-missing')){
+                        test.comment(`No SIM card detected in modem ${targetAddress} - skipping test`)
+                        return true
+                    }
+
                     // enable modem
                     await this.worker.executeCommandInHostOS(
                         `mmcli --modem=${targetAddress} --enable`,


### PR DESCRIPTION
This is to allow for the use case of a test device having a hard wired modem, that won't work in the region the test device is hosted in - e.g NA modem soldered on but test device in the EU. In that case we can remove the SIM, and the test will skip

Change-type: patch

For https://balena.fibery.io/Work/Project/Add-Ambient's-CDS-devices-to-AutoKit-1097

Leaving as draft until tested on target device


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
