### PR TITLE
add CONFIG_DM_FLAKEY for disk-watchdog testing

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -153,7 +153,8 @@ BALENA_CONFIGS ?= " \
     ${MODULE_COMPRESS} \
     ${WIREGUARD} \
     vlan \
-    "
+    disk-watchdog \
+"
 
 #
 # Balena specific kernel configuration
@@ -725,6 +726,11 @@ BALENA_CONFIGS[memcg] = " \
 # 802.1q VLANs are supported by NetworkManager on all device types
 BALENA_CONFIGS[vlan] = " \
     CONFIG_VLAN_8021Q=y \
+"
+
+# Used by disk-watchdog tests
+BALENA_CONFIGS[disk-watchdog] = " \
+    CONFIG_DM_FLAKEY=m \
 "
 
 ###########

--- a/tests/suites/os/tests/disk-watchdog/index.js
+++ b/tests/suites/os/tests/disk-watchdog/index.js
@@ -234,6 +234,13 @@ const verify_service_wont_restart = async (context, link, test) => {
 };
 
 const verify_reboot_with_flakey_disk = async (context, link, test) => {
+    await context
+        .get()
+        .worker.executeCommandInHostOS(
+            `modprobe dm_flakey`,
+            link,
+        );
+
     // Push service
     const ip = await context.get().worker.ip(link);
     await context


### PR DESCRIPTION
Add forgotten CONFIG_DM_FLAKEY for disk-watchdog testing

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [x] Covered in automated test suite
  - [x] Manual test case recorded
- [X] `Change-type` present on at least one commit
- [X] `Signed-off-by` is present
- [X] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
