### PR TITLE
kernel-balena: address dirty frag vulnerability

### DIFF
--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -157,10 +157,19 @@ BALENA_CONFIGS ?= " \
     disk-watchdog \
     dmabuf \
     cve_2026_31431 \
+    cve_2026_43284 \
 "
 
 # CVE-2026-31431: unconditionally disable CONFIG_CRYPTO_USER_API_AEAD
 BALENA_CONFIGS[cve_2026_31431] = "CONFIG_CRYPTO_USER_API_AEAD=n"
+
+# CVE-2026-43284: disable IPsec ESP (esp4/esp6) and RxRPC
+BALENA_CONFIGS[cve_2026_43284] = " \
+    CONFIG_INET_ESP=n \
+    CONFIG_INET6_ESP=n \
+    CONFIG_AF_RXRPC=n \
+    "
+
 
 #
 # Balena specific kernel configuration


### PR DESCRIPTION
This commit removes the esp4/esp6 and rxrpc modules as they are vulnerable to a yet unpatched and unnamed CVE.

Devices will not be able to use IPSEC based VPNs (esp4/esp6). The only consumer of rxrpc is the in-kernel AFS (Andrew File System) which is experimental anyway.

Change-type: patch

See: https://balena.fibery.io/Work/Improvement/Patch-Dirty-Frag-in-meta-balena-master-4175

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
