### PR TITLE
Update mobynit to v1.0.0

### DIFF
--- a/docs/host-extensions.md
+++ b/docs/host-extensions.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-BalenaOS supports layering the root filesystem with content from hostapp extension containers. In essence, hostapp extensions are container images flagged with the `balena.io.features.host-extension` label that are overlayed during the early boot process.
+BalenaOS supports layering the root filesystem with content from hostapp extension containers. In essence, hostapp extensions are container images flagged with the `io.balena.image.class=overlay` label that are overlayed during the early boot process.
 
 Hostapp extension containers are meant to extend or modify the root filesystem in a managed way, and to house content that cannot be placed on an application container.
 
@@ -14,11 +14,11 @@ The last stage of a hostapp extension container is shown next:
 
     FROM scratch
 
-    LABEL io.balena.features.host-extension=1
+    LABEL io.balena.image.class=overlay
 
     COPY --from=builder /hostext /
 
-The example Dockerfile above starts with an empty container, then adds the `io.balena.features.host-extension` label so that BalenaOS can identify it and overlay it at boot, and finally the desired content is copied from a space holder directory to the root of this container. Care should be taken not to shadow root filesystem content which is essential for BalenaOS to function.
+The example Dockerfile above starts with an empty container, then adds the `io.balena.image.class=overlay` label so that BalenaOS can identify it and overlay it at boot, and finally the desired content is copied from a space holder directory to the root of this container. Care should be taken not to shadow root filesystem content which is essential for BalenaOS to function.
 
 ## Managing hostapp extensions
 
@@ -28,7 +28,7 @@ Extensions are meant to be managed by the supervisor or as part of a hostOS upda
 
 An incorrect hostapp extension can leave your system in a non-working state. Balena advises against deploying custom made hostapp extensions and recommends to either use the hostapp extensions included as part of BalenaOS releases, or let the supervisor manage the installation, update and removal of production ready hostapp extensions.
 
-The overlaying of hostapp extensions can be disabled by specifying a `balena.nohostext` argument to the kernel command line.
+The overlaying of hostapp extensions can be disabled by specifying a `mobynit.no_overlays` argument to the kernel command line.
 
 ## Caveats
 

--- a/docs/host-extensions.md
+++ b/docs/host-extensions.md
@@ -8,6 +8,18 @@ Hostapp extension containers are meant to extend or modify the root filesystem i
 
 When deciding whether to use a hostapp extension for your content, first consider whether there is any reason why it could not be added to a standard application container.
 
+## How it works
+
+Mobynit runs as PID 1 and discovers container overlay filesystems by reading overlay2 metadata directly, without relying on Docker packages. During boot, it:
+
+1. Mounts the hostapp container (identified via a `current` symlink)
+2. Layers OS block containers marked with `io.balena.image.class=overlay`
+3. Relocates existing mounts into the new root filesystem
+4. Executes `pivot_root` to switch the system root
+5. Execs `/sbin/init`
+
+The rootfs is mounted as overlayfs lowerdirs and is intrinsically read-only.
+
 ## Building a hostapp extension container
 
 The last stage of a hostapp extension container is shown next:
@@ -18,7 +30,24 @@ The last stage of a hostapp extension container is shown next:
 
     COPY --from=builder /hostext /
 
-The example Dockerfile above starts with an empty container, then adds the `io.balena.image.class=overlay` label so that BalenaOS can identify it and overlay it at boot, and finally the desired content is copied from a space holder directory to the root of this container. Care should be taken not to shadow root filesystem content which is essential for BalenaOS to function.
+The example Dockerfile above starts with an empty container, then adds the `io.balena.image.class=overlay` label so that BalenaOS can identify it and overlay it at boot, and finally the desired content is copied from a space holder directory to the root of this container.
+
+By default, extensions are mounted to the right of the hostapp in the overlayfs lowerdir stack, meaning they can only contribute new files — they cannot replace existing hostapp content.
+
+## Mount ordering
+
+Extensions can define a mount order using the `io.balena.image.override=N` label, where N is a numeric priority. Extensions with this label are mounted to the left of the hostapp in the overlayfs lowerdir stack, enabling them to replace existing hostapp files. Lower N values have higher overlayfs precedence. Equal priorities sort by container name for deterministic behavior.
+
+    FROM scratch
+
+    LABEL io.balena.image.class=overlay
+    LABEL io.balena.image.override=10
+
+    COPY --from=builder /hostext /
+
+In overlayfs terminology, `lowerdir=A:B:C` means A has the highest lookup priority. The resulting lowerdir is: `lowerdir=<extensions with override sorted by N>:<hostapp>:<extensions without override>`.
+
+Care should be taken not to shadow root filesystem content which is essential for BalenaOS to function.
 
 ## Managing hostapp extensions
 
@@ -28,10 +57,12 @@ Extensions are meant to be managed by the supervisor or as part of a hostOS upda
 
 An incorrect hostapp extension can leave your system in a non-working state. Balena advises against deploying custom made hostapp extensions and recommends to either use the hostapp extensions included as part of BalenaOS releases, or let the supervisor manage the installation, update and removal of production ready hostapp extensions.
 
-The overlaying of hostapp extensions can be disabled by specifying a `mobynit.no_overlays` argument to the kernel command line.
+The overlaying of hostapp extensions can be disabled by specifying either of the following kernel command line arguments:
+
+* `mobynit.no_overlays`
+* `emergency`
 
 ## Caveats
 
-* Once BalenaOS has overlayed a hostapp extension the root filesystem cannot be remounted read-write.
-* Hostapp extensions are only supported for overlay2 filesystems
-* The numbers of extensions that can be mounted is capped by the length of the options passed to the kernel's do_mount() function which is currently the system's page size. For the typical paths in BalenaOS this is around 20 containers.
+* The root filesystem is intrinsically read-only when hostapp extensions are layered.
+* Hostapp extensions require the overlay2 storage driver.

--- a/docs/os-internals.md
+++ b/docs/os-internals.md
@@ -23,6 +23,6 @@ graph TD
     E --> F(udev by-state symlinks)
     F --> G{Balena UUIDs?} -- N --> H(Regenerate UUIDs) --> I(New root UUID stored in /run/initramfs for first boot) --> J(Mount rootfs using UUID)
     G -- Y --> J --> K
-    K(Switch root) --> L(Mobyinit) --> M(Pivot root disk/by-state/active) --> N(systemd) --> O(resin-mount using /dev/by-state)
+    K(Switch root) --> L(Mobynit) --> M("Mount overlay union (lowerdirs)") --> M2(Pivot root) --> N(systemd) --> O(resin-mount using /dev/by-state)
     O --> P(resin-boot) & Q(resin-state) & R(resin-data)
 ```

--- a/meta-balena-common/recipes-containers/docker-disk/files/entry.sh
+++ b/meta-balena-common/recipes-containers/docker-disk/files/entry.sh
@@ -45,10 +45,11 @@ done
 echo "Docker started."
 
 # Pull in host extension images
-BALENA_HOSTAPP_EXTENSIONS_FEATURE="io.balena.features.host-extension"
+BALENA_HOSTAPP_EXTENSIONS_LABEL="io.balena.image.class"
+BALENA_HOSTAPP_EXTENSIONS_VALUE="overlay"
 for image_name in ${HOSTEXT_IMAGES}; do
 	if docker pull --platform "${HOSTAPP_PLATFORM}" "${image_name}"; then
-		docker create --label "${BALENA_HOSTAPP_EXTENSIONS_FEATURE}" "${image_name}" none
+		docker create --label "${BALENA_HOSTAPP_EXTENSIONS_LABEL}=${BALENA_HOSTAPP_EXTENSIONS_VALUE}" "${image_name}" none
 	else
 		echo "Not able to pull ${image_name} for ${HOSTAPP_PLATFORM}"
 		exit 1

--- a/meta-balena-common/recipes-containers/hostapp-extensions-update/files/update-hostapp-extensions
+++ b/meta-balena-common/recipes-containers/hostapp-extensions-update/files/update-hostapp-extensions
@@ -5,7 +5,8 @@ set -e
 # shellcheck disable=SC1091
 . /usr/libexec/os-helpers-logging
 
-BALENA_HOSTAPP_EXTENSIONS_FEATURE="io.balena.features.host-extension"
+BALENA_HOSTAPP_EXTENSIONS_LABEL="io.balena.image.class"
+BALENA_HOSTAPP_EXTENSIONS_VALUE="overlay"
 BALENA_HOSTAPP_EXTENSIONS_DEFAULT="/etc/hostapp-extensions.conf"
 DOCKER_OVERLAY_ROOT="/var/lib/docker/overlay2/"
 
@@ -14,15 +15,19 @@ usage() {
 	cat <<EOF
 Usage: ${script_name} [OPTIONS]
 	-t Space separated list of repository tags for hostapp extension containers
+	-l Additional labels to apply (comma-separated key=value pairs)
 	-r Reboot after update
 EOF
 	exit 0
 }
 
-while getopts 'hrt:' flag; do
+extra_labels=""
+
+while getopts 'hrt:l:' flag; do
 	case "${flag}" in
 	r) reboot=1 ;;
 	t) target_hostext_images="${OPTARG}" ;;
+	l) extra_labels="${OPTARG}" ;;
 	h) usage ;;
 	*) error "Unexpected option ${flag}" ;;
 	esac
@@ -111,7 +116,7 @@ done
 
 info "Removing previous hostapp extensions"
 
-for image in $(${DOCKER} images --all --quiet --filter label="${BALENA_HOSTAPP_EXTENSIONS_FEATURE}"); do
+for image in $(${DOCKER} images --all --quiet --filter "label=${BALENA_HOSTAPP_EXTENSIONS_LABEL}=${BALENA_HOSTAPP_EXTENSIONS_VALUE}"); do
 	imagetag=$(${DOCKER} inspect "${image}" --format='{{index .RepoTags 0}}' 2>/dev/null)
 	cids=$(${DOCKER} ps --all --quiet --no-trunc --filter ancestor="${image}" | tr '\n' ' ')
 	case "${target_hostext_images}" in
@@ -145,7 +150,15 @@ if [ -n "${target_hostext_images}" ]; then
 			error "   - failed to install"
 			break
 		else
-			if ! ${DOCKER} create --runtime="bare" --label "${BALENA_HOSTAPP_EXTENSIONS_FEATURE}" "${hostext}" none  > /dev/null 2>&1; then
+			# Build label arguments
+			label_args="--label ${BALENA_HOSTAPP_EXTENSIONS_LABEL}=${BALENA_HOSTAPP_EXTENSIONS_VALUE}"
+			if [ -n "${extra_labels}" ]; then
+				for label in $(echo "${extra_labels}" | tr ',' ' '); do
+					label_args="${label_args} --label ${label}"
+				done
+			fi
+			# shellcheck disable=SC2086
+			if ! ${DOCKER} create --runtime="bare" ${label_args} "${hostext}" none  > /dev/null 2>&1; then
 				error "   - failed to spawn"
 				break
 			fi

--- a/meta-balena-common/recipes-containers/mobynit/mobynit_git.bb
+++ b/meta-balena-common/recipes-containers/mobynit/mobynit_git.bb
@@ -10,7 +10,8 @@ RDEPENDS:${PN} = "util-linux"
 
 GO_IMPORT = "github.com/balena-os/mobynit"
 SRC_URI = "git://${GO_IMPORT};nobranch=1;protocol=https"
-SRCREV="0423d69ee52970bb8eeae46da8f1d5cf7a8c948c"
+# v1.0.0
+SRCREV="68b5fba96640392b591d27d243b891f657d7d02b"
 
 S = "${WORKDIR}/${BPN}/src/${GO_IMPORT}"
 

--- a/meta-balena-common/recipes-core/balena-rollback/files/rollback-health
+++ b/meta-balena-common/recipes-core/balena-rollback/files/rollback-health
@@ -38,10 +38,13 @@ run_hooks_from_inactive () {
 	mount -o bind /run "${old_rootfs}/run"
 	mount --bind /mnt/boot/ "${old_rootfs}/mnt/boot/"
 	mount --bind /mnt/state/ "${old_rootfs}/mnt/state/"
+	mount --bind /mnt/data/ "${old_rootfs}/mnt/data/"
 	mount --bind /mnt/sysroot/ "${old_rootfs}/mnt/sysroot/"
 	mount --bind /mnt/sysroot/active/ "${old_rootfs}/mnt/sysroot/active/"
 	mount --bind /mnt/sysroot/inactive/ "${old_rootfs}/mnt/sysroot/inactive/"
 	mount -t sysfs sysfs "${old_rootfs}/sys/"
+	mount -t tmpfs tmpfs "${old_rootfs}/tmp/"
+	mount -t tmpfs tmpfs "${old_rootfs}/var/cache/"
 
 	# Allow old OS hooks to access efivars
 	if [ -d /sys/firmware/efi/efivars ]; then


### PR DESCRIPTION
Note this is a major release - the breaking change is that the rootfs is now inherently read only.

Relates to: https://balena.fibery.io/Work/Project/Hostapp-overlay-extensions---core-boot-infrastructure-2330
Breaking change announcement: https://balena.fibery.io/Work/Project/Hostapp-overlay-extensions---core-boot-infrastructure-2330/Breaking-changes-for-balenaOS-v7.x-4923

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
