### PR TITLE
balena-unique-key: Fix dependency on /home/root/.rnd mount point

### DIFF
--- a/meta-balena-common/recipes-support/balena-unique-key/balena-unique-key/balena-device-uuid.service
+++ b/meta-balena-common/recipes-support/balena-unique-key/balena-unique-key/balena-device-uuid.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Balena device UUID
-Requires=resin-boot.service home-root-.rnd.mount
-After=resin-boot.service home-root-.rnd.mount os-config-devicekey.service
+Requires=resin-boot.service bind-home-root-.rnd.service
+After=resin-boot.service bind-home-root-.rnd.service os-config-devicekey.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
We have changed the mount units to service units a while back but forgot to update a depending service to use the new service unit instead of the older mount point unit.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
