### PR TITLE
chrony: make default pools optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,12 +193,11 @@ The behavior of balenaOS can be configured by setting the following keys in the 
 
 ### ntpServers
 
-(string) A space-separated list of NTP servers to use for time synchronization. Defaults to `resinio.pool.ntp.org` servers:
+(string) A space-separated list of NTP servers to use for time synchronization.
 
-- `0.resinio.pool.ntp.org`
-- `1.resinio.pool.ntp.org`
-- `2.resinio.pool.ntp.org`
-- `3.resinio.pool.ntp.org`
+- When `ntpServers` is not defined, or empty, the following default pools are added to the chrony configuration: `0.resinio.pool.ntp.org`, `1.resinio.pool.ntp.org`, `2.resinio.pool.ntp.org`, `3.resinio.pool.ntp.org`.
+- When `ntpServers` is "null" (a string), no default pools are added. This is useful when your network provides its own NTP servers via DHCP Option 42 or when no external NTP access is desired.
+- When `ntpServers` is defined and not "null", only the listed servers are added (in addition to any servers supplied through DHCP Option 42).
 
 ### dnsServers
 

--- a/meta-balena-common/recipes-connectivity/balena-ntp-config/balena-ntp-config/balena-ntp-config
+++ b/meta-balena-common/recipes-connectivity/balena-ntp-config/balena-ntp-config/balena-ntp-config
@@ -9,6 +9,8 @@ set -e
 
 SERVER_DIR=/run/chrony
 SERVER_FILE=${SERVER_DIR}/added_config.sources
+DEFAULT_SERVER_FILE=${SERVER_DIR}/default.sources
+DEFAULT_NTP_SERVERS="0.resinio.pool.ntp.org 1.resinio.pool.ntp.org 2.resinio.pool.ntp.org 3.resinio.pool.ntp.org"
 
 if [ ! -f "$CONFIG_PATH" ]; then
 	echo "balena-ntp-config: $CONFIG_PATH does not exist."
@@ -25,12 +27,26 @@ fi
 if [ -f "$SERVER_FILE" ]; then
 	rm -f $SERVER_FILE
 fi
+if [ -f "$DEFAULT_SERVER_FILE" ]; then
+	rm -f $DEFAULT_SERVER_FILE
+fi
 
-if [ ! -z "$NTP_SERVERS" ]; then
-	echo "Adding NTP sources (config.json)"
-	for server in ${NTP_SERVERS}; do
-		echo "pool $server iburst minpoll 14 maxpoll 14 maxsources 1" >> $SERVER_FILE
+add_servers() {
+	local target_file=$1
+	local servers=$2
+	for server in $servers; do
+		echo "pool $server iburst minpoll 14 maxpoll 14 maxsources 1" >> "$target_file"
 	done
+}
+
+if [ "$NTP_SERVERS" = "null" ]; then
+	echo "balena-ntp-config: Default NTP sources disabled via config.json"
+elif [ -n "$NTP_SERVERS" ]; then
+	echo "Adding NTP sources (config.json)"
+	add_servers "$SERVER_FILE" "$NTP_SERVERS"
+else
+	echo "balena-ntp-config: Using default NTP sources"
+	add_servers "$DEFAULT_SERVER_FILE" "$DEFAULT_NTP_SERVERS"
 fi
 
 # Always update the sources as they may have been added or removed.

--- a/meta-balena-common/recipes-core/chrony/files/chrony.conf
+++ b/meta-balena-common/recipes-core/chrony/files/chrony.conf
@@ -1,7 +1,3 @@
-pool 0.resinio.pool.ntp.org iburst minpoll 14 maxpoll 14 maxsources 1
-pool 1.resinio.pool.ntp.org iburst minpoll 14 maxpoll 14 maxsources 1
-pool 2.resinio.pool.ntp.org iburst minpoll 14 maxpoll 14 maxsources 1
-pool 3.resinio.pool.ntp.org iburst minpoll 14 maxpoll 14 maxsources 1
 sourcedir /run/chrony
 driftfile /var/lib/chrony/drift
 maxupdateskew 100


### PR DESCRIPTION
## Summary
- remove the hardcoded `resinio.pool.ntp.org` pools from `chrony.conf`
- generate default pools at runtime unless `ntpServers` is `"null"`, keeping defaults and custom lists in separate chrony source files
- document the three `ntpServers` behaviours in `README.md`

Fixes #3680

Change-type: patch

### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)