### PR TITLE
coreutils: Restore /proc/uptime read so uptime works on scarthgap

### DIFF
--- a/meta-balena-scarthgap/recipes-core/coreutils/coreutils/0001-uptime-restore-proc-uptime-fallback.patch
+++ b/meta-balena-scarthgap/recipes-core/coreutils/coreutils/0001-uptime-restore-proc-uptime-fallback.patch
@@ -1,0 +1,106 @@
+From: Kyle Harding <kyle@balena.io>
+Subject: [PATCH] uptime: read elapsed time from /proc/uptime on Linux
+
+GNU coreutils 9.4 rewrote src/uptime.c on top of the gnulib 'readutmp'
+module and, in doing so, dropped the long-standing code that read the
+elapsed time directly from /proc/uptime.  The duration is now derived
+solely from a BOOT_TIME record in utmp.
+
+On systemd-based systems that do not record a usable BOOT_TIME entry in
+utmp -- such as balenaOS, whose /run/utmp holds USER_PROCESS records but
+no boot record (who -b reports the epoch) -- boot_time is 0, so uptime
+prints:
+
+    uptime: couldn't get boot time: No such file or directory
+     HH:MM:SS  up ???? days ??:??,  N user,  load average: ...
+
+This restores the pre-9.4 behaviour: when HAVE_PROC_UPTIME is defined
+(set by balenaOS for coreutils), read the up-seconds from /proc/uptime
+and use it as the authoritative source, falling back to the utmp
+BOOT_TIME computation only when that read fails.  /proc/uptime is always
+present under a mounted procfs, so this works regardless of utmp state.
+busybox's uptime applet already relies on /proc/uptime on the same
+devices and reports correctly.
+
+The %jd conversion stops at the '.' in "<up>.<frac> <idle>.<frac>", so
+parsing is locale-independent and keeps whole-second resolution, which
+is all uptime needs.
+
+This is not suitable for submission upstream: coreutils intentionally
+moved boot-time discovery into gnulib (readutmp/boot-time, which gained
+a /proc/uptime-based synthesis after 9.4).  The proper long-term fix is
+to carry a newer gnulib; this patch is the surgical backport for the
+9.4 line.
+
+Upstream-Status: Inappropriate [superseded upstream by the gnulib
+readutmp/boot-time module; this re-adds pre-9.4 behaviour for the 9.4 line]
+
+Signed-off-by: Kyle Harding <kyle@balena.io>
+---
+ src/uptime.c | 44 ++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 40 insertions(+), 4 deletions(-)
+
+--- a/src/uptime.c
++++ b/src/uptime.c
+@@ -53,9 +53,37 @@ print_uptime (idx_t n, struct gl_utmp const *utmp_buf)
+       if (UT_TYPE_BOOT_TIME (this))
+         boot_time = this->ut_ts.tv_sec;
+     }
++
++#ifdef HAVE_PROC_UPTIME
++  /* On Linux, read the elapsed time directly from /proc/uptime.  This is the
++     authoritative source and, unlike the utmp BOOT_TIME record, is always
++     available -- including on systemd-based systems (such as balenaOS) that
++     do not record a usable BOOT_TIME entry in utmp.  coreutils did this prior
++     to 9.4; the 9.4 rewrite onto the gnulib 'readutmp' module dropped it,
++     which broke 'uptime' wherever utmp lacks a BOOT_TIME record.  */
++  intmax_t proc_uptime = -1;
++  {
++    FILE *fp = fopen ("/proc/uptime", "r");
++    if (fp)
++      {
++        intmax_t secs;
++        /* /proc/uptime is "<up-seconds>.<frac> <idle-seconds>.<frac>"; the
++           "%jd" conversion stops at the '.', so this is locale-independent
++           and keeps whole-second resolution, which is all uptime needs.  */
++        if (fscanf (fp, "%jd", &secs) == 1 && 0 <= secs)
++          proc_uptime = secs;
++        fclose (fp);
++      }
++  }
++#endif
++
+   /* The gnulib module 'readutmp' is supposed to provide a BOOT_TIME entry
+      on all platforms.  */
+-  if (boot_time == 0)
++  if (boot_time == 0
++#ifdef HAVE_PROC_UPTIME
++      && proc_uptime < 0
++#endif
++     )
+     {
+       error (0, errno, _("couldn't get boot time"));
+       status = EXIT_FAILURE;
+@@ -75,8 +103,20 @@ print_uptime (idx_t n, struct gl_utmp const *utmp_buf)
+     }
+
+   intmax_t uptime;
+-  if (time_now == (time_t) -1 || boot_time == 0
+-      || ckd_sub (&uptime, time_now, boot_time) || uptime < 0)
++  bool have_uptime = false;
++#ifdef HAVE_PROC_UPTIME
++  if (0 <= proc_uptime)
++    {
++      uptime = proc_uptime;
++      have_uptime = true;
++    }
++#endif
++  if (! have_uptime
++      && time_now != (time_t) -1 && boot_time != 0
++      && ! ckd_sub (&uptime, time_now, boot_time) && 0 <= uptime)
++    have_uptime = true;
++
++  if (! have_uptime)
+     {
+       printf (_("up ???? days ??:??,  "));
+       status = EXIT_FAILURE;

--- a/meta-balena-scarthgap/recipes-core/coreutils/coreutils_9.4.bbappend
+++ b/meta-balena-scarthgap/recipes-core/coreutils/coreutils_9.4.bbappend
@@ -1,0 +1,13 @@
+# coreutils 9.4 (scarthgap) derives 'uptime' solely from a utmp BOOT_TIME record
+# and no longer reads /proc/uptime. balenaOS has no usable BOOT_TIME entry in
+# utmp, so uptime fails with "couldn't get boot time" and prints "up ???? days".
+# Restore the pre-9.4 /proc/uptime read, gated on the -DHAVE_PROC_UPTIME flag that
+# meta-balena-common's coreutils bbappend already sets (a dead no-op against 9.4's
+# rewritten uptime.c until this patch revives it).
+#
+# Pinned to coreutils 9.4 in the scarthgap layer on purpose: older layers
+# (dunfell/honister/kirkstone, coreutils 8.32-9.1) still ship the working
+# /proc/uptime code, and this patch's context would not apply to them. The
+# version-pinned filename means it only ever attaches to coreutils_9.4.bb.
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+SRC_URI:append = " file://0001-uptime-restore-proc-uptime-fallback.patch"

--- a/tests/suites/os/suite.js
+++ b/tests/suites/os/suite.js
@@ -454,6 +454,7 @@ module.exports = {
 		'./tests/fingerprint',
 		'./tests/fsck',
 		'./tests/os-release',
+		'./tests/uptime',
 		'./tests/iptables',
 		'./tests/migrate',
 		'./tests/issue',

--- a/tests/suites/os/tests/uptime/index.js
+++ b/tests/suites/os/tests/uptime/index.js
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+module.exports = {
+	title: 'Uptime tests',
+	tests: [
+		{
+			title: 'uptime reports elapsed time',
+			run: async function(test) {
+				// Capture stdout, stderr and the exit code in one shot so the
+				// result does not depend on whether the worker rejects on a
+				// non-zero exit. Provider-agnostic: passes for coreutils, busybox
+				// or procps, since they all read /proc/uptime and print a load
+				// average.
+				const output = await this.context
+					.get()
+					.worker.executeCommandInHostOS(
+						'uptime 2>&1; echo uptime_rc=$?',
+						this.link,
+					);
+
+				test.match(
+					output,
+					/uptime_rc=0/,
+					'uptime should exit 0',
+				);
+
+				test.match(
+					output,
+					/up\b.*load average:/,
+					'uptime should print an elapsed time and load average',
+				);
+
+				// Regression guard for the coreutils 9.4 utmp BOOT_TIME breakage
+				// (balena-os/meta-balena#3875): balenaOS has no usable BOOT_TIME
+				// record, so a uptime that relies on it fails this way.
+				test.notMatch(
+					output,
+					/couldn't get boot time/,
+					'uptime should not fail to get boot time',
+				);
+
+				test.notMatch(
+					output,
+					/\?\?\?\?/,
+					'uptime should not print the unknown-uptime placeholder',
+				);
+			},
+		},
+	],
+};


### PR DESCRIPTION
`uptime` is broken on scarthgap (7.x):

```
uptime: couldn't get boot time: No such file or directory
 12:59:37  up ???? days ??:??,  1 user,  load average: 2.66, 0.81, 0.28
```

On scarthgap `uptime` comes from GNU coreutils 9.4. The [9.4 rewrite of `uptime.c`](https://github.com/coreutils/coreutils/blob/v9.4/src/uptime.c) stopped reading `/proc/uptime` and now gets the boot time only from a `utmp` record. balenaOS doesn't write that record, so `uptime` can't tell how long the device has been up and falls back to `up ????`. coreutils [9.0](https://github.com/coreutils/coreutils/blob/v9.0/src/uptime.c) on kirkstone read `/proc/uptime` directly, which is why this only showed up on the version bump. It's still broken upstream in 9.6, since the real fix moved into gnulib ([bug#64937](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=64937)) which isn't in the 9.4 we ship.

The fix puts the `/proc/uptime` read back, behind the `-DHAVE_PROC_UPTIME` flag our common coreutils bbappend already sets (it was a no-op against 9.4's code). busybox's `uptime` already reads `/proc/uptime` on these devices and prints the right thing, so we know the data is there.

Scoped to the scarthgap layer with a version-pinned `coreutils_9.4.bbappend` so it can't touch the older layers (kirkstone/honister/dunfell still have the working code). Same pattern as the existing [`plymouth_24.004.60.bbappend`](https://github.com/balena-os/meta-balena/blob/master/meta-balena-scarthgap/recipes-core/plymouth/plymouth_24.004.60.bbappend).

Patch applies cleanly to the 9.4 source and the new logic checks out on its own. I haven't built it in a full scarthgap env yet, so that's the last thing to confirm before merge.

walnascar has the same bug (coreutils 9.6), so this same patch will need wiring in there too once that layer lands.