### PR TITLE
docs: secure-boot-abstractions: document the lack of provisioning det…

### DIFF
--- a/docs/secure-boot-abstractions.md
+++ b/docs/secure-boot-abstractions.md
@@ -47,9 +47,12 @@ Device specific signing classes are kept in device repositories.
 A balenaOS secured device uses both secure boot and disk encryption - these
 two functionalities are not provided separately.
 
-As such, a secured device always uses a flasher image that performs the
-installation, including the splitting of the boot partition and the encryption
-of the partitions.
+As such, a secured device always uses a flasher image that runs from memory and
+performs the installation, including the splitting of the boot partition and
+the encryption of the partitions.
+
+As the installer runs from memory, network interfaces are not brough up
+and provisioning information cannot be relayed to the cloud.
 
 The `resin-init-flasher` scripts contains the following abstractions to
 support provisioning of different device types:


### PR DESCRIPTION
…ails

When the installer script is ran from memory network interfaces are not available so provisioning information is not relayed to the cloud.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
