### PR TITLE
docker-tag-native.bb: add recipe

### DIFF
--- a/meta-balena-common/classes/image_types_balena.bbclass
+++ b/meta-balena-common/classes/image_types_balena.bbclass
@@ -384,10 +384,15 @@ IMAGE_CMD:balenaos-img () {
 # partition
 do_rootfs[vardeps] += "BALENA_BOOT_PARTITION_FILES"
 
+do_image_docker[depends] = " \
+    docker-tag-native:do_populate_sysroot \
+    "
+
 # XXX(petrosagg): This should be eventually implemented using a docker-native daemon
 IMAGE_CMD:docker () {
     DOCKER_IMAGE=$(${IMAGE_CMD_TAR} -cv -C ${IMAGE_ROOTFS} . | DOCKER_API_VERSION=${BALENA_API_VERSION} docker import -)
     DOCKER_API_VERSION=${BALENA_API_VERSION} docker save ${DOCKER_IMAGE} > ${BALENA_DOCKER_IMG}
+    docker-tag-native "${DOCKER_IMAGE}" "${MACHINE}" "${IMAGE_BASENAME}"
 }
 
 IMAGE_TYPEDEP:hostapp-ext4 = "docker"

--- a/meta-balena-common/recipes-containers/docker-tag-native/docker-tag-native.bb
+++ b/meta-balena-common/recipes-containers/docker-tag-native/docker-tag-native.bb
@@ -1,0 +1,14 @@
+DESCRIPTION = "Helper tool to tag imported docker images"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+inherit native
+
+SRC_URI = "file://docker-tag-native.sh"
+
+S = "${WORKDIR}"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/docker-tag-native.sh ${D}${bindir}/docker-tag-native
+}

--- a/meta-balena-common/recipes-containers/docker-tag-native/files/docker-tag-native.sh
+++ b/meta-balena-common/recipes-containers/docker-tag-native/files/docker-tag-native.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Usage: docker-tag-wrapper <image-id> <machine> <basename>
+
+set -eu
+
+IMAGE_ID="$1"
+MACHINE="$2"
+BASENAME="$3"
+
+BASE_TAG="balenaos-${MACHINE}-${BASENAME}:latest"
+DATE_TAG="balenaos-${MACHINE}-${BASENAME}:$(date +%Y%m%d%H%M%S)"
+
+echo "[docker-tag-wrapper] tagging ${IMAGE_ID} -> ${BASE_TAG}, ${DATE_TAG}"
+
+docker tag "${IMAGE_ID}" "${BASE_TAG}"
+docker tag "${IMAGE_ID}" "${DATE_TAG}"


### PR DESCRIPTION
this package helps making sense of docker image builded by yocto, they are now automatically tagged with:
balenaos-${MACHINE}-${BASENAME}:latest
balenaos-${MACHINE}-${BASENAME}:$(date +%Y%m%d%H%M%S)

Here's what it would look like :

`REPOSITORY                                           TAG              IMAGE ID       CREATED             SIZE
balenaos-generic-amd64-balena-image                  20250911094242   ff5a4728ea64   14 minutes ago      651MB
balenaos-generic-amd64-balena-image                  latest           ff5a4728ea64   14 minutes ago      651MB
balenaos-generic-amd64-balena-image                  20250911092551   581a35e9e126   31 minutes ago      651MB
`

Note that the hour is build time is UTC and not the local builder's one. I'm not sure of the overall implication of this change, but imo since we were using `IMAGE ID` only, we can still do that safely. This change is mostly useful in order to have a better dev experience and do not change anything regarding balena-os.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [X] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [X] `Change-type` present on at least one commit
- [X] `Signed-off-by` is present
- [X] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
