### PR TITLE
kernel-balena.bbclass: Enable DMA-BUF memory heaps

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -155,6 +155,7 @@ BALENA_CONFIGS ?= " \
     vlan \
     bpf \
     disk-watchdog \
+    dmabuf \
 "
 
 #
@@ -741,6 +742,13 @@ BALENA_CONFIGS_DEPS[bpf] = " \
 # Used by disk-watchdog tests
 BALENA_CONFIGS[disk-watchdog] = " \
     CONFIG_BLK_DEV_DM=y \
+"
+
+# Enable DMA-BUF memory heaps
+BALENA_CONFIGS[dmabuf] = " \
+    CONFIG_DMABUF_HEAPS=y \
+    CONFIG_DMABUF_HEAPS_CMA=y \
+    CONFIG_DMABUF_HEAPS_SYSTEM=y \
 "
 
 ###########


### PR DESCRIPTION
This is required by some external drivers (e.g. metis).

The configuration matches what both Fedora 42 and Debian 13 have enabled by default.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
