### PR TITLE
Require a new "qemu-os" tag for leviathan QEMU suites

### DIFF
--- a/.github/workflows/generic-aarch64.yml
+++ b/.github/workflows/generic-aarch64.yml
@@ -46,5 +46,5 @@ jobs:
           "test_suite": ["os","cloud","hup"],
           "environment": ["balena-cloud.com"],
           "worker_type": ["qemu"],
-          "runs_on": [["self-hosted", "X64", "kvm"]]
+          "runs_on": [["self-hosted", "X64", "kvm", "qemu-os"]]
         }

--- a/.github/workflows/generic-amd64.yml
+++ b/.github/workflows/generic-amd64.yml
@@ -40,14 +40,11 @@ jobs:
       device-repo-ref: master
       meta-balena-ref: ${{ github.event.pull_request.head.sha }}
       # Use QEMU workers for testing and run cloud suite against balenaCloud production.
-      # Use AX102 runners as the AX162 runners have issues with QEMU and AMD EPYC processors.
-      # See https://balena.fibery.io/Work/Project/Investigation-of-secure-boot-tests-not-booting-on-self-hosted-runners-1030
-      # See https://unix.stackexchange.com/questions/757583/linux-reboots-with-no-panic-when-booting-smp-configuration-from-kexec
       test_matrix: >
         {
           "test_suite": ["os","cloud","hup"],
           "environment": ["balena-cloud.com"],
           "worker_type": ["qemu"],
-          "runs_on": [["self-hosted", "X64", "kvm", "AX102"]],
+          "runs_on": [["self-hosted", "X64", "kvm"]],
           "secure_boot": ["sb",""]
         }

--- a/.github/workflows/generic-amd64.yml
+++ b/.github/workflows/generic-amd64.yml
@@ -45,6 +45,6 @@ jobs:
           "test_suite": ["os","cloud","hup"],
           "environment": ["balena-cloud.com"],
           "worker_type": ["qemu"],
-          "runs_on": [["self-hosted", "X64", "kvm"]],
+          "runs_on": [["self-hosted", "X64", "kvm", "qemu-os"]],
           "secure_boot": ["sb",""]
         }

--- a/.github/workflows/genericx86-64-ext.yml
+++ b/.github/workflows/genericx86-64-ext.yml
@@ -47,5 +47,5 @@ jobs:
           "test_suite": ["os","cloud","hup"],
           "environment": ["balena-cloud.com"],
           "worker_type": ["qemu"],
-          "runs_on": [["self-hosted", "X64", "kvm", "yocto"]]
+          "runs_on": [["self-hosted", "X64", "kvm", "qemu-os"]]
         }


### PR DESCRIPTION
Depends-on: https://github.com/balena-os/balena-generic/pull/635

**Remove the AX102 requirement for secure boot tests**
The latest self-hosted runners support cpu templates
so the guests will experience a consistent feature set
supported by the host.

**Require a new "qemu-os" tag for leviathan QEMU suites**
This allows us some control over which runners are available
for long-running leviathan QEMU test suites that download large
image files.

See: https://balena.fibery.io/Work/Improvement/Require-a-new-qemu-os-tag-for-leviathan-QEMU-suites-3184
See: https://balena.fibery.io/Work/Improvement/GitHub-VMs-Allow-loading-custom-guest-cpu-templates-3180
See: https://balena.fibery.io/Inputs/Pattern/QEMU-secure-boot-tests-do-not-boot-on-AMD-EPYC-chipset-self-hosted-runners-5130
See: https://balena.fibery.io/Inputs/Pattern/balenaOS-github-actions-frequent-failures-timeouts-during-download-artifact-step-5155

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
