### PR TITLE
recipes-connectivity: skip the cloud ssh key checks earlier for "root…

### DIFF
--- a/meta-balena-common/recipes-connectivity/openssh/balena-files/cloud-public-sshkeys
+++ b/meta-balena-common/recipes-connectivity/openssh/balena-files/cloud-public-sshkeys
@@ -24,12 +24,13 @@ shift
  _api_key="$DEVICE_API_KEY"
  _api_endpoint="$API_ENDPOINT"
 
+# We short circuit the 'root' user to always be used as a local account
+[ "$_username" = "root" ] && exit 0
+
 if [ -z "$_api_endpoint" ] || [ -z "$_api_key"  ] || [ -z "$_username" ]; then
 	exit 1
 fi
 
-# We short circuit the 'root' user to always be used as a local account
-[ "$_username" = "root" ] && exit 0
 
 # Get the user public ssh key from the API
 curl -H "Authorization: Bearer ${_api_key}" "$_api_endpoint/auth/v1/public-keys/$_username"


### PR DESCRIPTION
…" user

For scarthgap builds, there seems to be a problem when trying to ssh into a device locally using "root" , as we do during some tests, if the device is unmanaged. This is becuase the api endpoint and device api key aren't defined.

For some reason this wasn't a problem before

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
