### PR TITLE
minor: remove ssh service from os-config.json

### DIFF
--- a/meta-balena-common/recipes-core/os-config/os-config/os-config.json
+++ b/meta-balena-common/recipes-core/os-config/os-config/os-config.json
@@ -13,16 +13,6 @@
 				}
 			},
 			"systemd_services": ["prepare-openvpn.service", "openvpn.service"]
-		},
-		{
-			"id": "ssh",
-			"files": {
-				"authorized_keys": {
-					"path": "/home/root/.ssh/authorized_keys_remote",
-					"perm": "600"
-				}
-			},
-			"systemd_services": []
 		}
 	],
 	"keys": [


### PR DESCRIPTION
balenaOS can handle JIT SSH key request to the api and don't require a proxy authorized_key to be set by os-config

https://balena.fibery.io/Work/Project/Stop-provisioning-devices-with-the-ssh-master-key-(building)-1768