### PR TITLE
tests: cloud: Stop waiting for healthy supervisor in cloud suite befo…

### DIFF
--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -501,18 +501,6 @@ module.exports = {
 			'balena Engine should be running and healthy'
 		)
 
-		// we want to waitUntil here as the supervisor may take some time to come online.
-		await test.resolves(
-			this.utils.waitUntil(async () => {
-				let healthy = await this.worker.executeCommandInHostOS(
-				`curl --max-time 10 "localhost:48484/v1/healthy"`,
-				this.link
-				)
-				return (healthy === 'OK')
-			}, true, 120, 250),
-			'Supervisor should be running and healthy'
-		)
-
     // Retrieving journalctl logs: register teardown after device is reachable
     this.suite.teardown.register(async () => {
       await this.worker.archiveLogs(this.id, this.balena.uuid);


### PR DESCRIPTION
…re preload test

In the cloud suite we provision the device with no internet - to test that the prloaded app starts on first boot without api access. Supervisor 17.6.26 fixed a supervisor connectivity healthcheck, that causes the supervisor to now correctly report as non healthy if there is no connectivity. This caused a failure in the cloud suite where we were waiting for a healthy supervisor to continue to the preloaded app test, but as the internet is disabled until we complete that test, we were waiting until the test timed out.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
