### PR TITLE
kernel-balena.bbclass: Enable zram zstd compression for 6.12+ kernels

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -560,8 +560,11 @@ BALENA_CONFIGS[zram] = " \
     CONFIG_CRYPTO_LZ4=y \
     "
 
-BALENA_CONFIGS:append = " ${@configure_from_version("6.12", " zram_backend_lz4", "", d)}"
-BALENA_CONFIGS[zram_backend_lz4] = "CONFIG_ZRAM_BACKEND_LZ4=y"
+BALENA_CONFIGS:append = " ${@configure_from_version("6.12", " zram_backends", "", d)}"
+BALENA_CONFIGS[zram_backends] = " \
+    CONFIG_ZRAM_BACKEND_LZ4=y \
+    CONFIG_ZRAM_BACKEND_ZSTD=y \
+"
 
 # Kernel versions between 4.0 and 4.9
 # need this for lz4 support


### PR DESCRIPTION
Kernels 6.12+ need the corresponding CONFIG_ZRAM_BACKEND_* linux kernel config item enabled for the respective compression support to be available for zram.

For the flasher we need zram zstd support so we need to enable the new CONFIG_ZRAM_BACKEND_ZSTD option.

This fixes the following error when booting a flasher image running a 6.12+ kernel: zramctl: /dev/zram1: failed to set algorithm: Invalid argument

Changelog-entry: Enable zram zstd compression for 6.12+ kernels


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
