### PR TITLE
plymouth: start after udev settle

### DIFF
--- a/meta-balena-common/recipes-core/plymouth/plymouth/plymouth-start-balena-os.conf
+++ b/meta-balena-common/recipes-core/plymouth/plymouth/plymouth-start-balena-os.conf
@@ -3,8 +3,8 @@ Wants=
 After=
 Requires=
 
-Wants=systemd-vconsole-setup.service
-After=systemd-udev-trigger.service systemd-udevd.service resin-boot.service
+Wants=systemd-vconsole-setup.service systemd-udev-settle.service
+After=systemd-udev-trigger.service systemd-udevd.service systemd-udev-settle.service resin-boot.service
 Requires=resin-boot.service
 
 [Service]


### PR DESCRIPTION
In commit 72706964b8dd308b6c1772fa22c4e89d1680d205 we have reworked the plymouth unit files to use drop-in configs and avoid the need to patch the sources.

During this process we have lost the plymouth-start's depenency on systemd-udev-settle.service which creates a race condition around the GPU initialization. Sometimes plymouth starts too early, displays the splash screen on the early boot SW framebuffer, which then gets lost when the actual GPU driver takes over.

This patch re-adds the dependency on systemd-udev-settle.service which should address the issue.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
