### PR TITLE
initrdscripts: Unlock mutex if regenerate_uuid fails in fsuuidsinit

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/fsuuidsinit
+++ b/meta-balena-common/recipes-core/initrdscripts/files/fsuuidsinit
@@ -68,6 +68,7 @@ fsuuidsinit_run() {
                 info "Using new root UUID: ${bootparam_root}"
             fi
         else
+            rm -f "/run/initramfs/bootparam_root.mux"
             error "UUIDs not regenerated - retry on next boot"
             return
         fi


### PR DESCRIPTION
In commit 3f6a302bf53c6c0a609015c92ff927c7575412d9 we've introduced a mutex that prevents a race condition between the fsuuidsinit script changing FS UUIDs and udev creating the by-state symlinks. This mutex is never unlocked if the FS UUID change fails and leaks out from the initrd into the final system, where it blocks the 65-resin-update-state udev rule from properly executing. The system will usually somewhat come up, but fail in weird ways, e.g. automounts not working.

This patch unlocks the mutex on failure.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
