### PR TITLE
kernel-balena.bbclass: Fix zram module failure when setting algorithm

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -242,7 +242,6 @@ KERNEL_ZSTD = "${@configure_from_version("5.9", "kernel_zstd", "", d)}"
 BALENA_CONFIGS:append = "${@bb.utils.contains('MACHINE_FEATURES','efi'," ${KERNEL_ZSTD}",'',d)}"
 BALENA_CONFIGS[kernel_zstd] = " \
     CONFIG_KERNEL_ZSTD=y \
-    CONFIG_CRYPTO_ZSTD=y \
 "
 
 BALENA_CONFIGS[aufs] = " \
@@ -540,6 +539,7 @@ BALENA_CONFIGS[zram] = " \
     CONFIG_ZRAM=y \
     CONFIG_CRYPTO=y \
     CONFIG_CRYPTO_LZ4=y \
+    CONFIG_CRYPTO_ZSTD=y \
     "
 
 BALENA_CONFIGS:append = " ${@configure_from_version("6.12", " zram_backends", "", d)}"


### PR DESCRIPTION
The initramfs error addressed by this commit is:

    zramctl: /dev/zram1: failed to set algorithm: Invalid argument

zstd is the [default ](https://github.com/balena-os/meta-balena/blob/master/meta-balena-common/recipes-core/initrdscripts/files/zram#L36)algorithm currently used by the zram initramfs module,
which is installed for all device-types. Also, [the crypto API](https://www.kernel.org/doc/Documentation/blockdev/zram.txt) provides
the compression algorithms used by the zram kernel module, so let's make
this available for all devices as built-in, so it is accessible in the
initramfs.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
