### PR TITLE
balena-bootloader.bbclass: Size reduction

### DIFF
--- a/meta-balena-common/classes/balena-bootloader.bbclass
+++ b/meta-balena-common/classes/balena-bootloader.bbclass
@@ -501,6 +501,16 @@ BALENA_CONFIGS[crypto] = " \
     CONFIG_CRYPTO_SHA256=y \
     "
 
+# shrink size by removing unneeded functionality in balena-bootloader so we have enough space in the boot partition
+BALENA_CONFIGS:append = "shrink_size"
+BALENA_CONFIGS[shrink_size] = " \
+    CONFIG_CHROME_PLATFORMS=n \
+    CONFIG_MFD_CORE=n \
+    CONFIG_NEW_LEDS=n \
+    CONFIG_PPS=n \
+    CONFIG_VFIO=n \
+"
+
 ###########
 # HELPERS #
 ###########


### PR DESCRIPTION
Newer meta-balena updates are failing for iot-gate-imx8plus-sb with the error: ERROR: balena-image-flasher-1.0-r0 do_resin_boot_dirgen_and_deploy: resin-boot: Not enough space for atomic copy operations.

In order to have the size reduction available for all balena-bootloader users we do these changes directly here in the balena-bootloader class.

Changelog-entry: Reduce the size of the balena bootloader by removing unused functionality
Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
