### PR TITLE
renovate.json: Remove custom balena-git package rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,31 +33,12 @@
       "packageNameTemplate": "balena-os/balena-supervisor",
       "datasourceTemplate": "github-tags",
       "extractVersionTemplate": "^v(?<version>.*)$"
-    },
-    {
-      "fileMatch": ["(^|/)balena_git.bb$"],
-      "matchStrings": ["BALENA_VERSION = \"v?(?<currentValue>.*?)\"\\n"],
-      "depNameTemplate": "balena-engine",
-      "packageNameTemplate": "balena-os/balena-engine",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v?(?<version>.*)$"
     }
   ],
   "packageRules": [
     {
       "matchManagers": ["git-submodules"],
       "commitBody": "Update {{depName}}\nChange-type: patch"
-    },
-    {
-      "matchManagers": ["regex"],
-      "matchPackagePatterns": [".*balena-engine"],
-      "postUpgradeTasks": {
-        "commands": [
-          "sed -r \"s|SRCREV = \\\"[0-9a-f]+\\\"|SRCREV = \\\"$(git ls-remote -t {{{sourceUrl}}} refs/tags/v{{{newVersion}}} | awk '{print $1}')\\\"|\" -i {{{packageFile}}}"
-        ],
-        "fileFilters": ["**/balena_git.bb"],
-        "executionMode": "update"
-      }
     },
     {
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
Since 2533a1a we are no longer versioning or tagging balena commits to the engine, so this renovate package rule no longer applies.

Going forward, we will manually bump the commit hash unless we are moving to a new upstream tag.

See: https://balena.fibery.io/Work/Improvement/Update-meta-balena-to-release-v20.10-branch-3412

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
