### PR TITLE
initrdscripts: mount securityfs in migrate script

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/migrate
+++ b/meta-balena-common/recipes-core/initrdscripts/files/migrate
@@ -156,6 +156,9 @@ migrate_run() {
             fi
         fi
 
+        # Mount securityfs so that TPM event log is accessible to flasher
+        mount -t securityfs securityfs /sys/kernel/security
+
         # Run flasher - should not return
         /usr/bin/resin-init-flasher
         # Something went wrong - kill the process to prevent exploits


### PR DESCRIPTION
At this moment securityfs is not mounted in the initramfs, so when flasher is running from the migrate script, it won't find the TPM event log. This is fine for most systems, but on systems that have extra TPM events logged and measured, the expected PCR7 value will be computed incorrectly.

This patch mounts securityfs before running flasher from the migrate script.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
