### PR TITLE
Add zram compression size estimation and other SB related changes

### DIFF
--- a/meta-balena-common/recipes-core/busybox/busybox/balenaos.cfg
+++ b/meta-balena-common/recipes-core/busybox/busybox/balenaos.cfg
@@ -9,3 +9,5 @@ CONFIG_BC=y
 # Enable HTTPS for wget
 CONFIG_FEATURE_WGET_HTTPS=y
 CONFIG_FEATURE_WGET_OPENSSL=y
+# Enable conv support for dd
+CONFIG_FEATURE_DD_IBS_OBS=y

--- a/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup-efi-tpm
+++ b/meta-balena-common/recipes-core/initrdscripts/files/cryptsetup-efi-tpm
@@ -38,8 +38,6 @@
 . /usr/libexec/os-helpers-efi
 . /usr/sbin/balena-config-defaults
 
-ENCRYPTED_PARTITIONS="boot rootA rootB state data"
-
 ensure_luks2() {
     LUKS_DEVICE="$1"
 
@@ -70,29 +68,10 @@ cryptsetup_run() {
     # Die if anything fails here
     set -e
 
-    # Make sure there is only a single unencrypted partition.
-    # We will blindly mount it here with no further authentication,
-    # so if there are ambiguities, we prefer to bail out.
-    NONENC_PARTS="$(lsblk -nlo label | grep "${BALENA_NONENC_BOOT_LABEL}")"
-    if [ -z "${NONENC_PARTS}" ]; then
-        fail "Partition '${BALENA_NONENC_BOOT_LABEL}' not found"
-    fi
-
-    if [ "$(echo "${NONENC_PARTS}" | wc -l)" -gt 1 ]; then
-        fail "Multiple '${BALENA_NONENC_BOOT_LABEL}' partitions found"
-    fi
-
-    EFI_DEV=$(get_state_path_from_label "${BALENA_NONENC_BOOT_LABEL}")
-    if [ ! -e "$EFI_DEV" ]; then
-        fail "Won't attempt to decrypt drives because the EFI partition is not split"
-    fi
-
-    # Check whether there are any LUKS partitions
-    if ! lsblk -nlo fstype | grep -q crypto_LUKS; then
-        fail "There are no encrypted partitions"
-    fi
+    boot_part_assert
 
     EFI_MOUNT_DIR="/efi"
+    EFI_DEV=$(get_state_path_from_label "${BALENA_NONENC_BOOT_LABEL}")
     mkdir "$EFI_MOUNT_DIR"
     mount "$EFI_DEV" "$EFI_MOUNT_DIR"
 
@@ -123,20 +102,16 @@ cryptsetup_run() {
 
     tpm2_flushcontext "${SESSION_CTX}" >/dev/null 2>&1
 
-    BOOT_DEVICE=$(lsblk -nlo pkname "${EFI_DEV}")
-
-    # Check that we have the expected amount of encrypted partitions on the boot device
-    LUKS_PARTITIONS=$(lsblk -nlo "kname,uuid,fstype,partlabel" "/dev/${BOOT_DEVICE}" | grep "crypto_LUKS")
-    if [ "$(echo "${LUKS_PARTITIONS}" | wc -l)" != "$(echo "${ENCRYPTED_PARTITIONS}" | wc -w)" ]; then
-        fail "An unexpected amount of encrypted partitions was found"
-    fi
+    luks_parts_premount_assert
 
     # Unlock all the partitions - cryptsetup luksOpen does not wait for udev processing
     # of the DM device to complete, it just kicks off the process and returns.
     # Since this is async, we can perform all the luksOpens here, note the device names
     # and wait for them in a separate loop later
     LUKS_UNLOCKED=""
-    for PART_NAME in ${ENCRYPTED_PARTITIONS}; do
+    BOOT_DEVICE=$(lsblk -nlo pkname "${EFI_DEV}")
+    LUKS_PARTITIONS=$(lsblk -nlo "kname,uuid,fstype,partlabel" "/dev/${BOOT_DEVICE}" | grep "crypto_LUKS")
+    for PART_NAME in ${DEFAULT_PARTITION_NAMES}; do
         LUKS_UUID=$(echo "${LUKS_PARTITIONS}" | grep " \(balena\|resin\)-${PART_NAME}$" | awk '{print $2}')
 
         if [ -z "${LUKS_UUID}" ]; then
@@ -161,51 +136,7 @@ cryptsetup_run() {
     # We know what the system should look like after the partitions are unlocked.
     # We want to make sure that the newly unlocked partitions are the ones
     # we are going to actually use, there is nothing missing and nothing extra.
-    for PART_NAME in ${ENCRYPTED_PARTITIONS}; do
-        LUKS_LINE=$(echo "${LUKS_PARTITIONS}" | grep " \(balena\|resin\)-${PART_NAME}$")
-
-        # Effectively the same checks have been done in the previous loop
-        # We want to be defensive, so we don't mind double-checking
-        if [ -z "${LUKS_LINE}" ]; then
-            fail "Partition '${PART_NAME}' not found"
-        fi
-
-        if [ "$(echo "${LUKS_LINE}" | wc -l)" -gt 1 ]; then
-            fail "More than one '${PART_NAME}' partition found"
-        fi
-
-        LUKS_KNAME=$(echo "${LUKS_LINE}" | awk '{print $1}')
-        LUKS_LABEL=$(echo "${LUKS_LINE}" | awk '{print $4}')
-
-        # Even though the following lsblk could be restricted to just /dev/${LUKS_KNAME}
-        # we intentionally do not want to do that. If there are multiple filesystems with
-        # the correct label, even though we know which one to use, we prefer to bail out,
-        # as this should never happen.
-        FS_LINE=$(lsblk -nlo "kname,pkname,label" | grep "${LUKS_LABEL}")
-        if [ -z "${FS_LINE}" ]; then
-            fail "Filesystem '${LUKS_LABEL}' not found after decryption"
-        fi
-
-        if [ "$(echo "${FS_LINE}" | wc -l)" -gt 1 ]; then
-            fail "More than one '${LUKS_LABEL}' filesystems found after decryption"
-        fi
-
-        FS_KNAME=$(echo "${FS_LINE}" | awk '{print $1}')
-        FS_PKNAME=$(echo "${FS_LINE}" | awk '{print $2}')
-
-        # We have found an encrypted partition with partlabel=${LUKS_LABEL} and a filesystem
-        # with label=${LUKS_LABEL}. Check that these are parent/child.
-        if [ "${FS_PKNAME}" != "${LUKS_KNAME}" ]; then
-            fail "LUKS partition '${LUKS_LABEL}' does not provide the expected filesystem"
-        fi
-
-        # The original idea was to check the /dev/disk/by-state symlinks here,
-        # but they do not all exist at this point. Because resin_update_state_probe
-        # only creates the symlinks for partitions that are on the same physical drive
-        # as the root partition, no by-state symlinks are created until rootA or rootB
-        # is unlocked. This is not an issue here and all further scripts that actually
-        # want to use the symlinks will trigger udev and get them created.
-    done
+    luks_parts_postmount_assert
 
     rm -f "$PASSPHRASE_FILE"
     umount "$EFI_MOUNT_DIR"

--- a/meta-balena-common/recipes-core/initrdscripts/files/migrate
+++ b/meta-balena-common/recipes-core/initrdscripts/files/migrate
@@ -109,7 +109,7 @@ migrate_run() {
     if [ -n "${image}" ]; then
         EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT="${BALENA_BOOT_MOUNTPOINT}"
         if findmnt "${FLASH_BOOT_MOUNT}" > /dev/null; then
-            _image_size=$(du -cb "${image}" | awk '/total/{print $1}')
+            _image_size=$(estimate_size_in_zram "${image}")
             _flash_boot_size=$(du -cb ${FLASH_BOOT_MOUNT} | awk '/total/{print $1}')
             # shellcheck disable=SC2086
             _kernel_images_size=$(du -cb ${kernel_images} | awk '/total/{print $1}')

--- a/meta-balena-common/recipes-extended/zstd/zstd_%.bbappend
+++ b/meta-balena-common/recipes-extended/zstd/zstd_%.bbappend
@@ -1,0 +1,3 @@
+do_install:append() {
+	rm -f "${D}/usr/bin/zstdgrep" "${D}/usr/bin/zstdless" "${D}/usr/bin/pzstd"
+}

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers.bb
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers.bb
@@ -4,7 +4,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${BALENA_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 DEPENDS = "time-native curl-native"
-RDEPENDS:${PN}-fs = "e2fsprogs-tune2fs mtools parted bash util-linux-fdisk"
+RDEPENDS:${PN}-fs = "e2fsprogs-tune2fs mtools parted bash util-linux-fdisk zstd"
 RDEPENDS:${PN}-fs:append = "${@bb.utils.contains('MACHINE_FEATURES','raid',' mdadm','',d)}"
 RDEPENDS:${PN}-tpm2 = "libtss2-tcti-device tpm2-tools tcgtool"
 RDEPENDS:${PN}-config = "bash"

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
@@ -486,3 +486,94 @@ erase_disk() {
     dd if=/dev/urandom of="/dev/${tdisk}" bs="${_sector_size}" count="${GPT_RESERVED_LBA}" conv=sync
     dd if=/dev/urandom of="/dev/${tdisk}" bs="${_sector_size}" seek="$(expr "${_size_in_sectors}" - "${GPT_RESERVED_LBA}" )" count="${GPT_RESERVED_LBA}" conv=sync
 }
+
+# Estimate the compressed size of a file stored in zram
+#
+# Inputs:
+#
+# 1: Uncompressed file to estimate
+#
+# Outputs:
+#
+# Estimated compressed size
+#
+# Returns:
+#
+# 0: Success
+# 1: Failure
+#
+estimate_size_in_zram() {
+	_file="${1}"
+	_zram_mount="${2:-/tmp}"
+
+	[ ! -f "$_file" ] && error "File not found!" && return 1
+
+	# Find which zram device is being used for /tmp
+	_zram=$(basename $(df "${_zram_mount}" | awk 'NR==2 {print $1}'))
+	if [ -z "$_zram" ]; then
+		error "Unable to determine zram device"
+		return 1
+	fi
+
+	if [ ! -d "/sys/block/$_zram" ]; then
+		error "zram not found"
+		return 1
+	fi
+
+	_alg=$(sed -n 's/.*\[\(.*\)\].*/\1/p' "/sys/block/$_zram/comp_algorithm")
+	if [ -z "$_alg" ]; then
+		error "Unable to determine compression algorithm"
+		return 1
+	fi
+
+	if [ ! command -v "$_alg" > /dev/null 2>&1 ]; then
+		error "$_alg not found"
+		return 1
+	fi
+
+	info "Using $_alg to estimate compressed size of $_file"
+	CHUNK_SIZE_BYTES=$(expr 250 \* 1024 \* 1024)
+	SAMPLE_SIZE_BYTES=$(expr 50 \* 1024 \* 1024)
+
+	_dev=$(df "$_file" | awk 'NR==2 {print $1}')
+	_blk_sz=$(lsblk -o NAME,PHY-SEC,TYPE "$_dev" 2>/dev/null | awk '$3 == "part" {print $2}' | head -n1)
+	if [ -z "$_blk_sz" ] || [ "$_blk_sz" -eq 0 ]; then
+		warn "Unable to determine block size, using 512 bytes"
+		_blk_sz=512
+	fi
+
+	_file_sz_bytes=$(du -cb "$_file" | awk '/total/ {print $1}')
+	_total_chunks=$(expr \( "$_file_sz_bytes" + "$CHUNK_SIZE_BYTES" - 1 \) / "$CHUNK_SIZE_BYTES")
+
+	_sample_blks=$(expr "$SAMPLE_SIZE_BYTES" / "$_blk_sz")
+	_samples_total=0
+	_compressed_total=0
+
+	_i=0
+	while [ "$_i" -lt "$_total_chunks" ]; do
+		_chunk_start_byte=$(expr "$_i" \* "$CHUNK_SIZE_BYTES")
+		_sample_start_blk=$(expr "$_chunk_start_byte" / "$_blk_sz")
+
+		if [ $(expr "$_chunk_start_byte" + "$SAMPLE_SIZE_BYTES") -gt "$_file_sz_bytes" ]; then
+			break
+		fi
+
+		_cs=$(dd if="$_file" bs="$_blk_sz" skip="$_sample_start_blk" count="$_sample_blks" status=none 2>/dev/null | "$_alg" -c 2>/dev/null | wc -c)
+
+		_compressed_total=$(expr "$_compressed_total" + "$_cs")
+		_samples_total=$(expr "$_samples_total" + 1)
+
+		_i=$(expr "$_i" + 1)
+	done
+
+	if [ "$_samples_total" -eq 0 ]; then
+		echo "$_file_sz_bytes"
+		return 0
+	fi
+
+	_average_ratio=$(echo "scale=4; $_compressed_total / ($_samples_total * $SAMPLE_SIZE_BYTES)" | bc)
+	_estimated_sz=$(echo "$_file_sz_bytes * $_average_ratio" | bc | awk '{printf "%.0f", $0}')
+
+	info "Estimated compressed size for $_file of size $_file_sz_bytes is $_estimated_sz bytes with average ratio $_average_ratio"
+	echo "$_estimated_sz"
+}

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
@@ -577,3 +577,98 @@ estimate_size_in_zram() {
 	info "Estimated compressed size for $_file of size $_file_sz_bytes is $_estimated_sz bytes with average ratio $_average_ratio"
 	echo "$_estimated_sz"
 }
+
+DEFAULT_PARTITION_NAMES="boot rootA rootB state data"
+
+# Assert the following conditions:
+#
+# 1. There is only a single unencrypted partition
+# 2. The boot partition is split
+#
+# Outputs the parent of the unencrypted partition for further use
+#
+boot_part_assert() {
+	_nonenc_part="$(lsblk -nlo label | grep "${BALENA_NONENC_BOOT_LABEL}")"
+	_nonenc_part_count="$(echo "${_nonenc_part}" | wc -l)"
+	if [ "${_nonenc_part_count}" -eq 0 ]; then
+		fail "Partition '${BALENA_NONENC_BOOT_LABEL}' not found."
+	elif [ "${_nonenc_part_count}" -gt 1 ]; then
+		fail "Multiple '${BALENA_NONENC_BOOT_LABEL}' partitions found."
+	fi
+
+	_nonenc_dev=$(get_state_path_from_label "${BALENA_NONENC_BOOT_LABEL}")
+	if [ ! -e "${_nonenc_dev}" ]; then
+		fail "Won't attempt to decrypt drives because the boot partition is not split"
+	fi
+}
+
+# Assert the following conditions before mounting the LUKS partitions:
+#
+# 1. The number of encrypted LUKS partitions is the expected
+# 2. All LUKS encrypted partitions are on the same device
+#
+luks_parts_premount_assert() {
+	_parent_dev="$(lsblk -nlo pkname,label | grep "${BALENA_NONENC_BOOT_LABEL}" | awk '{print $1}')"
+	[ -z "${_parent_dev}" ] && fail "No parent device specified"
+
+	_luks_parts=$(lsblk -nlo "kname,uuid,fstype,partlabel" "/dev/${_parent_dev}" | grep "crypto_LUKS")
+	if [ -n "${_luks_parts}" ]; then
+		if [ "$(echo "${_luks_parts}" | wc -l)" != "$(echo "${DEFAULT_PARTITION_NAMES}" | wc -w)" ]; then
+			fail "An unexpected amount of encrypted partitions was found"
+		fi
+	fi
+}
+
+# Assert we have mounted the expected LUKS partitions
+#
+luks_parts_postmount_assert() {
+	_nonenc_dev=$(get_state_path_from_label "${BALENA_NONENC_BOOT_LABEL}")
+	[ -z "${_nonenc_dev}" ] && fail "Error: Could not find non-encrypted boot device for ${BALENA_NONENC_BOOT_LABEL}."
+
+	_luks_part=$(lsblk -nlo "kname,uuid,fstype,partlabel" "/dev/$(lsblk -nlo pkname "${_nonenc_dev}")" | grep "crypto_LUKS")
+	for PART_NAME in ${DEFAULT_PARTITION_NAMES}; do
+		LUKS_LINE=$(echo "${_luks_parts}" | grep " \(balena\|resin\)-${PART_NAME}$")
+
+		# Effectively the same checks have been done in the previous loop
+		# We want to be defensive, so we don't mind double-checking
+		if [ -z "${LUKS_LINE}" ]; then
+			fail "Partition '${PART_NAME}' not found"
+		fi
+
+		if [ "$(echo "${LUKS_LINE}" | wc -l)" -gt 1 ]; then
+			fail "More than one '${PART_NAME}' partition found"
+		fi
+
+		LUKS_KNAME=$(echo "${LUKS_LINE}" | awk '{print $1}')
+		LUKS_LABEL=$(echo "${LUKS_LINE}" | awk '{print $4}')
+
+		# Even though the following lsblk could be restricted to just /dev/${LUKS_KNAME}
+		# we intentionally do not want to do that. If there are multiple filesystems with
+		# the correct label, even though we know which one to use, we prefer to bail out,
+		# as this should never happen.
+		FS_LINE=$(lsblk -nlo "kname,pkname,label" | grep "${LUKS_LABEL}")
+		if [ -z "${FS_LINE}" ]; then
+			fail "Filesystem '${LUKS_LABEL}' not found after decryption"
+		fi
+
+		if [ "$(echo "${FS_LINE}" | wc -l)" -gt 1 ]; then
+			fail "More than one '${LUKS_LABEL}' filesystems found after decryption"
+		fi
+
+		FS_KNAME=$(echo "${FS_LINE}" | awk '{print $1}')
+		FS_PKNAME=$(echo "${FS_LINE}" | awk '{print $2}')
+
+		# We have found an encrypted partition with partlabel=${LUKS_LABEL} and a filesystem
+		# with label=${LUKS_LABEL}. Check that these are parent/child.
+		if [ "${FS_PKNAME}" != "${LUKS_KNAME}" ]; then
+			fail "LUKS partition '${LUKS_LABEL}' does not provide the expected filesystem"
+		fi
+
+		# The original idea was to check the /dev/disk/by-state symlinks here,
+		# but they do not all exist at this point. Because resin_update_state_probe
+		# only creates the symlinks for partitions that are on the same physical drive
+		# as the root partition, no by-state symlinks are created until rootA or rootB
+		# is unlocked. This is not an issue here and all further scripts that actually
+		# want to use the symlinks will trigger udev and get them created.
+	done
+}


### PR DESCRIPTION
Updated with a test that compares the estimated zram compression with real zram compression and fails the build if the difference is not in a 5% threshold.

**Update**: I split the zram estimation test PRs into https://github.com/balena-os/meta-balena/pull/3688 given that builder updates are required. See that PR for details.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
