### PR TITLE
Revert "packagegroup-resin: Add systemd-analyze to production images …

### DIFF
--- a/meta-balena-common/recipes-core/packagegroups/packagegroup-resin.inc
+++ b/meta-balena-common/recipes-core/packagegroups/packagegroup-resin.inc
@@ -8,7 +8,7 @@ PACKAGE_ARCH = "${TUNE_PKGARCH}"
 inherit packagegroup
 
 RDEPENDS:${PN} = " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd-analyze', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', bb.utils.contains('DISTRO_FEATURES', 'osdev-image', 'systemd-analyze', '', d), '', d)} \
     ${BALENA_INIT_PACKAGE} \
     ${BALENA_MOUNTS} \
     ${BALENA_REGISTER} \


### PR DESCRIPTION
…as well"

This reverts commit ae99502356d994dee5896164afbe7df8bde00d6a to free up rootfs space.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
