### PR TITLE
tests:modem: Disable for kontron-come-xelx

### DIFF
--- a/tests/suites/os/tests/modem/index.js
+++ b/tests/suites/os/tests/modem/index.js
@@ -23,6 +23,12 @@ const PING_ATTEMPTS = 3;
 module.exports = {
     title: 'Cellular tests',
     run: async function (test) {
+
+        if (this.suite.deviceType.slug == 'kontron-come-xelx') {
+            test.comment('Skipping modem test on Kontron COMe xELx');
+            return;
+        }
+
         test.comment('starting modem tests...');
 
         async function getConfig() {


### PR DESCRIPTION
Currently the modem is not used on this device type

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
