### PR TITLE
kernel-balena.bbclass: Enable required CONFIG_CGROUP_BPF

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -154,6 +154,7 @@ BALENA_CONFIGS ?= " \
     ${WIREGUARD} \
     vlan \
     disk-watchdog \
+    bpf \
 "
 
 #
@@ -731,6 +732,14 @@ BALENA_CONFIGS[vlan] = " \
 # Used by disk-watchdog tests
 BALENA_CONFIGS[disk-watchdog] = " \
     CONFIG_DM_FLAKEY=m \
+"
+
+# enable CGROUP_BPF required by the supervisor
+BALENA_CONFIGS[bpf] = " \
+    CONFIG_CGROUP_BPF=y \
+"
+BALENA_CONFIGS_DEPS[bpf] = " \
+    CONFIG_BPF_SYSCALL=y \
 "
 
 ###########


### PR DESCRIPTION
This is required to fix the following error:

balena-supervisor[13352]: Error response from daemon: No such container: resin_supervisor
balena-supervisor[13361]: balena_supervisor
balena-supervisor[13370]: active
balena-supervisor[13381]: Container config has not changed
balena-supervisor[13447]: time="2025-11-12T06:15:12Z" level=error msg="error waiting for container: context canceled"
balena-supervisor[13447]: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed:
unable to start container process: error during container init: error setting cgroup config for procHooks process: bpf_prog_query(BPF_CGROUP_DEVICE) failed: function not implemented: unknown

systemd[1]: balena-supervisor.service: Main process exited, code=exited, status=1/FAILURE
systemd[1]: balena-supervisor.service: Failed with result 'exit-code'.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
