### PR TITLE
os-extra-firmware: Make the systemd service ExecStart the script dire…

### DIFF
--- a/meta-balena-common/recipes-support/os-extra-firmware/os-extra-firmware/os-extra-firmware.service
+++ b/meta-balena-common/recipes-support/os-extra-firmware/os-extra-firmware/os-extra-firmware.service
@@ -9,7 +9,7 @@ Conflicts=umount.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=@BASE_BINDIR@/sh @BINDIR@/os-extra-firmware
+ExecStart=@BINDIR@/os-extra-firmware
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
…ctly

Explicitly calling the sh interpreter makes the service fail on Dunfell based devices.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
