### PR TITLE
meta-balena-dunfell:os-extra-firmware: Make the systemd service ExecS…

### DIFF
--- a/meta-balena-dunfell/recipes-support/os-extra-firmware/files/os-extra-firmware-override.conf
+++ b/meta-balena-dunfell/recipes-support/os-extra-firmware/files/os-extra-firmware-override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=@BINDIR@/os-extra-firmware

--- a/meta-balena-dunfell/recipes-support/os-extra-firmware/os-extra-firmware.bbappend
+++ b/meta-balena-dunfell/recipes-support/os-extra-firmware/os-extra-firmware.bbappend
@@ -1,0 +1,14 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://os-extra-firmware-override.conf"
+
+do_install:append() {
+    install -d ${D}${systemd_system_unitdir}/os-extra-firmware.service.d
+    install -m 0644 ${WORKDIR}/os-extra-firmware-override.conf ${D}${systemd_system_unitdir}/os-extra-firmware.service.d/
+
+    sed -i -e 's,@BASE_BINDIR@,${base_bindir},g' \
+            -e 's,@BINDIR@,${bindir},g' \
+            ${D}${systemd_system_unitdir}/os-extra-firmware.service.d/*
+}
+
+FILES:${PN} += "${systemd_system_unitdir}/os-extra-firmware.service.d/os-extra-firmware-override.conf"


### PR DESCRIPTION
…tart the script directly

Explicitly calling the sh interpreter makes the service fail on Dunfell based devices.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
