### PR TITLE
recipes-core/systemd: Fix building with Wrynose

### DIFF
--- a/meta-balena-common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-balena-common/recipes-core/systemd/systemd_%.bbappend
@@ -66,7 +66,7 @@ do_install:append() {
     install -m 0644 ${UNPACKDIR}/condition-virtualization-not-docker.conf \
         ${D}/${sysconfdir}/systemd/system/systemd-logind.service.d
     install -d -m 0755 ${D}/${sysconfdir}/systemd/logind.conf.d
-    install -m 0644 ${WORKDIR}/10-balena-lid-switch-ignore.conf \
+    install -m 0644 ${UNPACKDIR}/10-balena-lid-switch-ignore.conf \
         ${D}/${sysconfdir}/systemd/logind.conf.d
 
     # mask systemd-getty-generator


### PR DESCRIPTION
A PR which uses WORKDIR was merged before the Wrynose PR, and the automated re-base did not catch this because WORKDIR can be used in all Yocto versions pre-Wrynose.

We thus update the recipe to make it compatible with all Yocto versions again.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
