### PR TITLE
tests: os: secureboot: skip bootloader integrity for imx8mp-var-dart-…

### DIFF
--- a/tests/suites/os/tests/secureboot/index.js
+++ b/tests/suites/os/tests/secureboot/index.js
@@ -465,11 +465,21 @@ class imxSecureBoot extends secureBoot {
 			"waitForFailedBoot() will reject if the device boots successfully",
 		)
 
+		/* Skip all bootloader integrity tests for devices that do not bring link up on boot failure */
+		const skipAllIntegrityDevices = [
+			'imx8mp-var-dart-pl1000pp',
+			'imx8mp-var-dart-pl1000pp-sb',
+		];
+		if (skipAllIntegrityDevices.includes(this.suite.deviceType.slug)) {
+			this.test.comment(`Skipping bootloader integrity tests for ${this.suite.deviceType.slug}`);
+			return;
+		}
+
 		for (const args of tests) {
-			if ( args.name == 'Bootloader' &&
-				( this.suite.deviceType.slug == 'iot-gate-imx8' ||
-				  this.suite.deviceType.slug == 'iot-gate-imx8-sb' ) ) {
-				// iot-gate-imx8 needs U-Boot for flashing to work
+			/* Skip only U-Boot integrity test for devices that need U-Boot for flashing */
+			if (args.name == 'Bootloader' &&
+				(this.suite.deviceType.slug == 'iot-gate-imx8' ||
+				 this.suite.deviceType.slug == 'iot-gate-imx8-sb')) {
 				this.test.comment(`Skipping bootloader integrity test for ${this.suite.deviceType.slug}`);
 				continue;
 			}


### PR DESCRIPTION
…pl1000pp

This device type authenticates the bootloader in the SPL and is not able to bring the ethernet link up before that as the SPL does not have that support.

Changelog-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
