### PR TITLE
networkmanager_%.bbappend: Don't remove /usr/lib/NetworkManager/conf.…

### DIFF
--- a/meta-balena-common/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/meta-balena-common/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -87,8 +87,7 @@ do_install:append() {
 
     ln -s /var/run/resolvconf/interface/NetworkManager ${D}/etc/resolv.dnsmasq
 
-    # remove these empty not-used (at this moment) directories so we don't have to package them
-    rmdir ${D}${libdir}/NetworkManager/conf.d
+    # remove this empty not-used (at this moment) directory so we don't have to package it
     rmdir ${D}${libdir}/NetworkManager/VPN
 }
 


### PR DESCRIPTION
…d from the rootfs

We need to allow for various boards to be able to use this location for placing any needed drop-ins now that /etc/NetworkManager/conf.d is bindmounted at boot time.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
