### PR TITLE
tests: hup: allow specifying downloaded image type

### DIFF
--- a/tests/suites/hup/config.js
+++ b/tests/suites/hup/config.js
@@ -6,6 +6,7 @@ module.exports = [
       networkWired: false,
       networkWireless: false,
       downloadVersion: 'latest',
+      downloadImageType: process.env.DOWNLOAD_IMAGE_TYPE,
       balenaApiKey: process.env.BALENACLOUD_API_KEY,
       balenaApiUrl: process.env.BALENACLOUD_API_URL,
       organization: process.env.BALENACLOUD_ORG,

--- a/tests/suites/hup/suite.js
+++ b/tests/suites/hup/suite.js
@@ -379,9 +379,12 @@ module.exports = {
 			return
 		}
 
+		console.log('OS download options:')
+		console.log(this.suite.options.balenaOS.download)
 		let path = await this.sdk.fetchOS(
 			this.suite.options.balenaOS.download.version,
 			this.suite.deviceType.slug,
+			this.suite.options.balenaOS.download.imageType
 		);
 
 		const keys = await this.utils.createSSHKey(this.sshKeyPath);


### PR DESCRIPTION
Allows selecting image type (flasher vs raw) in the hup suite, to hup from

Change-type: patch

Built on https://github.com/balena-os/meta-balena/pull/3648
depends on https://github.com/balena-os/leviathan/pull/1302 to actually work
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
