### PR TITLE
Update vacuum-size to 128M to match vacuum.conf and journald-balena-os.conf

### DIFF
--- a/meta-balena-common/recipes-core/systemd/periodic-vacuum-logs/periodic-vacuum-logs.service
+++ b/meta-balena-common/recipes-core/systemd/periodic-vacuum-logs/periodic-vacuum-logs.service
@@ -2,4 +2,4 @@
 After=systemd-journald.service
 
 [Service]
-ExecStart=/bin/journalctl --vacuum-size=32M
+ExecStart=/bin/journalctl --vacuum-size=128M


### PR DESCRIPTION
In PR #3628 @alexgg increased the size of journald logs from 32M to 128M in vacuum.conf and journald-balena-os.conf

We discovered that our logs were still being purged down to ~32M overnight, and following an investigation, noticed that this limit is also hardcoded in periodic-vacuum-logs.service

This PR increases the limit to 128M in this systemd service file for consistency with the others. With this change applied our logs are now purged to ~128M overnight

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
