### PR TITLE
balena-bootloader.bbclass: Move common bits from devices to class

### DIFF
--- a/meta-balena-common/classes/balena-bootloader.bbclass
+++ b/meta-balena-common/classes/balena-bootloader.bbclass
@@ -673,3 +673,23 @@ SIGNING_ARTIFACTS = "${B}/${KERNEL_OUTPUT_DIR}/${KERNEL_IMAGETYPE}.initramfs"
 addtask sign_efi before do_deploy after do_bundle_initramfs
 
 DESTDIR = "${DEPLOYDIR}/${KERNEL_PACKAGE_NAME}"
+
+KMETA = "kernel-meta"
+
+BALENA_DEFCONFIG_NAME = "${KBUILD_DEFCONFIG}"
+
+do_deploy:append () {
+    BOOTENV_FILE="${DEPLOYDIR}/${KERNEL_PACKAGE_NAME}/bootenv"
+    grub-editenv "${BOOTENV_FILE}" create
+    grub-editenv "${BOOTENV_FILE}" set "resin_root_part=A"
+    grub-editenv "${BOOTENV_FILE}" set "bootcount=0"
+    grub-editenv "${BOOTENV_FILE}" set "upgrade_available=0"
+}
+
+do_deploy[depends] += " grub-native:do_populate_sysroot"
+
+INITRAMFS_IMAGE = "balena-image-bootloader-initramfs"
+
+KERNEL_PACKAGE_NAME = "balena-bootloader"
+
+PROVIDES = "virtual/balena-bootloader"

--- a/meta-balena-common/classes/balena-bootloader.bbclass
+++ b/meta-balena-common/classes/balena-bootloader.bbclass
@@ -673,3 +673,33 @@ SIGNING_ARTIFACTS = "${B}/${KERNEL_OUTPUT_DIR}/${KERNEL_IMAGETYPE}.initramfs"
 addtask sign_efi before do_deploy after do_bundle_initramfs
 
 DESTDIR = "${DEPLOYDIR}/${KERNEL_PACKAGE_NAME}"
+
+KMETA = "kernel-meta"
+
+BALENA_DEFCONFIG_NAME = "${KBUILD_DEFCONFIG}"
+
+do_install:append() {
+    # Module support is needed as a dependency for kexec image authentication
+    # specifically CONFIG_SYSTEM_DATA_VERIFICATION
+    # But we remove modules here and everything else from /usr
+    rm -rf ${D}/usr
+}
+
+do_deploy:append () {
+    BOOTENV_FILE="${DEPLOYDIR}/${KERNEL_PACKAGE_NAME}/bootenv"
+    grub-editenv "${BOOTENV_FILE}" create
+    grub-editenv "${BOOTENV_FILE}" set "resin_root_part=A"
+    grub-editenv "${BOOTENV_FILE}" set "bootcount=0"
+    grub-editenv "${BOOTENV_FILE}" set "upgrade_available=0"
+}
+
+do_deploy[depends] += " grub-native:do_populate_sysroot"
+
+INITRAMFS_IMAGE = "balena-image-bootloader-initramfs"
+
+KERNEL_PACKAGE_NAME = "balena-bootloader"
+
+PROVIDES = "virtual/balena-bootloader"
+
+# remove this task to prevent the creation of the metadata that triggers rootfs.py to run depmod for the linux-balena-bootloader
+deltask do_packagedata


### PR DESCRIPTION
After adding the balena bootloader to a handful of devices, some stuff keeps getting copy/pasted into the bootloader recipes.

This patch moves the common bits to balena-bootloader.bbclass to avoid duplication and make it easier to use.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
