### PR TITLE
os-helpers-tpm2: Always use password protection for TPM NVRAM writes

### DIFF
--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-tpm2
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-tpm2
@@ -236,23 +236,19 @@ tpm_nvram_store_passphrase() {
 		efi_binaries="${grub_bin} ${kernel_bin}"
 	fi
 
-	stdout=/proc/self/fd/1
-	current_digest=$(tpm2_pcrread sha256:7 --quiet -o "${stdout}" | _hexencode)
-	computed_digest=$(generate_pcr_digests 7 "${stdout}" "" "${efi_binaries}" | _hexencode)
-	if [ "${current_digest}" != "${computed_digest}" ]; then
-		# The PCR policy can't be satisfied until the next boot, so associate a
-		# password with the nvindex that will allow us to write the LUKS
-		# passphrase immediately
-		tpm2_startauthsession --session "${session_ctx}"
-		tpm2_policypassword \
-			--session "${session_ctx}" \
-			--policy "${policy_dir}/policy.password"
-		tpm2_flushcontext "${session_ctx}"
+	# When updating, most of the times the PCR policy can't be satisfied
+	# until the next boot, so associate a password with the nvindex
+	# that will allow us to write the LUKS passphrase immediately.
+	# It is probably possible not to use the password if the new policy
+	# is already satisfied, but at this moment it feels like an unnecessary
+	# optimization.
+	tpm2_startauthsession --session "${session_ctx}"
+	tpm2_policypassword \
+		--session "${session_ctx}" \
+		--policy "${policy_dir}/policy.password"
+	tpm2_flushcontext "${session_ctx}"
 
-		policy_password="hex:$(hw_gen_passphrase "${passphrase_sz}" | _hexencode)"
-		nvdefine_addl_args="--index-auth ${policy_password}"
-		status=reboot_required
-	fi
+	policy_password="hex:$(hw_gen_passphrase "${passphrase_sz}" | _hexencode)"
 
 	policies="$(find "${policy_dir}" -type f | sort | xargs)"
 	if [ "$(echo "${policies}" | wc -w)" -gt 1 ]; then
@@ -277,20 +273,12 @@ tpm_nvram_store_passphrase() {
 	tpm2_nvdefine "${PASSPHRASE_NVINDEX}" --size "${passphrase_sz}" \
 					      --attributes "authwrite|policyread|policywrite" \
 					      --policy "${policy}" \
-					      ${nvdefine_addl_args}
+					      --index-auth ${policy_password}
 
 	tpm2_startauthsession --policy-session --session "${session_ctx}"
-	if [ -n "${policy_password}" ]; then
-		nvwrite_addl_args="--auth ${policy_password}"
-	else
-		pcrs="sha256:0,2,3,7"
-		tpm2_policypcr --session "${session_ctx}" --pcr-list "${pcrs}"
-		nvwrite_addl_args="--auth session:${session_ctx}"
-	fi
 
 	# shellcheck disable=SC2086
-	tpm2_nvwrite "${PASSPHRASE_NVINDEX}" --input "${passphrase_file}" \
-					     ${nvwrite_addl_args}
+	tpm2_nvwrite "${PASSPHRASE_NVINDEX}" --input "${passphrase_file}" --auth "${policy_password}"
 
 	# If we are migrating from passphrase encrypted on disk to passphrase stored in TPM NVRAM,
 	# we still need to re-encrypt the passphrase and store it in the EFI partition for rollback
@@ -299,8 +287,11 @@ tpm_nvram_store_passphrase() {
 		hw_encrypt_passphrase "${passphrase_file}" "${policy}" "${disk_enc_dir}"
 	fi
 
+	# destroy the policy password before leaving the function
+	# +2 to get 2 more bytes (4 hex characters) because the password has been prefixed by "hex:"
+	policy_password="$(dd if=/dev/urandom bs=$((${passphrase_sz} + 2)) count=1 | _hexencode)"
+
 	tpm2_flushcontext "${session_ctx}"
-	echo "${status}"
 }
 
 generate_pcr_digests() {


### PR DESCRIPTION
At this moment tpm_nvram_store_passphrase checks whether the expected policy is currently met or not, and acts differently in each case. If the policy doesn't match, the TPM write is protected by a one-time password that is lost when the function exits.
If the policy matches, it will be used to protect the write directly. The latter seems to be broken at least in some scenarios (e.g. retrying HUP after a rollback).

This patch makes removes the special-casing and makes tpm_nvram_store_passphrase always use the password protection. While using the current PCR states directly is a nice optimization, always using the password is more universal and makes the code simpler.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
