### PR TITLE
wpa_supplicant: enable OWE networks

### DIFF
--- a/meta-balena-common/recipes-connectivity/wpa-supplicant/wpa-supplicant_2.10.bb
+++ b/meta-balena-common/recipes-connectivity/wpa-supplicant/wpa-supplicant_2.10.bb
@@ -59,6 +59,9 @@ do_configure () {
 	${MAKE} -C wpa_supplicant clean
 	sed -e '/^CONFIG_TLS=/d' <wpa_supplicant/defconfig >wpa_supplicant/.config
 
+	sed -i -e 's/^#\?CONFIG_OWE=./CONFIG_OWE=1/' wpa_supplicant/.config
+	echo 'CONFIG_IEEE80211W=y' >> wpa_supplicant/.config
+
 	if ${@ bb.utils.contains('PACKAGECONFIG', 'openssl', 'true', 'false', d) }; then
 		echo 'CONFIG_TLS=openssl' >>wpa_supplicant/.config
 	elif ${@ bb.utils.contains('PACKAGECONFIG', 'gnutls', 'true', 'false', d) }; then


### PR DESCRIPTION
This patch adds two config options necessary to enable Opportunistic Wireless Encryption (open networks with client isolation). The main thing is `CONFIG_OWE`, which enables the feature. `CONFIG_IEEE80211W` adds management frame protection, which is optional in OWE, but we expect it to be necessary on most networks. It's also mandatory for other WPA3 family protocols such as SAE.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
