### PR TITLE
.github/workflows: Change meta-balena ref to last commit of the pull …

### DIFF
--- a/.github/workflows/bananapi-m1-plus.yml
+++ b/.github/workflows/bananapi-m1-plus.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-allwinner
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/beaglebone-ai64.yml
+++ b/.github/workflows/beaglebone-ai64.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-beaglebone
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/beaglebone-pocket.yml
+++ b/.github/workflows/beaglebone-pocket.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-beaglebone
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/beaglebone.yml
+++ b/.github/workflows/beaglebone.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-beaglebone
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/generic-aarch64.yml
+++ b/.github/workflows/generic-aarch64.yml
@@ -38,7 +38,7 @@ jobs:
       # Needed for testing - defaults to production
       deploy-environment: balena-staging.com
       device-repo-ref: master
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}
       # Use QEMU workers for testing and run cloud suite against balenaCloud production
       # This would be faster with KVM on ARM64 but nested KVM is only on x86_64
       test_matrix: >

--- a/.github/workflows/generic-amd64.yml
+++ b/.github/workflows/generic-amd64.yml
@@ -38,7 +38,7 @@ jobs:
       # Needed for testing - defaults to production
       deploy-environment: balena-staging.com
       device-repo-ref: master
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}
       # Use QEMU workers for testing and run cloud suite against balenaCloud production.
       # Use AX102 runners as the AX162 runners have issues with QEMU and AMD EPYC processors.
       # See https://balena.fibery.io/Work/Project/Investigation-of-secure-boot-tests-not-booting-on-self-hosted-runners-1030

--- a/.github/workflows/genericx86-64-ext.yml
+++ b/.github/workflows/genericx86-64-ext.yml
@@ -40,7 +40,7 @@ jobs:
       device-repo: balena-os/balena-intel
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}
       # Use QEMU workers for testing and run cloud suite against balenaCloud production
       test_matrix: >
         {

--- a/.github/workflows/genericx86-64.yml
+++ b/.github/workflows/genericx86-64.yml
@@ -40,4 +40,4 @@ jobs:
       device-repo: balena-os/balena-intel
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/imx6ul-var-dart.yml
+++ b/.github/workflows/imx6ul-var-dart.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-variscite
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/imx7-var-som.yml
+++ b/.github/workflows/imx7-var-som.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-variscite
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/iot-gate-imx8.yml
+++ b/.github/workflows/iot-gate-imx8.yml
@@ -39,4 +39,4 @@ jobs:
       device-repo: balena-os/balena-iot-gate-imx8
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/iot-gate-imx8plus.yml
+++ b/.github/workflows/iot-gate-imx8plus.yml
@@ -39,4 +39,4 @@ jobs:
       device-repo: balena-os/balena-iot-gate-imx8plus
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/jetson-agx-orin-devkit.yml
+++ b/.github/workflows/jetson-agx-orin-devkit.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-jetson-orin
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/jetson-nano.yml
+++ b/.github/workflows/jetson-nano.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-jetson
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/jetson-tx2.yml
+++ b/.github/workflows/jetson-tx2.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-jetson
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/jetson-xavier.yml
+++ b/.github/workflows/jetson-xavier.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-jetson
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/nanopi-neo-air.yml
+++ b/.github/workflows/nanopi-neo-air.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-allwinner
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/nanopi-r2c.yml
+++ b/.github/workflows/nanopi-r2c.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-nanopi-r2c
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/orangepi-plus2.yml
+++ b/.github/workflows/orangepi-plus2.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-allwinner
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/owa5x.yml
+++ b/.github/workflows/owa5x.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-owa5x
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/raspberrypi.yml
+++ b/.github/workflows/raspberrypi.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-raspberrypi
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/raspberrypi2.yml
+++ b/.github/workflows/raspberrypi2.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-raspberrypi
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/raspberrypi3-64.yml
+++ b/.github/workflows/raspberrypi3-64.yml
@@ -40,4 +40,4 @@ jobs:
       device-repo: balena-os/balena-raspberrypi
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/raspberrypi3.yml
+++ b/.github/workflows/raspberrypi3.yml
@@ -40,4 +40,4 @@ jobs:
       device-repo: balena-os/balena-raspberrypi
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/raspberrypi4-64.yml
+++ b/.github/workflows/raspberrypi4-64.yml
@@ -40,4 +40,4 @@ jobs:
       device-repo: balena-os/balena-raspberrypi
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/revpi-connect-4.yml
+++ b/.github/workflows/revpi-connect-4.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-raspberrypi
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/revpi-connect-s.yml
+++ b/.github/workflows/revpi-connect-s.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-raspberrypi
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/revpi-connect.yml
+++ b/.github/workflows/revpi-connect.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-raspberrypi
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/revpi-core-3.yml
+++ b/.github/workflows/revpi-core-3.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-raspberrypi
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/rockpi-4b-rk3399.yml
+++ b/.github/workflows/rockpi-4b-rk3399.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-radxa
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/surface-go.yml
+++ b/.github/workflows/surface-go.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-intel
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/surface-pro-6.yml
+++ b/.github/workflows/surface-pro-6.yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-intel
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/var-som-mx6..yml
+++ b/.github/workflows/var-som-mx6..yml
@@ -38,4 +38,4 @@ jobs:
       device-repo: balena-os/balena-variscite
       device-repo-ref: master
       # Pin to the current commit
-      meta-balena-ref: ${{ github.sha }}
+      meta-balena-ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
…request

Using github.sha will point to a temporary merge commit which should be the commit of merging the PR. This has caused issues from time to time with the builds failing with an error such as:

fatal: unable to read tree (d1611af4dccfe68c7fe136816ead2257a9659425)

Instead let's switch to using github.event.pull_request.head.sha which is the commit ID of the last commit to the head branch of the pull request as per https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull-request-event-pull_request

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
