### PR TITLE
add initial disk watchdog recipes and sources

### DIFF
--- a/meta-balena-common/recipes-core/packagegroups/packagegroup-resin.bb
+++ b/meta-balena-common/recipes-core/packagegroups/packagegroup-resin.bb
@@ -33,4 +33,5 @@ RDEPENDS:${PN} += " \
     systemd-zram-swap \
     ${@bb.utils.contains('BALENA_STORAGE', 'aufs', 'aufs-util-auplink', '', d)} \
     ${BALENA_SUPERVISOR} \
+    disk-watchdog \
     "

--- a/meta-balena-common/recipes-core/systemd/disk-watchdog.bb
+++ b/meta-balena-common/recipes-core/systemd/disk-watchdog.bb
@@ -1,0 +1,50 @@
+SUMMARY = "Disk watchdog service for monitoring disk health"
+DESCRIPTION = "A watchdog service that monitors disk health"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${BALENA_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = "git://github.com/balena-os/disk-watchdogd.git;branch=master;protocol=https"
+SRCREV = "1060e49da45d9bfda3047856d66bdc7c6b8c1911"
+
+SRC_URI += "file://disk-watchdogd.service \
+            file://disk-watchdog-boot-history.service \
+            file://disk-watchdog-boot-history"
+
+S = "${WORKDIR}/git"
+
+WD_TEST_FILE ?= "${bindir}/disk-watchdogd"
+DISK_WD_BOOT_DIR ?= "/mnt/state/disk-watchdog"
+
+DEPENDS += "systemd"
+RDEPENDS:${PN} += "systemd"
+RDEPENDS:${PN} += "os-helpers-fs bash"
+
+do_compile() {
+    oe_runmake all
+}
+
+inherit systemd
+
+SYSTEMD_SERVICE:${PN} = "disk-watchdogd.service disk-watchdog-boot-history.service"
+SYSTEMD_AUTO_ENABLE = "enable"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 disk-watchdogd ${D}${bindir}/
+
+    # Substitute paths in service file
+    sed -i -e 's|@DAEMON_PATH@|/usr/bin/disk-watchdogd|g' \
+           -e 's|@WD_TEST_FILE@|${WD_TEST_FILE}|g' \
+           -e 's|@OS_HELPERS_FS@|${libexecdir}/os-helpers-fs|g' \
+           -e 's|@DISK_WD_BOOT_DIR@|${DISK_WD_BOOT_DIR}|g' \
+           ${WORKDIR}/disk-watchdogd.service
+
+    # Substitute paths in boot history script
+    sed -i -e 's|@DISK_WD_BOOT_DIR@|${DISK_WD_BOOT_DIR}|g' \
+           ${WORKDIR}/disk-watchdog-boot-history
+
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/disk-watchdogd.service ${D}${systemd_unitdir}/system/
+    install -m 0644 ${WORKDIR}/disk-watchdog-boot-history.service ${D}${systemd_unitdir}/system/
+    install -m 0755 ${WORKDIR}/disk-watchdog-boot-history ${D}${bindir}/
+}

--- a/meta-balena-common/recipes-core/systemd/disk-watchdog/disk-watchdog-boot-history
+++ b/meta-balena-common/recipes-core/systemd/disk-watchdog/disk-watchdog-boot-history
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Disk watchdog boot history updater
+# This script runs once per boot to update the boot timestamp history
+
+TIME_WINDOW=600  # 10 minutes
+MAX_BOOTS=3
+
+# Read boot history, one timestamp per line
+read_boot_history() {
+    local boot_file="@DISK_WD_BOOT_DIR@/boot-history"
+    if [[ -f "$boot_file" ]]; then
+        cat "$boot_file"
+    fi
+}
+
+# Write boot history, one timestamp per line
+write_boot_history() {
+    local timestamps="$1"
+    local boot_file="@DISK_WD_BOOT_DIR@/boot-history"
+    mkdir -p "$(dirname "$boot_file")" 2>/dev/null || true
+    echo "$timestamps" > "$boot_file" 2>/dev/null || true
+}
+
+# Disable the watchdog service by creating the disable file
+disable_watchdog_service() {
+    mkdir -p @DISK_WD_BOOT_DIR@ 2>/dev/null || true
+    touch @DISK_WD_BOOT_DIR@/disabled 2>/dev/null || true
+}
+
+# Update boot history with current boot timestamp
+update_boot_history() {
+    local current_time=$(date +%s)
+    local filtered_history=""
+
+    echo "Boot history updater: Processing boot at timestamp $current_time"
+
+    # Process existing boots, keeping only recent ones
+    while IFS= read -r timestamp; do
+        if [[ -n "$timestamp" && $((current_time - timestamp)) -lt $TIME_WINDOW ]]; then
+            filtered_history="${filtered_history}${timestamp}"$'\n'
+        fi
+    done < <(read_boot_history)
+
+    # Add current boot timestamp
+    filtered_history="${filtered_history}${current_time}"
+
+    # Write updated history
+    write_boot_history "$filtered_history"
+
+    # Count boots in the updated history
+    local boot_count=$(echo "$filtered_history" | wc -l)
+
+    echo "Boot history updated successfully (boot #$boot_count in last $((TIME_WINDOW/60)) minutes)"
+
+    # Check if we have too many boots
+    if [[ $boot_count -ge $MAX_BOOTS ]]; then
+        echo "Excessive boots detected ($boot_count >= $MAX_BOOTS) - disabling disk watchdog"
+        disable_watchdog_service
+    else
+        echo "Boot count ($boot_count) below threshold ($MAX_BOOTS) - watchdog will be allowed to start"
+    fi
+}
+
+# Main execution
+update_boot_history
+exit 0

--- a/meta-balena-common/recipes-core/systemd/disk-watchdog/disk-watchdog-boot-history.service
+++ b/meta-balena-common/recipes-core/systemd/disk-watchdog/disk-watchdog-boot-history.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Disk watchdog boot history updater
+After=local-fs.target
+Before=disk-watchdogd.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/disk-watchdog-boot-history
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-balena-common/recipes-core/systemd/disk-watchdog/disk-watchdogd.service
+++ b/meta-balena-common/recipes-core/systemd/disk-watchdog/disk-watchdogd.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Disk watchdog service for monitoring disk health
+After=local-fs.target disk-watchdog-boot-history.service
+Requires=disk-watchdog-boot-history.service
+ConditionPathExists=!@DISK_WD_BOOT_DIR@/disabled
+
+[Service]
+Type=notify
+ExecStart=/bin/sh -c '@DAEMON_PATH@ -v -f @WD_TEST_FILE@ -b $(source @OS_HELPERS_FS@ && get_sector_size /dev/disk/by-state/active)'
+WatchdogSec=30s
+StartLimitInterval=2min
+StartLimitBurst=3
+StartLimitAction=reboot-force
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
@@ -16,6 +16,16 @@ if [ -f "/usr/libexec/os-helpers-logging" ]; then
 . /usr/libexec/os-helpers-logging
 fi
 
+# Get the physical sector size for a device
+# Arguments:
+#   1 - device path (e.g., /dev/sda1, /dev/mmcblk0p1)
+# Returns: sector size in bytes via stdout
+get_sector_size() {
+	local _device="$1"
+
+	lsblk -o NAME,PHY-SEC,TYPE "$_device" 2>/dev/null | awk '$3 == "part" || $3 == "crypt" {print $2}' | head -n1
+}
+
 # Wait for a file to appear with loop count limit.
 # Use-case example: wait for udev to create a filesystem symlink.
 # Arguments:
@@ -536,7 +546,7 @@ estimate_size_in_zram() {
 	SAMPLE_SIZE_BYTES=$(expr 50 \* 1024 \* 1024)
 
 	_dev=$(df "$_file" | awk 'NR==2 {print $1}')
-	_blk_sz=$(lsblk -o NAME,PHY-SEC,TYPE "$_dev" 2>/dev/null | awk '$3 == "part" {print $2}' | head -n1)
+	_blk_sz=$(get_sector_size "$_dev")
 	if [ -z "$_blk_sz" ] || [ "$_blk_sz" -eq 0 ]; then
 		warn "Unable to determine block size, using 512 bytes"
 		_blk_sz=512

--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -477,5 +477,6 @@ module.exports = {
 		'./tests/swap',
 		'./tests/internet-sharing',
 		'./tests/safe-reboot',
+		'./tests/disk-watchdog',
 	],
 };

--- a/tests/suites/os/tests/disk-watchdog/Dockerfile.template
+++ b/tests/suites/os/tests/disk-watchdog/Dockerfile.template
@@ -1,0 +1,12 @@
+FROM balenalib/%%BALENA_ARCH%%-alpine:3.12-run
+
+RUN apk add device-mapper e2fsprogs bash
+
+COPY create-dm-flakey.sh /usr/bin/create-dm-flakey.sh
+RUN chmod +x /usr/bin/create-dm-flakey.sh
+
+COPY entrypoint.sh /usr/bin/entrypoint.sh
+RUN chmod +x /usr/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]
+CMD ["sleep", "infinity"]

--- a/tests/suites/os/tests/disk-watchdog/create-dm-flakey.sh
+++ b/tests/suites/os/tests/disk-watchdog/create-dm-flakey.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Create a dm-flakey device on top of a loop-backed image and mount it.
+# Usage:
+#   create-dm-flakey.sh <mount_point> <image_path> <dm_name>
+#   create-dm-flakey.sh cleanup <mount_point> <image_path> <dm_name>
+# Exit codes:
+#   1: usage
+#   2: image creation failed
+#   3: loop setup failed
+#   4: mkfs failed
+#   5: dmsetup failed
+#   6: mount failed
+#   7: could not determine device size
+
+set -u
+
+die() { echo "ERROR: $2" >&2; cleanup; exit "$1"; }
+
+cleanup() {
+    # Best-effort cleanup
+    set +e
+    if [[ -n ${MOUNT_POINT:-} ]] && mountpoint -q "$MOUNT_POINT"; then
+        umount "$MOUNT_POINT" >/dev/null 2>&1
+    fi
+    if [[ -n ${DM_NAME:-} ]] && dmsetup info "$DM_NAME" >/dev/null 2>&1; then
+        dmsetup remove "$DM_NAME" >/dev/null 2>&1
+    fi
+    # Determine loop device by variable or by image path
+    if [[ -z ${LOOP_DEV:-} ]] && [[ -n ${IMG_PATH:-} ]]; then
+        LOOP_DEV=$(losetup -d "$IMG_PATH" | awk -F: 'NR==1{print $1}')
+    fi
+    if [[ -n ${LOOP_DEV:-} ]] && losetup -a | grep -q "^$LOOP_DEV:"; then
+        losetup -d "$LOOP_DEV" >/dev/null 2>&1
+    fi
+    # Remove backing image if provided
+    if [[ -n ${IMG_PATH:-} && -f "$IMG_PATH" ]]; then
+        rm -f "$IMG_PATH"
+    fi
+    set -e
+}
+
+if [[ $# -lt 3 ]]; then
+    echo "Usage: $0 <mount_point> <image_path> <dm_name> | $0 cleanup <mount_point> <image_path> <dm_name>" >&2
+    exit 1
+fi
+
+if [[ "$1" == "cleanup" ]]; then
+    MOUNT_POINT=$2
+    IMG_PATH=$3
+    DM_NAME=$4
+    cleanup
+    exit 0
+fi
+
+if [[ $# -ne 3 ]]; then
+    echo "Usage: $0 <mount_point> <image_path> <dm_name>" >&2
+    exit 1
+fi
+
+MOUNT_POINT=$1
+IMG_PATH=$2
+DM_NAME=$3
+
+mkdir -p "$MOUNT_POINT" || die 6 "Failed to create mount point $MOUNT_POINT"
+
+# Create image if missing (100 MiB)
+if [[ ! -e "$IMG_PATH" ]]; then
+    if ! dd if=/dev/zero of="$IMG_PATH" bs=1M count=10 status=none; then
+        die 2 "Failed to create image at $IMG_PATH"
+    fi
+fi
+
+# Setup loop device
+LOOP_DEV=$(losetup -f) || die 3 "Failed to get free loop device"
+if ! losetup -P "$LOOP_DEV" "$IMG_PATH"; then
+    die 3 "Failed to attach $IMG_PATH to $LOOP_DEV"
+fi
+
+# Create filesystem on the loop device
+if ! mkfs.ext4 -F "$LOOP_DEV" >/dev/null; then
+    die 4 "mkfs.ext4 failed on $LOOP_DEV"
+fi
+
+if ! mount "$LOOP_DEV" "$MOUNT_POINT"; then
+    die 6 "Failed to mount $LOOP_DEV on $MOUNT_POINT"
+fi
+dd if=/dev/urandom of="$MOUNT_POINT/test.bin" bs=1M count=5 status=none || die 7 "Failed to create test.bin on $MOUNT_POINT"
+if ! umount "$MOUNT_POINT"; then
+    die 6 "Failed to unmount $MOUNT_POINT"
+fi
+
+# Determine size in 512B sectors
+SECTORS=$(blockdev --getsz "$LOOP_DEV" 2>/dev/null) || true
+[[ -n "$SECTORS" && "$SECTORS" =~ ^[0-9]+$ ]] || die 7 "Could not determine size for $LOOP_DEV"
+
+# Create dm-flakey mapping: 1s up / 1s down
+TABLE="0 $SECTORS flakey $LOOP_DEV 0 1 2"
+if ! echo "$TABLE" | dmsetup create "$DM_NAME"; then
+    die 5 "dmsetup create failed for $DM_NAME"
+fi
+
+# Mount the flakey device
+if ! mount "/dev/mapper/$DM_NAME" "$MOUNT_POINT"; then
+    die 6 "Failed to mount /dev/mapper/$DM_NAME on $MOUNT_POINT"
+fi
+
+# Leave devices mounted/active; caller is responsible for teardown.
+exit 0

--- a/tests/suites/os/tests/disk-watchdog/disk-watchdog-override.conf
+++ b/tests/suites/os/tests/disk-watchdog/disk-watchdog-override.conf
@@ -1,0 +1,5 @@
+[Service]
+ExecStart=
+ExecStart=/bin/sh -c '/usr/bin/disk-watchdogd -v -f /mnt/state/flakey-mount/test.bin -b 512'
+WatchdogSec=
+WatchdogSec=2

--- a/tests/suites/os/tests/disk-watchdog/docker-compose.yml
+++ b/tests/suites/os/tests/disk-watchdog/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+services:
+  disk-watchdog:
+    build: .
+    restart: on-failure
+    privileged: true
+    volumes:
+      - logs:/logs
+
+volumes:
+  logs:

--- a/tests/suites/os/tests/disk-watchdog/entrypoint.sh
+++ b/tests/suites/os/tests/disk-watchdog/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+setup_devtmpfs() {
+    newdev=/tmp/dev
+    mkdir -p "$newdev"
+    mount -t devtmpfs none "$newdev"
+    mount --move /dev/console "$newdev/console"
+    mount --move /dev/mqueue "$newdev/mqueue"
+    mount --move /dev/pts "$newdev/pts"
+    mount --move /dev/shm "$newdev/shm"
+    umount /dev
+    mount --move "$newdev" /dev
+    ln -sf /dev/pts/ptmx /dev/ptmx
+}
+
+# Run setup before anything else
+setup_devtmpfs
+
+# Execute the main command
+exec "$@"

--- a/tests/suites/os/tests/disk-watchdog/index.js
+++ b/tests/suites/os/tests/disk-watchdog/index.js
@@ -1,0 +1,331 @@
+/* Copyright 2019 balena
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// Minimal helpers to verify file/dir existence in container or host
+const verifyFileOrDirExists = async (context, link, test, path, testFlag, location = 'disk-watchdog') => {
+    const exec = location === 'host'
+        ? (cmd) => context.get().worker.executeCommandInHostOS(cmd, link)
+        : (cmd) => context.get().worker.executeCommandInContainer(cmd, location, link);
+    const out = await exec(`test ${testFlag} ${path} && echo exists || echo missing`);
+    test.is(out.trim(), 'exists', `${path} should exist (${location})`);
+};
+
+const verifyFileExists = async (context, link, test, path, location = 'disk-watchdog') => {
+    await verifyFileOrDirExists(context, link, test, path, '-f', location);
+};
+
+const verifyDirExists = async (context, link, test, path, location = 'disk-watchdog') => {
+    await verifyFileOrDirExists(context, link, test, path, '-d', location);
+};
+
+const verifyBlockDeviceExists = async (context, link, test, path, location = 'disk-watchdog') => {
+    await verifyFileOrDirExists(context, link, test, path, '-b', location);
+};
+
+// Retry helper for flakey devices: try N times with delay to detect existence
+const waitForExists = async (
+    context,
+    link,
+    path,
+    testFlag = '-f',
+    attempts = 60,
+    delaySeconds = 0.5,
+    location = 'host',
+) => {
+    const exec = location === 'host'
+        ? (cmd) => context.get().worker.executeCommandInHostOS(cmd, link)
+        : (cmd) => context.get().worker.executeCommandInContainer(cmd, location, link);
+    const cmd = `sh -lc 'for i in $(seq 1 ${attempts}); do if test ${testFlag} ${path}; then echo exists; exit 0; fi; sleep ${delaySeconds}; done; echo missing'`;
+    return (await exec(cmd)).trim();
+};
+
+const createDmFlakey = async (context, link, test, deviceName = 'flakey-disk') => {
+    const containerMount = '/tmp/mnt';
+    const containerImage = '/tmp/disk-image';
+
+    await context
+        .get()
+        .worker.executeCommandInContainer(
+            `sh -lc 'bash -x /usr/bin/create-dm-flakey.sh ${containerMount} ${containerImage} ${deviceName} 2>&1 | tee /logs/flakey.log'`,
+            'disk-watchdog',
+            link,
+        );
+
+    test.comment(await context
+        .get()
+        .worker.executeCommandInContainer(
+            `sh -lc 'cat /logs/flakey.log'`,
+            'disk-watchdog',
+            link,
+        ));
+
+    const testBinExists = await waitForExists(context, link, `${containerMount}/test.bin`, '-f', 10, 1, 'disk-watchdog');
+    test.is(testBinExists, 'exists', `${containerMount}/test.bin should exist in container`);
+    await verifyFileExists(context, link, test, "/bin/bash", 'disk-watchdog');
+    await verifyFileExists(context, link, test, `${containerImage}`, 'disk-watchdog');
+    await verifyDirExists(context, link, test, `/dev/mapper/`, 'disk-watchdog');
+    await verifyBlockDeviceExists(context, link, test, `/dev/mapper/${deviceName}`, 'disk-watchdog');
+    await verifyBlockDeviceExists(context, link, test, `/dev/mapper/${deviceName}`, 'host');
+
+    await context
+        .get()
+        .worker.executeCommandInContainer(
+            `sh -lc 'umount ${containerMount}'`,
+            'disk-watchdog',
+            link,
+        );
+};
+
+const mountFlakeyOnHost = async (context, link, test, deviceName, hostMount) => {
+    await context
+        .get()
+        .worker.executeCommandInHostOS(
+            `mkdir -p ${hostMount} && mount /dev/mapper/${deviceName} ${hostMount}`,
+            link,
+        );
+    const mp = await context
+        .get()
+        .worker.executeCommandInHostOS(
+            `mountpoint -q ${hostMount} && echo mounted || echo not`,
+            link,
+        );
+    test.is(mp.trim(), 'mounted', `${hostMount} should be a mount point on host`);
+
+    const wait = await waitForExists(context, link, `${hostMount}/test.bin`);
+    test.is(wait, 'exists', `${hostMount}/test.bin should eventually exist on host`);
+};
+
+const modify_disk_watchdogd_systemd = async (context, link, test) => {
+    await context
+        .get()
+        .worker.executeCommandInHostOS(
+            `mkdir -p /run/systemd/system/disk-watchdogd.service.d`,
+            link,
+        );
+
+    await context.get().worker.sendFile(
+        `${__dirname}/disk-watchdog-override.conf`,
+        `/run/systemd/system/disk-watchdogd.service.d/override.conf`,
+        link,
+    );
+
+    await verifyFileExists(context, link, test, `/run/systemd/system/disk-watchdogd.service.d/override.conf`, 'host');
+
+    test.comment('Restarting disk-watchdogd...');
+    await context
+        .get()
+        .worker.executeCommandInHostOS(
+            `systemctl daemon-reload && systemctl restart disk-watchdogd`,
+            link,
+        );
+};
+
+const expectRebootSoon = async (context, link, test, timeoutSeconds = 120, pollSeconds = 2) => {
+    // Create a marker in /tmp that should disappear after reboot
+    await context
+        .get()
+        .worker.executeCommandInHostOS(
+            `touch /tmp/reboot-check`,
+            link,
+        );
+
+    const start = Date.now();
+    let rebooted = false;
+    while ((Date.now() - start) / 1000 < timeoutSeconds) {
+        test.comment(`Waiting for device to reboot... ${Math.floor((Date.now() - start) / 1000)} / ${timeoutSeconds} seconds`);
+        const status = await context
+            .get()
+            .worker.executeCommandInHostOS(
+                `[[ ! -f /tmp/reboot-check ]] && echo gone || echo present || true`,
+                link,
+            );
+        if (status.trim() === 'gone') {
+            test.comment('Device rebooted (marker in /tmp disappeared)');
+            rebooted = true;
+            break;
+        }
+        await new Promise((r) => setTimeout(r, pollSeconds * 1000));
+    }
+};
+
+const verify_boot_count = async (context, link, test, expectedCount = '2') => {
+    const bootLines = await context
+        .get()
+        .worker.executeCommandInHostOS(
+            `sh -lc 'wc -l < /mnt/state/disk-watchdog/boot-history'`,
+            link,
+        );
+
+    test.is(bootLines.trim(), String(expectedCount), `boot-history should have ${expectedCount} lines`);
+};
+
+const verify_service_disabled = async (context, link, test) => {
+    // Reset boot-history and add 3 controlled timestamps: now, now-60s, now-120s
+    await context
+        .get()
+        .worker.executeCommandInHostOS(
+            `sh -lc 'n=$(date +%s); printf "%s\n%s\n%s\n" "$n" "$((n-60))" "$((n-120))" > /mnt/state/disk-watchdog/boot-history'`,
+            link,
+        );
+
+    // Ensure the count matches expectation after reset
+    await verify_boot_count(context, link, test, String(3));
+
+    // Restart service; ExecStartPre should prevent start and create disabled marker
+    await context
+        .get()
+        .worker.executeCommandInHostOS(
+            `systemctl restart disk-watchdog-boot-history disk-watchdogd || true`,
+            link,
+        );
+
+    // Verify service is not active (failed or inactive is acceptable)
+    const state = (await context
+        .get()
+        .worker.executeCommandInHostOS(
+            `systemctl is-active disk-watchdogd || true`,
+            link,
+        )).trim();
+    test.is(state == 'active', false, 'disk-watchdogd should not be active after disable threshold');
+
+    // Verify disabled file exists
+    await verifyFileExists(context, link, test, '/mnt/state/disk-watchdog/disabled', 'host');
+};
+
+const verify_service_wont_restart = async (context, link, test) => {
+    // Ensure disabled marker exists and clear boot history to simulate fresh boots
+    await context
+        .get()
+        .worker.executeCommandInHostOS(
+            `sh -lc 'touch /mnt/state/disk-watchdog/disabled && : > /mnt/state/disk-watchdog/boot-history'`,
+            link,
+        );
+
+    // Attempt to start the service explicitly
+    await context
+        .get()
+        .worker.executeCommandInHostOS(
+            `systemctl restart disk-watchdog-boot-history disk-watchdogd || true`,
+            link,
+        );
+
+    // It should not become active if disabled
+    const state = (await context
+        .get()
+        .worker.executeCommandInHostOS(
+            `systemctl is-active disk-watchdogd || true`,
+            link,
+        )).trim();
+    test.is(state == 'active', false, 'disk-watchdogd should not start when disabled file exists');
+};
+
+const verify_reboot_with_flakey_disk = async (context, link, test) => {
+    // Push service
+    const ip = await context.get().worker.ip(link);
+    await context
+        .get()
+        .worker.pushContainerToDUT(ip, __dirname, 'disk-watchdog');
+    test.comment('Service pushed');
+
+    // Create flakey device and mount on host
+    const deviceName = 'flakey-disk';
+    await createDmFlakey(context, link, test, deviceName);
+    const hostMount = '/mnt/state/flakey-mount';
+    await mountFlakeyOnHost(context, link, test, deviceName, hostMount);
+
+    // Install systemd override on host and restart disk-watchdogd
+    test.comment('Installing disk-watchdogd systemd override on host...');
+    await modify_disk_watchdogd_systemd(context, link, test);
+
+    // Expect device to reboot shortly (watchdog triggers reboot)
+    await expectRebootSoon(context, link, test, 120, 2);
+
+    // Verify that boot history is now 2
+    test.comment('Verifying boot history is now 2...');
+    await verify_boot_count(context, link, test, '2');
+};
+
+const cleanup_disk_watchdog_vars = async (context, link, test) => {
+    test.comment('Setting up clean test environment...');
+
+    // Remove disabled marker if it exists
+    await context
+        .get()
+        .worker.executeCommandInHostOS(
+            `rm -f /mnt/state/disk-watchdog/disabled && : > /mnt/state/disk-watchdog/boot-history`,
+            link,
+        );
+    // Restart services to ensure clean state
+    await context
+        .get()
+        .worker.executeCommandInHostOS(
+            `systemctl restart disk-watchdog-boot-history disk-watchdogd || true`,
+            link,
+        );
+
+    test.comment('Clean test environment ready');
+};
+
+const verify_service_enabled_and_active = async (context, link, test) => {
+    const enabled = await context
+        .get()
+        .worker.executeCommandInHostOS(
+            `systemctl is-enabled disk-watchdogd || true`,
+            link,
+        );
+    test.is(enabled.trim(), 'enabled', 'disk-watchdogd should be enabled');
+
+    // Retry checking service state in case it's still activating
+    let active = '';
+    for (let i = 0; i < 10; i++) {
+        active = await context
+            .get()
+            .worker.executeCommandInHostOS(
+                `systemctl is-active disk-watchdogd || true`,
+                link,
+            );
+        if (active.trim() === 'active') {
+            break;
+        }
+        await new Promise(r => setTimeout(r, 2000));
+    }
+    test.is(active.trim(), 'active', 'disk-watchdogd should be active');
+};
+
+module.exports = {
+    title: 'Disk watchdog test',
+    run: async function(test) {
+        // Setup clean test environment first, as it might have been tempered by previous tests
+        await cleanup_disk_watchdog_vars(this.context, this.link, test);
+
+        // Sanity: service should be enabled and active before inducing failures
+        await verify_service_enabled_and_active(this.context, this.link, test);
+
+        test.comment('Verifying boot history is 1 at boot...');
+        await verify_boot_count(this.context, this.link, test, '1');
+
+        test.comment('Verifying reboot with flakey disk...');
+        await verify_reboot_with_flakey_disk(this.context, this.link, test);
+
+        test.comment('Verifying service is disabled after 3 boots...');
+        await verify_service_disabled(this.context, this.link, test, '3');
+
+        test.comment('Verifying service can\'t be started when it has been disabled...');
+        await verify_service_wont_restart(this.context, this.link, test);
+    },
+};
+


### PR DESCRIPTION
Hey guys,

This PR is the on going work on the disk watchdog.

Please any review will be very appreciated.

Shall we create a new repository for the sources?

Please find the fibery document describing the advancement : https://balena.fibery.io/Sandbox/Custom-watchdog-systemd-service-4222

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [x] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [X] `Signed-off-by` is present
- [X] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
