### PR TITLE
os-helpers-fs: move logic to assert partition structure to helper file

### DIFF
--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
@@ -486,3 +486,59 @@ erase_disk() {
     dd if=/dev/urandom of="/dev/${tdisk}" bs="${_sector_size}" count="${GPT_RESERVED_LBA}" conv=sync
     dd if=/dev/urandom of="/dev/${tdisk}" bs="${_sector_size}" seek="$(expr "${_size_in_sectors}" - "${GPT_RESERVED_LBA}" )" count="${GPT_RESERVED_LBA}" conv=sync
 }
+
+# Assert the following conditions:
+#
+# 1. The number of unlocked partitions is as expected
+# 2. The number of mounted encrypted partitions is the expected
+# 3. The mounted encrypted partitions are on the same device
+# 4. Only one partition is mounted per expected partition label
+#
+# Inputs:
+#
+# $1: Unlocked partition numbers
+#
+dmcrypt_parts_assert() {
+	_unlocked="${1}"
+
+	[ -z "${_unlocked}" ] && fail "No unlocked partition number specified"
+
+	_parent_dev="$(lsblk -nlo PKNAME,LABEL | grep "${BALENA_NONENC_BOOT_LABEL}" | awk '{print $1}')"
+	_nonenc_part="$(lsblk -nlo label | grep "${BALENA_NONENC_BOOT_LABEL}" | awk '{print $2}')"
+	[ -z "${_nonenc_part}" ] && fail "No non-encrypted boot partition found"
+	[ -z "${_parent_dev}" ] && fail "No parent device specified"
+
+	_enc_parts=$(dmsetup ls --target crypt 2>/dev/null | awk '{print $1}')
+	[ -z "${_enc_parts}" ] && fail "No encrypted partitions found"
+
+	if [ "$(echo "${_enc_parts}" | wc -l)" != "${_unlocked}" ]; then
+			fail "An unexpected amount of encrypted partitions was unlocked"
+	fi
+
+	if [ "$(echo "${_enc_parts}" | wc -l)" != "$(echo "${DEFAULT_PARTITION_NAMES}" | wc -w)" ]; then
+		fail "An unexpected amount of encrypted partitions was found"
+	fi
+
+	for _part in ${_enc_parts}; do
+		if ! dmsetup deps "${_part}" | grep -q "${_nonenc_part}"; then
+			fail "Encrypted partition '${_part}' is not on the same device as ${_nonenc_part}"
+		fi
+	done
+
+	for _part in ${DEFAULT_PARTITION_NAMES}; do
+			_enc_parts_count=$(echo "${_enc_parts}" | grep -Ec "^(resin|balena)-${PART_NAME}$")
+
+			if [ "${_enc_parts_count}" -lt "1"  ]; then
+					fail "Partition '${_part}' not found"
+			fi
+
+			if [ "${_enc_parts_count}" -gt "1"  ]; then
+					fail "More than one '${_part}' partition found"
+			fi
+
+			_part_count=$(lsblk -nlo label | grep -Ec "^(resin|balena)-${_part}$")
+			if [ "${_part_count}" -gt "1" ]; then
+					fail "More than one '${_part}' found"
+			fi
+	done
+}


### PR DESCRIPTION
Move the generic dmcrypt partition assertion logic. This is slightly different as paritions do not contain meta-data that can identify the encrypted partitions so dmsetup is used after the partition is mounted.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
