### PR TITLE
tests/extra-firmware: Skip post-reboot extra firmware check for a specific device type

### DIFF
--- a/tests/suites/os/tests/extra-firmware/index.js
+++ b/tests/suites/os/tests/extra-firmware/index.js
@@ -325,6 +325,11 @@ module.exports = {
             // Step 6: Load module - expect firmware FOUND and VERIFIED
             await testFirmwareFound(worker, link, test);
 
+            if (this.suite.deviceType.slug == 'srd3-xavier') {
+                test.comment('Skipping extra-firmware post-reboot test on Jetpack 4 Xavier AGX');
+                return;
+            }
+
             // Step 7: Reboot
             await worker.rebootDut(link);
 


### PR DESCRIPTION
... on which the cboot bootloader does not have FAT support to access the extra_uEnv.txt environment file.

This device-type uses an old version of Jetpack - 4.0 - which does not have uboot / grub / UEFI EDK2 support, nor does it use balena-bootloader. We thus switch to running only the runtime portion of the extra-firmware test.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
