### PR TITLE
kernel-balena.bbclass: Remove references to disabling CONFIG_RTL8192CU

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -112,7 +112,6 @@ BALENA_CONFIGS ?= " \
     brcmfmac \
     cdc-acm \
     ralink \
-    rtl8192cu \
     r8188eu \
     systemd \
     leds-gpio \
@@ -300,23 +299,6 @@ BALENA_CONFIGS[systemd] ?= " \
     CONFIG_CGROUP_SCHED=y \
     CONFIG_FAIR_GROUP_SCHED=y \
     CONFIG_CFS_BANDWIDTH=y"
-
-#
-# We use an out-of-tree kernel module for RTL8192CU WiFi devices
-# Deactivate in-tree driver and add all the dependencies of the out-of-the tree
-# one
-#
-BALENA_CONFIGS[rtl8192cu] ?= "\
-    CONFIG_RTL8192CU=n \
-    CONFIG_HOSTAP=m \
-    CONFIG_WIRELESS=y \
-    CONFIG_USB=y \
-    CONFIG_MAC80211=m \
-    CONFIG_CFG80211=m \
-    CONFIG_CFG80211_WEXT=y \
-    CONFIG_WIRELESS_EXT=y \
-    CONFIG_WEXT_PRIV=y \
-    "
 
 # Activate R8188EU driver
 BALENA_CONFIGS_DEPS[r8188eu] ?= "\


### PR DESCRIPTION
This commit is a continuation of e3b7a1555542e6b1381f1a5f7131b935d1f66f22

Devices that need a driver for RTL8192 based chipsets should enable the in-tree CONFIG_RTL8192CU kernel driver which should be stable in newer kernel releases.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
