### PR TITLE
tests: cloud: Don't disable DUT internet access if secureboot enabled

### DIFF
--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -462,8 +462,10 @@ module.exports = {
 
     // disable port forwarding on the testbot - disables the DUT internet access. We do this after flashing is completed
     // in case the flashing requires internet access - e.g jetson-flash container build
+    // We disable it to test that preloaded apps start without internet access
+    // If this is for a secureboot enabled device, don't disable port forwarding, as we aren't running the preload test anyway
     if (
-			this.workerContract.workerType !== `qemu`
+			this.workerContract.workerType !== `qemu` && !config.installer.secureboot
 		){
       await this.worker.executeCommandInWorker('sh -c "echo 0 > /proc/sys/net/ipv4/ip_forward"');
       this.suite.teardown.register(async () => {


### PR DESCRIPTION
For the preload test, we disable DUT internet access to check the preloaded app starts without API access. For secureboot devices, we dont run the preload test as its not a supported feature yet. So don't disable the internet access for a secureboot device

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
