### PR TITLE
grub-conf: Don't sign non-luks grub.cfg

### DIFF
--- a/meta-balena-common/recipes-bsp/grub/grub-conf.bb
+++ b/meta-balena-common/recipes-bsp/grub/grub-conf.bb
@@ -32,7 +32,7 @@ do_compile() {
         "${WORKDIR}/grub.cfg_internal_luks_template" > "${B}/grub.cfg_internal_luks"
 }
 
-SIGNING_ARTIFACTS = "${B}/grub.cfg_external ${B}/grub.cfg_internal ${B}/grub.cfg_internal_luks"
+SIGNING_ARTIFACTS = "${B}/grub.cfg_external ${B}/grub.cfg_internal_luks"
 addtask sign_gpg before do_install after do_compile
 
 do_install[noexec] = '1'

--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/0-signed-update
@@ -217,7 +217,7 @@ if [ -n "${SETUPMODE_VAL}" ] && [ "${SETUPMODE_VAL}" -ne "0" ]; then
 fi
 
 # Not applicable if the signatures are in place
-if [ -f "/resin-boot/EFI/BOOT/grub.cfg.sig" ]; then
+if [ -f "/resin-boot/EFI/BOOT/grub-luks.cfg.sig" ]; then
     updateKeys
     umountEfiVars
     exit $?


### PR DESCRIPTION
At this moment we sign 3 artifacts:
* `grub.cfg_external` - for flasher (secure boot or not)
* `grub.cfg_internal_luks` - for secure boot + LUKS
* `grub.cfg_internal` - for regular systems

We don't verify any signatures on systems with secure boot disabled so there is no need to sign `grub.cfg_internal`. On the contrary, having it signed only makes the file loadable on secure boot systems, which is undesirable.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
