### PR TITLE
hostapp.yml: Add root hostapp composition for all boards

### DIFF
--- a/hostapp.yml
+++ b/hostapp.yml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/balena-os/balena-yocto-scripts/refs/heads/master/schemas/hostapp-composition.json
+version: '2.4'
+services:
+
+  hostapp:
+    image: __BUILD_OUTPUT__
+    x-build: {}
+    labels:
+      io.balena.image.store: 'root'
+      io.balena.image.class: 'hostapp'
+      io.balena.update.requires-reboot: '1'
+      io.balena.private.hostapp.board-rev: '__DEVICE_REPO_REV__'


### PR DESCRIPTION
This composition matches the default hostapp composition that is injected by yocto scripts if none is provided.

By having it here, we can start adding extensions and customizations.

Change-type: patch
See: https://balena.fibery.io/Work/Improvement/Base-meta-balena-hostapp-composition-4333

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
