### PR TITLE
image_types_balena.bbclass: Double the default size of the rootfs par…

### DIFF
--- a/meta-balena-common/classes/image_types_balena.bbclass
+++ b/meta-balena-common/classes/image_types_balena.bbclass
@@ -92,12 +92,12 @@ def disk_aligned(d, rootfs_size):
     return rootfs_size
 
 # The rootfs size is calculated by substracting from the maximum BalenaOS image
-# 700 MiB size, the size  of all other partitions except the data partition,
+# 1340 MiB size, the size  of all other partitions except the data partition,
 # dividing by 2, and substracting filesystem metadata and reserved allocations
 def balena_rootfs_size(d):
     boot_part_size = int(d.getVar("BALENA_BOOT_SIZE"))
     state_part_size = int(d.getVar("BALENA_STATE_SIZE"))
-    balena_rootfs_size = int(((700 * 1024) - boot_part_size - state_part_size) / 2)
+    balena_rootfs_size = int(((1340 * 1024) - boot_part_size - state_part_size) / 2)
     return int(disk_aligned(d, balena_rootfs_size))
 
 BALENA_BOOT_FS_LABEL ?= "resin-boot"


### PR DESCRIPTION
…titions

This commit changes the default rootfs partition sizes of new devices added to balena to 640 MiB. Existing devices will need to override this value in order to keep using the old 320 MiB sizes.

Change-type: minor


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
