### PR TITLE
kernel-balena.bbclass: Include 802.1q VLAN driver

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -153,6 +153,7 @@ BALENA_CONFIGS ?= " \
     ${FIRMWARE_COMPRESS} \
     ${MODULE_COMPRESS} \
     ${WIREGUARD} \
+    vlan \
     "
 
 #
@@ -733,6 +734,11 @@ BALENA_CONFIGS:append = "${@bb.utils.contains('MACHINE_FEATURES','efi',' efi-sec
 BALENA_CONFIGS:append = " ${@configure_from_version("6.11", " memcg", "", d)}"
 BALENA_CONFIGS[memcg] = " \
     CONFIG_MEMCG_V1=y \
+"
+
+# 802.1q VLANs are supported by NetworkManager on all device types
+BALENA_CONFIGS[vlan] = " \
+    CONFIG_VLAN_8021Q=y \
 "
 
 ###########


### PR DESCRIPTION
On most devices this is already included but we want it everywhere, NetworkManager provides native support and it can't work without the driver.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
