### PR TITLE
blueZ cache gatt attribute only for paired device

### DIFF
--- a/meta-balena-common/recipes-connectivity/bluez5/files/main.conf
+++ b/meta-balena-common/recipes-connectivity/bluez5/files/main.conf
@@ -3,3 +3,6 @@ DeviceID=false
 
 [Policy]
 AutoEnable=true
+
+[GATT]
+Cache=yes


### PR DESCRIPTION
We have seen on support multiple cases of users having the state partition filled up with gatt attributes. It can lead to different issue one of them being inode exhaustion.

Change-type: minor

[#balena-io/os > bluetooth cache files filling up state partition nodes](https://balena.zulipchat.com/#narrow/channel/345889-balena-io.2Fos/topic/bluetooth.20cache.20files.20filling.20up.20state.20partition.20nodes/with/603627170)
---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
