### PR TITLE
wpa_supplicant: Enable SAE to support WPA3 personal

### DIFF
--- a/meta-balena-common/recipes-connectivity/wpa-supplicant/wpa-supplicant/defconfig
+++ b/meta-balena-common/recipes-connectivity/wpa-supplicant/wpa-supplicant/defconfig
@@ -550,3 +550,7 @@ CONFIG_AUTOSCAN_EXPONENTIAL=y
 #
 # External password backend for testing purposes (developer use)
 #CONFIG_EXT_PASSWORD_TEST=y
+
+# Enable WPA3 personal
+# This uses SAE (Simultaneous Authentication of Equals) for key_mgmt
+CONFIG_SAE=y


### PR DESCRIPTION
At this moment we completely lack WPA3 support in wpa_supplicant. Mixed WPA2/WPA3 networks will sometimes fall back to WPA2 and sometimes won't work. WPA3-only networks never work.

This patch enables SAE in the config, which should allow networks secured with WPA3 personal to work.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
