### PR TITLE
Feature: systemd: ignore lid switch events via logind drop-in

### DIFF
--- a/meta-balena-common/recipes-core/systemd/systemd/10-balena-lid-switch-ignore.conf
+++ b/meta-balena-common/recipes-core/systemd/systemd/10-balena-lid-switch-ignore.conf
@@ -1,0 +1,3 @@
+[Login]
+HandleLidSwitch=ignore
+HandleLidSwitchDocked=ignore

--- a/meta-balena-common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-balena-common/recipes-core/systemd/systemd_%.bbappend
@@ -2,6 +2,7 @@ FILESEXTRAPATHS:append := ":${THISDIR}/${PN}"
 
 SRC_URI:append = " \
     file://coredump.conf \
+    file://10-balena-lid-switch-ignore.conf \
     file://reboot.target.conf \
     file://poweroff.target.conf \
     file://journald-balena-os.conf \
@@ -44,6 +45,7 @@ FILES:${PN} += " \
     /etc/localtime \
     /etc/mtab \
     ${sysconfdir}/systemd/journald.conf.d \
+    ${sysconfdir}/systemd/logind.conf.d/10-balena-lid-switch-ignore.conf \
     "
 
 do_install:append() {
@@ -63,6 +65,9 @@ do_install:append() {
     install -d -m 0755 ${D}/${sysconfdir}/systemd/system/systemd-logind.service.d
     install -m 0644 ${WORKDIR}/condition-virtualization-not-docker.conf \
         ${D}/${sysconfdir}/systemd/system/systemd-logind.service.d
+    install -d -m 0755 ${D}/${sysconfdir}/systemd/logind.conf.d
+    install -m 0644 ${WORKDIR}/10-balena-lid-switch-ignore.conf \
+        ${D}/${sysconfdir}/systemd/logind.conf.d
 
     # mask systemd-getty-generator
     install -d -m 0755 ${D}/${sysconfdir}/systemd/system-generators


### PR DESCRIPTION
# Summary

Add a `systemd-logind` drop‑in that disables lid‑close handling so laptop‑class devices do not suspend when the lid is closed.

The drop‑in sets:

```
HandleLidSwitch=ignore
HandleLidSwitchDocked=ignore
```

This follows review guidance from **balena-generic PR #741** to move this behavior into **meta-balena** as a common hardcoded feature.

---

# Files Changed

- `systemd_%.bbappend`
- `10-balena-lid-switch-ignore.conf`

---

# Test Plan

1. Build an image for one **amd64** device and one **aarch64** device.  
2. Verify that the file exists on the device:  
   `/etc/systemd/logind.conf.d/10-balena-lid-switch-ignore.conf`
3. Confirm that closing the lid no longer triggers suspend.

---

# Manual Test Case Recorded

**Manual validation:**  
Built and flashed images for **generic-amd64** and **generic-aarch64**. Verified that:

- `/etc/systemd/logind.conf.d/10-balena-lid-switch-ignore.conf` contains  
  - `HandleLidSwitch=ignore`  
  - `HandleLidSwitchDocked=ignore`
- Closing the laptop lid no longer triggers suspend on both targets.

---

# Contributor Checklist

<!-- For completed items, change [ ] to [x]. -->

- [ ] Changes have been tested  
- [ ] Covered in automated test suite  
- [x] Manual test case recorded  
- [x] Change-type present on at least one commit  
- [x] Signed-off-by is present  
- [x] PR complies with the Open Embedded Commit Patch Message Guidelines  
- [x] *(Optional)* Changelog-entry present on at least one commit if you want to set the changelog entry manually  

---

# Reviewer Guidelines

When submitting a review, please choose:

- **Approve** — if this change is acceptable in the codebase (even if minor or cosmetic tweaks could improve it).  
- **Request Changes** — if this change would *not* be acceptable (e.g., bugs, future development blockers, security or performance issues).  
- **Comment** — if you do not feel you have enough information to decide.
