### PR TITLE
simplify disk watchdog tests

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -153,8 +153,8 @@ BALENA_CONFIGS ?= " \
     ${MODULE_COMPRESS} \
     ${WIREGUARD} \
     vlan \
-    disk-watchdog \
     bpf \
+    disk-watchdog \
 "
 
 #
@@ -729,17 +729,17 @@ BALENA_CONFIGS[vlan] = " \
     CONFIG_VLAN_8021Q=y \
 "
 
-# Used by disk-watchdog tests
-BALENA_CONFIGS[disk-watchdog] = " \
-    CONFIG_DM_FLAKEY=m \
-"
-
 # enable CGROUP_BPF required by the supervisor
 BALENA_CONFIGS[bpf] = " \
     CONFIG_CGROUP_BPF=y \
 "
 BALENA_CONFIGS_DEPS[bpf] = " \
     CONFIG_BPF_SYSCALL=y \
+"
+
+# Used by disk-watchdog tests
+BALENA_CONFIGS[disk-watchdog] = " \
+    CONFIG_BLK_DEV_DM=y \
 "
 
 ###########

--- a/tests/suites/os/tests/disk-watchdog/Dockerfile.template
+++ b/tests/suites/os/tests/disk-watchdog/Dockerfile.template
@@ -2,8 +2,8 @@ FROM balenalib/%%BALENA_ARCH%%-alpine:3.12-run
 
 RUN apk add device-mapper e2fsprogs bash
 
-COPY create-dm-flakey.sh /usr/bin/create-dm-flakey.sh
-RUN chmod +x /usr/bin/create-dm-flakey.sh
+COPY create-device-mapper.sh /usr/bin/create-device-mapper.sh
+RUN chmod +x /usr/bin/create-device-mapper.sh
 
 COPY entrypoint.sh /usr/bin/entrypoint.sh
 RUN chmod +x /usr/bin/entrypoint.sh

--- a/tests/suites/os/tests/disk-watchdog/disk-watchdog-override.conf
+++ b/tests/suites/os/tests/disk-watchdog/disk-watchdog-override.conf
@@ -1,5 +1,5 @@
 [Service]
 ExecStart=
-ExecStart=/bin/sh -c '/usr/bin/disk-watchdogd -v -f /mnt/state/flakey-mount/test.bin -b 512'
+ExecStart=/bin/sh -c '/usr/bin/disk-watchdogd -v -f /mnt/state/io-error-mount/test.bin -b 512'
 WatchdogSec=
 WatchdogSec=2


### PR DESCRIPTION
Simplifying the disk watchdog tests to avoid relying on flakey DM_FLAKEY driver.

At least two devices are failing at the moment:
https://github.com/balena-os/balena-advantech-mx8/actions/runs/19231791654/job/54976571731?pr=733
https://github.com/balena-os/balena-compulab-imx9/actions/runs/19314182150/job/55252200816?pr=189
https://github.com/balena-os/balena-raspberrypi/actions/runs/19332019907/job/55375012323?pr=1279#step:15:9087

Waiting for 
> https://github.com/balena-os/balena-advantech-mx8/actions/runs/19359477858 (manual action wiith new tests) :ok: 
> https://github.com/balena-os/balena-raspberrypi/actions/runs/19359505128 (manual action with new tests) :ok:
> https://github.com/balena-os/balena-compulab-imx9/actions/runs/19314182150?pr=189 (build rerun as the failure wasn't hopefully related to the test), imx93 has trouble with the os test but is stuck on a bluetooth test for now

To see if the problem is fixed

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [x] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->
