### PR TITLE
bug: balena-os.inc: set User-Agent for wget FETCHCMD to fix crates.io HTTP 403

### DIFF
--- a/meta-balena-common/conf/distro/include/balena-os.inc
+++ b/meta-balena-common/conf/distro/include/balena-os.inc
@@ -3,6 +3,11 @@ require conf/distro/poky.conf
 include conf/distro/include/balena-os-yocto-version.inc
 include conf/distro/include/balena-os-rust-version.inc
 
+# crates.io now rejects requests without a proper User-Agent (HTTP 403).
+# bitbake's default wget command does not pass a User-Agent, which causes
+# Rust crate fetches (crate://) to fail. Force a User-Agent so fetches work.
+FETCHCMD:wget = "/usr/bin/env wget -t 2 -T 100 --user-agent=balena-yocto-build --progress=dot -v"
+
 DISTRO = "balena-os"
 DISTRO_NAME = "balenaOS"
 DISTRO_VERSION = "7.0.0"

--- a/meta-balena-common/conf/distro/include/balena-os.inc
+++ b/meta-balena-common/conf/distro/include/balena-os.inc
@@ -8,7 +8,7 @@ include conf/distro/include/balena-os-rust-version.inc
 # Rust crate fetches (crate://) to fail. Force a User-Agent so fetches work.
 # NOTE: FETCHCMD_wget is a literal variable name (read via d.getVar in
 # bitbake's wget fetcher); the override-syntax form FETCHCMD:wget is not
-# applied because "wget" is not in OVERRIDES.
+# applied because "wget" is not in OVERRIDES. 
 FETCHCMD_wget = "/usr/bin/env wget -t 2 -T 100 --user-agent=balena-yocto-build --progress=dot -v"
 
 DISTRO = "balena-os"

--- a/meta-balena-common/conf/distro/include/balena-os.inc
+++ b/meta-balena-common/conf/distro/include/balena-os.inc
@@ -6,7 +6,10 @@ include conf/distro/include/balena-os-rust-version.inc
 # crates.io now rejects requests without a proper User-Agent (HTTP 403).
 # bitbake's default wget command does not pass a User-Agent, which causes
 # Rust crate fetches (crate://) to fail. Force a User-Agent so fetches work.
-FETCHCMD:wget = "/usr/bin/env wget -t 2 -T 100 --user-agent=balena-yocto-build --progress=dot -v"
+# NOTE: FETCHCMD_wget is a literal variable name (read via d.getVar in
+# bitbake's wget fetcher); the override-syntax form FETCHCMD:wget is not
+# applied because "wget" is not in OVERRIDES.
+FETCHCMD_wget = "/usr/bin/env wget -t 2 -T 100 --user-agent=balena-yocto-build --progress=dot -v"
 
 DISTRO = "balena-os"
 DISTRO_NAME = "balenaOS"


### PR DESCRIPTION
### Contributor checklist
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [x] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
```

## Suggested commit message (matches OE guidelines)

```
balena-os.inc: set User-Agent for wget FETCHCMD to fix crates.io HTTP 403

crates.io rejects HTTP requests without a recognizable User-Agent
(returns HTTP 403), causing every Rust crate fetch to fail with wget
exit code 8 and aborting builds for any Rust-based recipe (e.g.
healthdog, fatrw).

Override FETCHCMD_wget at the distro level to pass --user-agent so
crate:// (and any other wget-based) fetches succeed.

Use the literal variable name FETCHCMD_wget; the override-syntax form
FETCHCMD:wget is silently ignored by bitbake's wget fetcher because
"wget" is not in OVERRIDES.