### PR TITLE
libmbim: Prepare for Yocto Wrynose

### DIFF
--- a/meta-balena-common/recipes-connectivity/libmbim/libmbim_1.32.0.bb
+++ b/meta-balena-common/recipes-connectivity/libmbim/libmbim_1.32.0.bb
@@ -14,8 +14,6 @@ inherit meson pkgconfig bash-completion gobject-introspection
 SRCREV = "2bc1080292aae30000e808ec77d7a99b87eb3553"
 SRC_URI = "git://gitlab.freedesktop.org/mobile-broadband/libmbim.git;protocol=https;branch=mbim-1-32"
 
-S = "${WORKDIR}/git"
-
 EXTRA_OEMESON = " \
     -Dgtk_doc=false \
     -Dman=false \

--- a/meta-balena-dunfell/recipes-connectivity/libmbim/libmbim_%.bbappend
+++ b/meta-balena-dunfell/recipes-connectivity/libmbim/libmbim_%.bbappend
@@ -1,0 +1,1 @@
+S = "${WORKDIR}/git"

--- a/meta-balena-kirkstone/recipes-connectivity/libmbim/libmbim_%.bbappend
+++ b/meta-balena-kirkstone/recipes-connectivity/libmbim/libmbim_%.bbappend
@@ -1,0 +1,1 @@
+S = "${WORKDIR}/git"

--- a/meta-balena-scarthgap/recipes-connectivity/libmbim/libmbim_%.bbappend
+++ b/meta-balena-scarthgap/recipes-connectivity/libmbim/libmbim_%.bbappend
@@ -1,0 +1,1 @@
+S = "${WORKDIR}/git"


### PR DESCRIPTION
Yocto Wrynose does not allow setting S anymore since it is now implicitly set correctly by the build system.

To keep compatibility with older supported Yocto versions, we still define S in the respective meta-balena-<Yocto_release> subdirectories.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
