### PR TITLE
tests: whitelist extra PCR2 events by default

### DIFF
--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -389,7 +389,8 @@ module.exports = {
     config.developmentMode = true;
     config.installer = {
       secureboot: ['1', 'true'].includes(process.env.FLASHER_SECUREBOOT),
-      migrate: { force: this.suite.options.balenaOS.config.installerForceMigration }
+      migrate: { force: this.suite.options.balenaOS.config.installerForceMigration },
+      whitelist_pcr2: true
     };
 
     // Add config to suite context so accessible within tests. Main use case is to check secureboot status

--- a/tests/suites/hup/suite.js
+++ b/tests/suites/hup/suite.js
@@ -421,7 +421,8 @@ module.exports = {
 						developmentMode: true,
 						installer: {
 							secureboot: ['1', 'true'].includes(process.env.FLASHER_SECUREBOOT),
-							migrate: { force: this.suite.options.balenaOS.config.installerForceMigration }
+							migrate: { force: this.suite.options.balenaOS.config.installerForceMigration },
+							whitelist_pcr2: true
 						},
 					},
 				},

--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -317,7 +317,8 @@ module.exports = {
 						installer: {
 							secureboot: ['1', 'true'].includes(process.env.FLASHER_SECUREBOOT),
 							// Note that QEMU needs to be configured with no internal storage
-							migrate: { force: this.suite.options.balenaOS.config.installerForceMigration }
+							migrate: { force: this.suite.options.balenaOS.config.installerForceMigration },
+							whitelist_pcr2: true
 						},
 					},
 				},


### PR DESCRIPTION
By introducing the option to whitelist or ignore extra events in PCR2, we have changed the default behavior of the system. Instead of copying the contents of PCR2 during provisioning, we now expect no drivers to be loaded, unless there was an explicit opt-in through config.json. This is the behavior that we've seen on physical hardware, however qemu behaves differently - it loads the PXE driver for the network card unconditionally, even if secure boot is enabled and the driver has not been whitelisted.

This patch makes all the testsuites opt-in for the PCR2 whitelist, which is just a workaround to restore the previous behavior and unblock the automated testsuite.

A proper fix should either be in leviathan, or in QEMU, or implementing a proper test for the PCR2 feature, that checks all the possible states.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
