### PR TITLE
meta-balena-common: Consistently prepend spaces when using append

### DIFF
--- a/meta-balena-common/recipes-bsp/efitools/efitools.inc
+++ b/meta-balena-common/recipes-bsp/efitools/efitools.inc
@@ -51,7 +51,7 @@ EXTRA_OEMAKE = "\
 "
 EXTRA_OEMAKE:append:x86 = " ARCH=ia32"
 EXTRA_OEMAKE:append:x86-64 = " ARCH=x86_64"
-EXTRA_OEMAKE:append:arm = "ARCH=arm"
+EXTRA_OEMAKE:append:arm = " ARCH=arm"
 EXTRA_OEMAKE:append:aarch64 = " ARCH=aarch64"
 
 EFI_BOOT_PATH = "/boot/efi/EFI/BOOT"

--- a/meta-balena-common/recipes-connectivity/dnsmasq/dnsmasq_%.bbappend
+++ b/meta-balena-common/recipes-connectivity/dnsmasq/dnsmasq_%.bbappend
@@ -20,4 +20,4 @@ ALTERNATIVE_TARGET[resolv-conf] = "${sysconfdir}/resolv-conf.dnsmasq"
 ALTERNATIVE_LINK_NAME[resolv-conf] = "${sysconfdir}/resolv.conf"
 ALTERNATIVE_PRIORITY[resolv-conf] = "60"
 
-PACKAGECONFIG:append = "dbus"
+PACKAGECONFIG:append = " dbus"

--- a/meta-balena-common/recipes-connectivity/modemmanager/modemmanager_%.bbappend
+++ b/meta-balena-common/recipes-connectivity/modemmanager/modemmanager_%.bbappend
@@ -17,7 +17,7 @@ SRC_URI:append = " \
 
 PACKAGECONFIG:remove = "polkit"
 
-PACKAGECONFIG:append = "at"
+PACKAGECONFIG:append = " at"
 
 do_install:append() {
     install -d ${D}${base_libdir}/udev/rules.d/

--- a/meta-balena-common/recipes-core/images/balena-image.bb
+++ b/meta-balena-common/recipes-core/images/balena-image.bb
@@ -69,7 +69,7 @@ BALENA_BOOT_PARTITION_FILES:append = " \
 "
 
 # add the secure boot keys if needed
-BALENA_BOOT_PARTITION_FILES:append = "${@oe.utils.conditional('SIGN_API','','','balena-keys:/balena-keys/',d)}"
+BALENA_BOOT_PARTITION_FILES:append = "${@oe.utils.conditional('SIGN_API','','',' balena-keys:/balena-keys/',d)}"
 
 # add the LUKS variant of GRUB config if needed
 BALENA_BOOT_PARTITION_FILES:append = "${@bb.utils.contains('MACHINE_FEATURES','efi',' grub.cfg_internal_luks:/EFI/BOOT/grub-luks.cfg','',d)}"
@@ -89,7 +89,7 @@ BALENA_BOOT_PARTITION_FILES:append = " \
     system-proxy/README.ignore:/system-proxy/README.ignore \
 "
 
-BALENA_BOOT_PARTITION_FILES:append = "${@ ' extra_uEnv.txt:/extra_uEnv.txt ' if d.getVar('UBOOT_MACHINE') or d.getVar('UBOOT_CONFIG') else ''}"
+BALENA_BOOT_PARTITION_FILES:append = " ${@ ' extra_uEnv.txt:/extra_uEnv.txt ' if d.getVar('UBOOT_MACHINE') or d.getVar('UBOOT_CONFIG') else ''}"
 
 # Resin image flag file
 BALENA_BOOT_PARTITION_FILES:append = " ${BALENA_IMAGE_FLAG_FILE}:/${BALENA_IMAGE_FLAG_FILE}"

--- a/meta-balena-common/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bb
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bb
@@ -26,10 +26,10 @@ SECUREBOOT_HOOKS = " \
 SECUREBOOT_HOOK_DIRS = " \
     95-secureboot \
     "
-HOSTAPP_HOOKS:append = "${@bb.utils.contains('MACHINE_FEATURES', 'efi', '${SECUREBOOT_HOOKS}', '', d)}"
+HOSTAPP_HOOKS:append = "${@bb.utils.contains('MACHINE_FEATURES', 'efi', ' ${SECUREBOOT_HOOKS}', '', d)}"
 
 HOSTAPP_HOOKS_DIRS = "75-supervisor-db 76-supervisor-db"
-HOSTAPP_HOOKS_DIRS:append = "${@bb.utils.contains('MACHINE_FEATURES', 'efi', '${SECUREBOOT_HOOK_DIRS}', '', d)}"
+HOSTAPP_HOOKS_DIRS:append = "${@bb.utils.contains('MACHINE_FEATURES', 'efi', ' ${SECUREBOOT_HOOK_DIRS}', '', d)}"
 
 GRUB_INSTALL_DIR = "${@bb.utils.contains('MACHINE_FEATURES','efi','/EFI/BOOT','/grub',d)}"
 


### PR DESCRIPTION
The '+=' operator ensures a space is inserted before appending a value, however ':append' does not. So let's prepend a space consistently where ':append' is used.

Change-type: patch

Fixes https://github.com/balena-os/meta-balena/issues/3727

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
