### PR TITLE
remove all bins from nss to save some place

### DIFF
--- a/meta-balena-common/recipes-support/nss/nss_%.bbappend
+++ b/meta-balena-common/recipes-support/nss/nss_%.bbappend
@@ -1,5 +1,13 @@
+# We only need the library from the NSS package
+# so we are removing everything else
+
 # package some test binaries in a separate package which we won't include in the rootfs
 PACKAGES =+ "${PN}-test-bins"
 FILES:${PN}-test-bins = "\
-    ${bindir}/*test \
+    ${bindir}/* \
+"
+
+PACKAGES =+ "${PN}-test-libs"
+FILES:${PN}-test-libs = "\
+    ${libdir}/libnssckbi-testlib.so \
 "


### PR DESCRIPTION
Fibery hunch:

https://balena.fibery.io/Inputs/Hunch/Remove-NSS-dev-test-benchmark-binaries-from-balenaOS-rootfs-1664

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
