### PR TITLE
linux-firmware: Ensure Intel AX210 firmware can be installed

### DIFF
--- a/meta-balena-common/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/meta-balena-common/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -71,8 +71,8 @@ FILES:${PN}-ibt-18-16-1  = " \
 PACKAGES =+ "${PN}-ibt-41-41"
 
 FILES:${PN}-ibt-41-41  = " \
-    ${nonarch_base_libdir}/firmware/intel/ibt-0041-0041.ddc \
-    ${nonarch_base_libdir}/firmware/intel/ibt-0041-0041.sfi \
+    ${nonarch_base_libdir}/firmware/intel/ibt-0041-0041.ddc* \
+    ${nonarch_base_libdir}/firmware/intel/ibt-0041-0041.sfi* \
 "
 
 LICENSE:${PN}-ibt-41-41 = "Firmware-ibt_firmware"
@@ -99,8 +99,8 @@ FILES:${PN}-iwlwifi-cc-a0 = " \
 PACKAGES =+ "${PN}-iwlwifi-ty-a0"
 
 FILES:${PN}-iwlwifi-ty-a0  = " \
-    ${nonarch_base_libdir}/firmware/iwlwifi-ty-a0-*.ucode \
-    ${nonarch_base_libdir}/firmware/iwlwifi-ty-a0-*.pnvm \
+    ${nonarch_base_libdir}/firmware/iwlwifi-ty-a0-*.ucode* \
+    ${nonarch_base_libdir}/firmware/iwlwifi-ty-a0-*.pnvm* \
 "
 
 LICENSE:${PN}-iwlwifi-ty-a0 = "Firmware-iwlwifi_firmware"


### PR DESCRIPTION
... on devices which enable firmware compression.

Change-type: patch

Connects-to: https://github.com/balena-os/balena-iot-gate-imx8/pull/916
Context: [#channel/support-help > Load module firmware from container @ 💬](https://balena.zulipchat.com/#narrow/channel/403752-channel.2Fsupport-help/topic/Load.20module.20firmware.20from.20container/near/535996624)

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
