### PR TITLE
tests/modem: Skip modem test on unsupported Orin device-type

### DIFF
--- a/tests/suites/os/tests/modem/index.js
+++ b/tests/suites/os/tests/modem/index.js
@@ -24,8 +24,8 @@ module.exports = {
     title: 'Cellular tests',
     run: async function (test) {
 
-        if (this.suite.deviceType.slug == 'kontron-come-xelx') {
-            test.comment('Skipping modem test on Kontron COMe xELx');
+        if (this.suite.deviceType.slug == 'kontron-come-xelx' || this.suite.deviceType.slug == 'jetson-orin-nx-es') {
+            test.comment(`Skipping modem test on ${this.suite.deviceType.slug}`);
             return;
         }
 


### PR DESCRIPTION
This particular device-type has an e-SIM and cannot be tested in our autokit. Connectivity will be tested by the vendor.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
