### PR TITLE
.github/workflows: Add automerge-gate workflow for all jobs

### DIFF
--- a/.github/workflows/automerge-gate.yml
+++ b/.github/workflows/automerge-gate.yml
@@ -1,0 +1,23 @@
+name: Automerge Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, auto_merge_enabled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: All Passed # must match the required check in your ruleset
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      checks: read
+      pull-requests: read
+      actions: read
+    steps:
+      - uses: pkgdeps/automerge-gate@v4.1.0
+        with:
+          gate-mode: 'public'


### PR DESCRIPTION
This check only passes when all other jobs are successful.

We will use it for branch protection on ESR branches where workflows can be selectively disabled if they are not expected to pass - either because they are not ESR devices, or they did not get a branch created.

Change-type: patch
See: https://balena.fibery.io/Work/Improvement/backport-patch-to-3-active-ESR-versions-for-each-device-type-4162

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
