### PR TITLE
tests: Define imx8mmebcrs16a1 as flasherConfig type

### DIFF
--- a/tests/suites/cloud/suite.js
+++ b/tests/suites/cloud/suite.js
@@ -36,6 +36,7 @@ const supportsBootConfig = (deviceType) => {
 const flasherConfig = (deviceType) => {
 	return (
 		[
+			'imx8mmebcrs16a1',
 			'imx8mm-var-dart-plt'
 		].includes(deviceType)
 	);

--- a/tests/suites/hup/suite.js
+++ b/tests/suites/hup/suite.js
@@ -38,6 +38,7 @@ const supportsBootConfig = (deviceType) => {
 const flasherConfig = (deviceType) => {
 	return (
 		[
+			'imx8mmebcrs16a1',
 			'imx8mm-var-dart-plt'
 		].includes(deviceType)
 	);

--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -45,6 +45,7 @@ const externalAnt = (deviceType) => {
 const flasherConfig = (deviceType) => {
 	return (
 		[
+			'imx8mmebcrs16a1',
 			'imx8mm-var-dart-plt'
 		].includes(deviceType)
 	);


### PR DESCRIPTION
This allows us to boot the flasher image from microSD even when the bootswitch is set to eMMC boot. This is needed for automated testing.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
