### PR TITLE
resin-init-flasher: Sleep before SysRq to let shutdown properly execu…

### DIFF
--- a/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
+++ b/meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher
@@ -624,5 +624,6 @@ else
 	fi
 fi
 
+sleep 5
 echo "${_a}" > /proc/sysrq-trigger
 fail "Unable to shutdown or reboot"


### PR DESCRIPTION
…te if need be

There are cases when at the end of the flashing procedure the board will execute "shutdown -h now" but sometimes the shutdown procedure is not immediate and the script will continue with the next instruction which is to use SysRq and on some hardware this can happen right when the previous shutdown command is still running in the background and the effect will be that the board does not actually power off in the end (eth carrier is still on, the power circuitry is still online and so on.)

To fix this we sleep for 5 seconds to give the system a chance to properly shutdown. If it has not been shutdown in 5 seconds then most likely shutdown is broken so we force it via SysRq.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
