### PR TITLE
recipes-support/os-extra-firmware: Extract extra-firmware volume data path

### DIFF
--- a/meta-balena-common/recipes-support/os-extra-firmware/os-extra-firmware/os-extra-firmware
+++ b/meta-balena-common/recipes-support/os-extra-firmware/os-extra-firmware/os-extra-firmware
@@ -15,10 +15,10 @@ if [[ -z "$OS_EXTRA_FIRMWARE_VOLUME" ]]; then
     # it will be removed.
     bootloader_config_modify "extra_os_firmware_class_path"
 else
-    extra_firmware_volume_path="/var/lib/docker/volumes/${OS_EXTRA_FIRMWARE_VOLUME}"
-    if [ ! -d "${extra_firmware_volume_path}" ]; then
+    extra_firmware_volume_path=$(/usr/bin/balena volume inspect ${OS_EXTRA_FIRMWARE_VOLUME} | /usr/bin/jq -r ".[].Mountpoint")
+    if [ -z "${extra_firmware_volume_path}" ] || [ ! -d "${extra_firmware_volume_path}" ]; then
         # Volume should exist at this point
-        fail "${extra_firmware_volume_path} - path does not exist"
+        fail "${extra_firmware_volume_path} - path is not set or is not a directory"
     fi
 
     kernel_cmdline=$(cat "/proc/cmdline")

--- a/meta-balena-common/recipes-support/os-extra-firmware/os-extra-firmware/os-extra-firmware.service
+++ b/meta-balena-common/recipes-support/os-extra-firmware/os-extra-firmware/os-extra-firmware.service
@@ -2,7 +2,7 @@
 Description=OS extra firmware management service
 DefaultDependencies=no
 Requires=var-volatile.mount
-After=var-volatile.mount resin-boot.service var-lib-docker.mount
+After=var-volatile.mount resin-boot.service var-lib-docker.mount balena.service
 Before=umount.target
 Conflicts=umount.target
 


### PR DESCRIPTION
The volume data path currently is /var/lib/docker/volumes/extra-firmware/_data, but that might change in the future, so let's use the engine to extract the actual value.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
