### PR TITLE
recipes-support/balena-config-vars: Avoid failure caused by race in c…

### DIFF
--- a/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/balena-config-vars
+++ b/meta-balena-common/recipes-support/balena-config-vars/balena-config-vars/balena-config-vars
@@ -140,11 +140,15 @@ else
         fi
     fi
     if [ -n "${BALENA_CONFIG_VARS_CACHE}" ] && [ -n "${CONFIG_PARAMS}" ]; then
-        tmpfile=$(mktemp)
-        echo "${CONFIG_PARAMS}" | sed -e 's/^[[:space:]]*//' > "${tmpfile}"
-        chmod a+rx "${tmpfile}"
-        mv "${tmpfile}" "${BALENA_CONFIG_VARS_CACHE}"
+        (
+            flock -x 200
+            tmpfile=$(mktemp)
+            echo "${CONFIG_PARAMS}" | sed -e 's/^[[:space:]]*//' > "${tmpfile}"
+            chmod a+rx "${tmpfile}"
+            mv "${tmpfile}" "${BALENA_CONFIG_VARS_CACHE}"
+        ) 200>"${BALENA_CONFIG_VARS_CACHE}.lock"
     fi
+
     eval "$CONFIG_PARAMS"
 fi
 


### PR DESCRIPTION

    
    Services like os-fan-profile or os-power-mode may fail
    at startup due to a race in the creation of the balena-config-vars
    cache:
    
        mv: cannot create regular file '/var/cache/balena-config-vars': File exists
    
    The cache file may bee generated at the same time by another
    instance of the same helper function. To avoid that,
    we now introduce the lock file /var/cache/balena-config-vars.lock
    
    Change-type: patch
    Signed-off-by: Alexandru Costache <alexandru@balena.io>



---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
