### PR TITLE
balena-bootloader.bbclass: Further size reduction

### DIFF
--- a/meta-balena-common/classes/balena-bootloader.bbclass
+++ b/meta-balena-common/classes/balena-bootloader.bbclass
@@ -78,6 +78,7 @@ BALENA_CONFIGS ?= " \
     nls \
     misc \
     ${@oe.utils.conditional('SIGN_API','','',' crypto',d)} \
+    shrink_size \
     "
 
 #
@@ -508,6 +509,7 @@ BALENA_CONFIGS[shrink_size] = " \
     CONFIG_MFD_CORE=n \
     CONFIG_NEW_LEDS=n \
     CONFIG_PPS=n \
+    CONFIG_PTP_1588_CLOCK=n \
     CONFIG_VFIO=n \
 "
 


### PR DESCRIPTION
This disables support for PTP clock since it's not something I foresee us needing in the balena bootloader.

Additionaly, fix the actual bootloader shrinking since the initial commit which introduced this did not effectively add the disabling of these options to the .config

Changelog-entry: Further reduce the size of the balena bootloader by removing PTP clock support
Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
