### PR TITLE
recipes-core/packagegroup-resin: Set PACKAGE_ARCH

### DIFF
--- a/meta-balena-common/recipes-core/packagegroups/packagegroup-resin.bb
+++ b/meta-balena-common/recipes-core/packagegroups/packagegroup-resin.bb
@@ -3,6 +3,8 @@ LICENSE = "Apache-2.0"
 
 PR = "r1"
 
+PACKAGE_ARCH="${TUNE_PKGARCH}"
+
 inherit packagegroup
 
 BALENA_INIT_PACKAGE ?= "resin-init"

--- a/meta-balena-common/recipes-core/packagegroups/packagegroup-resin.inc
+++ b/meta-balena-common/recipes-core/packagegroups/packagegroup-resin.inc
@@ -3,6 +3,8 @@ LICENSE = "Apache-2.0"
 
 PR = "r1"
 
+PACKAGE_ARCH = "${TUNE_PKGARCH}"
+
 inherit packagegroup
 
 RDEPENDS:${PN} = " \


### PR DESCRIPTION
Packages with dinamically changed names cannot be included in allarch package groups. This package was set to allarch because it inherits packagegroup class, which sets PACKAGE_ARCH to "all" by default.

This fixes the following error:
    packagegroup-resin-1.0-r1 do_package_write_ipk: An allarch packagegroup shouldn't depend on packages which are dynamically renamed (kernel-modules to kernel-modules-6.6.3-g284172f37508)

See https://github.com/openembedded/meta-openembedded/commit/112cca9f474

Change-type: Patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
