### PR TITLE
hostapp-update-hooks: make rollback possible when migrating to TPM NVRAM

### DIFF
--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
@@ -46,6 +46,7 @@ updateKeys() {
     EFI_MOUNT_DIR="/mnt/efi"
     PASSPHRASE_FILE="$(mktemp -t)"
     CURRENT_POLICY_PATH="$(find /mnt/efi -name "policies.*")"
+    DISK_ENC_DIR=""
     for UNLOCK_PCRS in  0,2,3,7 0,1,2,3; do
         tpm2_startauthsession --policy-session -S "${SESSION_CTX}"
         tpm2_policypcr -S "${SESSION_CTX}" -l "sha256:${UNLOCK_PCRS}"
@@ -59,6 +60,7 @@ updateKeys() {
             info "Retrieved passphrase from TPM NVRAM"
         elif hw_decrypt_passphrase "$EFI_MOUNT_DIR" "session:${SESSION_CTX}" "${PASSPHRASE_FILE}"; then
             UNLOCK_PCRS_SUCCESS="${UNLOCK_PCRS}"
+            DISK_ENC_DIR="$(mktemp -d)"
             info "Decrypted passphrase stored on disk"
         fi
 
@@ -139,9 +141,23 @@ updateKeys() {
             ;;
     esac
 
-    tpm_nvram_store_passphrase "${PASSPHRASE_FILE}" "${POLICY_PATH}"
+    tpm_nvram_store_passphrase "${PASSPHRASE_FILE}" "${POLICY_PATH}" "${DISK_ENC_DIR}"
     cp -rf "${POLICY_PATH}" "${EFI_MOUNT_DIR}"
     rm -rf "${CURRENT_POLICY_PATH}"
+
+    # If we are migrating from encrypted passphrase stored in the boot partition
+    # to passphrase stored in TPM NVRAM, the above has re-encrypted the passphrase
+    # and we now need to store it in the EFI partition, otherwise rollback won't work.
+    if [ -n "${DISK_ENC_DIR}" ]; then
+        tpm2_evictcontrol -c "${EFI_MOUNT_DIR}/balena-luks.ctx"
+
+        mv "${DISK_ENC_DIR}/persistent.ctx" "${EFI_MOUNT_DIR}/balena-luks.ctx"
+        mv "${DISK_ENC_DIR}/passphrase.enc" "${EFI_MOUNT_DIR}/balena-luks.enc"
+
+        rm -rf "${DISK_ENC_DIR}"
+
+        sync "${EFI_MOUNT_DIR}"
+    fi
 
     # update the second stage bootloader kernel binary, as the hash of the
     # original may not be present in the signature database

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-tpm2
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-tpm2
@@ -222,6 +222,8 @@ tpm_nvram_retrieve_passphrase() {
 tpm_nvram_store_passphrase() {
 	passphrase_file=$1
 	policy_dir=$2
+	disk_enc_dir=$3
+
 	passphrase_sz=32
 
 	session_ctx=$(mktemp)
@@ -289,6 +291,14 @@ tpm_nvram_store_passphrase() {
 	# shellcheck disable=SC2086
 	tpm2_nvwrite "${PASSPHRASE_NVINDEX}" --input "${passphrase_file}" \
 					     ${nvwrite_addl_args}
+
+	# If we are migrating from passphrase encrypted on disk to passphrase stored in TPM NVRAM,
+	# we still need to re-encrypt the passphrase and store it in the EFI partition for rollback
+	# to work. It will be removed by rollback-health when the new OS is validated.
+	if [ -n "${disk_enc_dir}" ]; then
+		hw_encrypt_passphrase "${passphrase_file}" "${policy}" "${disk_enc_dir}"
+	fi
+
 	tpm2_flushcontext "${session_ctx}"
 	echo "${status}"
 }


### PR DESCRIPTION
At this moment migrating from passphrase encrypted in the EFI partition to passphrase stored in TPM NVRAM is a one way operation. The signed-update HUP hook will move the passphrase to TPM NVRAM and protect it with a new policy, but doesn't update the encrypted file in the EFI partition. That way, if the new OS doesn't work and triggers a rollback, the passphrase can't be decrypted when running the "old" hooks and rollback fails, leaving the system in an inconsistent state.

This patch makes the signed-update hook re-encrypt the passphrase and update it in the boot partition one last time during the migration.
* If HUP goes through, the encrypted file is removed from the boot partition and the system sticks with NVRAM only.
* If HUP fails, the system can rollback and the "old" OS version is able to decrypt the passphrase without involving NVRAM.

It's worth noting that both the RSA key and the NVRAM slot are protected by the same policy, so the "old" OS will be allowed to access the passphrase in the TPM NVRAM, even though there is no OS tooling that would know how to do that. And the "new" OS will be allowed to decrypt the passphrase in the EFI partition until it's removed by rollback-health, even though it will prefer to use NVRAM.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
