### PR TITLE
Allow multi kernel image builds

### DIFF
--- a/meta-balena-common/classes/kernel-balena-override.bbclass
+++ b/meta-balena-common/classes/kernel-balena-override.bbclass
@@ -1,0 +1,131 @@
+# kernel-balena-override.bbclass
+#
+# Late kernel config-fragment merge for kernel-OVERRIDE extensions.
+#
+# Discovery: an explicit, ordered list in KERNEL_BALENA_OVERRIDE_FRAGMENTS,
+#            each resolved on FILESPATH. Never SRC_URI (that merges early).
+# Timing:    merged after all BALENA_CONFIGS processing
+#            (do_kernel_resin_checkconfig), so a fragment wins.
+# Safety:    do_kernel_balena_verify_fragments asserts every requested symbol
+#            landed, and re-asserts the signing posture, after the merge.
+
+inherit kernel-balena
+
+KERNEL_BALENA_OVERRIDE_FRAGMENTS ?= ""
+
+def kernel_balena_override_fragments(d):
+    names = (d.getVar("KERNEL_BALENA_OVERRIDE_FRAGMENTS") or "").split()
+    filespath = d.getVar("FILESPATH") or ""
+    resolved = []
+    for name in names:
+        path = bb.utils.which(filespath, name)
+        if not path:
+            bb.fatal("kernel-balena-override: fragment not found on FILESPATH: %s" % name)
+        resolved.append(path)
+    return resolved
+
+def kernel_balena_parse_config(path):
+    """Return {CONFIG_X: value} for every positively-set symbol in a kconfig
+    file. '# CONFIG_X is not set' lines and other comments are ignored."""
+    symbols = {}
+    with open(path) as handle:
+        for line in handle:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            symbols[key.strip()] = value.strip()
+    return symbols
+
+def kernel_balena_required_symbols(fragments, extra_symbols):
+    """Symbols that must be present after the merge: every positive fragment
+    entry (value != n) plus explicit CONFIG_X=value strings."""
+    required = {}
+    for fragment in fragments:
+        for key, value in kernel_balena_parse_config(fragment).items():
+            if value != "n":
+                required[key] = value
+    for symbol in extra_symbols:
+        key, value = symbol.split("=", 1)
+        required[key.strip()] = value.strip()
+    return required
+
+python do_kernel_balena_merge_fragments() {
+    import os
+    import subprocess
+
+    fragments = kernel_balena_override_fragments(d)
+    if not fragments:
+        return
+
+    S = d.getVar("S")
+    B = d.getVar("B")
+    base_config = os.path.join(B, ".config")
+
+    make_cmd = d.getVar("KERNEL_MAKE_CMD") or "make"
+    make_opts = d.getVar("EXTRA_OEMAKE") or ""
+    arch = d.getVar("ARCH")
+    if not arch:
+        bb.fatal("kernel-balena-override: ARCH variable not set")
+
+    bb.note("Merging %d kernel fragment(s):" % len(fragments))
+    for f in fragments:
+        bb.note("  %s" % f)
+
+    merge_script = os.path.join(S, "scripts", "kconfig", "merge_config.sh")
+    cmd = " ".join([merge_script, "-m", "-O", B, base_config] + fragments)
+    ret = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    if ret.returncode != 0:
+        bb.fatal("merge_config.sh failed:\n%s" % ret.stderr)
+    if ret.stderr:
+        bb.note(ret.stderr)
+
+    cmd = "%s %s -C %s O=%s ARCH=%s olddefconfig" % (make_cmd, make_opts, S, B, arch)
+    bb.note("Running olddefconfig")
+    ret = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    if ret.returncode != 0:
+        bb.fatal("olddefconfig failed:\n%s" % ret.stderr)
+}
+addtask kernel_balena_merge_fragments after do_kernel_resin_checkconfig before do_compile
+do_kernel_balena_merge_fragments[dirs] += "${B}"
+
+python do_kernel_balena_verify_fragments() {
+    import os
+
+    fragments = kernel_balena_override_fragments(d)
+    if not fragments:
+        return
+
+    have = kernel_balena_parse_config(os.path.join(d.getVar("B"), ".config"))
+
+    # Signing guard: when signing is enabled the secure-boot posture inherited
+    # from BALENA_CONFIGS[secureboot] must survive the late fragment merge.
+    extra = []
+    if d.getVar("SIGN_API"):
+        secureboot = d.getVarFlag("BALENA_CONFIGS", "secureboot") or ""
+        extra = [s for s in secureboot.split() if "=" in s and not s.endswith("=n")]
+
+    required = kernel_balena_required_symbols(fragments, extra)
+
+    missing = []
+    for key, value in sorted(required.items()):
+        if have.get(key) != value:
+            missing.append("%s=%s (found %s)" % (key, value, have.get(key, "unset")))
+
+    if missing:
+        bb.fatal("kernel-balena-override: required kernel config missing after merge:\n%s"
+                 % "\n".join(missing))
+}
+addtask kernel_balena_verify_fragments after do_kernel_balena_merge_fragments before do_compile
+do_kernel_balena_verify_fragments[dirs] += "${B}"
+
+# Fold fragment content into the task hashes so a change re-runs the merge and
+# the check. The verify logic itself lives in this class, so a change to it
+# already rehashes the task through the normal bbclass code checksum.
+python () {
+    fragments = kernel_balena_override_fragments(d)
+    if fragments:
+        checksums = " " + " ".join("%s:True" % f for f in fragments)
+        d.appendVarFlag("do_kernel_balena_merge_fragments", "file-checksums", checksums)
+        d.appendVarFlag("do_kernel_balena_verify_fragments", "file-checksums", checksums)
+}

--- a/meta-balena-common/classes/kernel-balena.bbclass
+++ b/meta-balena-common/classes/kernel-balena.bbclass
@@ -1195,6 +1195,11 @@ do_deploy:prepend () {
 
 # copy to deploy dir latest .config and Module.symvers (after kernel modules have been built)
 do_deploy:append () {
-    install -m 0644 ${D}/boot/Module.symvers-* ${DEPLOYDIR}/Module.symvers
-    install -m 0644 ${D}/boot/config-* ${DEPLOYDIR}/.config
+    deployDir="${DEPLOYDIR}"
+    if [ -n "${KERNEL_DEPLOYSUBDIR}" ]; then
+        deployDir="${DEPLOYDIR}/${KERNEL_DEPLOYSUBDIR}"
+        mkdir -p "$deployDir"
+    fi
+    install -m 0644 ${D}/boot/Module.symvers-* "$deployDir/Module.symvers"
+    install -m 0644 ${D}/boot/config-* "$deployDir/.config"
 }

--- a/meta-balena-common/recipes-kernel/linux/kernel-image-initramfs.bb
+++ b/meta-balena-common/recipes-kernel/linux/kernel-image-initramfs.bb
@@ -6,16 +6,19 @@ LIC_FILES_CHKSUM = "file://${BALENA_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d9
 PACKAGES = "${PN}"
 FILES:${PN} = "/boot"
 
+KERNEL_INITRAMFS_PROVIDER ?= "virtual/kernel"
+KERNEL_INITRAMFS_DEPLOY_DIR ?= "${DEPLOY_DIR_IMAGE}"
+
 do_install() {
     mkdir -p ${D}/boot
     for type in ${KERNEL_IMAGETYPE}; do
-        install -m 0644 ${DEPLOY_DIR_IMAGE}/${type}-initramfs-${MACHINE}.bin ${D}/boot/${type}
-        if [ -f "${DEPLOY_DIR_IMAGE}/${type}.initramfs.sig" ]; then
-            install -m 0644 ${DEPLOY_DIR_IMAGE}/${type}.initramfs ${D}/boot/${type}
-            install -m 0644 "${DEPLOY_DIR_IMAGE}/${type}.initramfs.sig" "${D}/boot/${type}.sig"
+        install -m 0644 ${KERNEL_INITRAMFS_DEPLOY_DIR}/${type}-initramfs-${MACHINE}.bin ${D}/boot/${type}
+        if [ -f "${KERNEL_INITRAMFS_DEPLOY_DIR}/${type}.initramfs.sig" ]; then
+            install -m 0644 ${KERNEL_INITRAMFS_DEPLOY_DIR}/${type}.initramfs ${D}/boot/${type}
+            install -m 0644 "${KERNEL_INITRAMFS_DEPLOY_DIR}/${type}.initramfs.sig" "${D}/boot/${type}.sig"
         fi
     done
 }
-do_install[depends] += "virtual/kernel:do_deploy"
+do_install[depends] += "${KERNEL_INITRAMFS_PROVIDER}:do_deploy"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/meta-balena-kirkstone/classes/kernel-balena-noimage.bbclass
+++ b/meta-balena-kirkstone/classes/kernel-balena-noimage.bbclass
@@ -5,5 +5,8 @@
 #    the initramfs bundled kernel image
 python __anonymous() {
     kernel_image_type = d.getVar('KERNEL_IMAGETYPE')
-    d.appendVar('PACKAGE_EXCLUDE', ' kernel-image-%s-*' % kernel_image_type.lower())
+    kernel_package_name = d.getVar('KERNEL_PACKAGE_NAME') or "kernel"
+    d.appendVar('PACKAGE_EXCLUDE',
+                ' %s-image-%s-*' % (kernel_package_name, kernel_image_type.lower()))
+    d.setVar('RRECOMMENDS:%s-base' % kernel_package_name, '')
 }

--- a/meta-balena-scarthgap/classes/kernel-balena-noimage.bbclass
+++ b/meta-balena-scarthgap/classes/kernel-balena-noimage.bbclass
@@ -8,4 +8,5 @@ python __anonymous() {
     kernel_package_name = d.getVar('KERNEL_PACKAGE_NAME') or "kernel"
     d.appendVar('PACKAGE_EXCLUDE',
                 ' %s-image-%s-*' % (kernel_package_name, kernel_image_type.lower()))
+    d.setVar('RRECOMMENDS:%s-base' % kernel_package_name, '')
 }

--- a/meta-balena-scarthgap/classes/kernel-balena-noimage.bbclass
+++ b/meta-balena-scarthgap/classes/kernel-balena-noimage.bbclass
@@ -5,5 +5,7 @@
 #    the initramfs bundled kernel image
 python __anonymous() {
     kernel_image_type = d.getVar('KERNEL_IMAGETYPE')
-    d.appendVar('PACKAGE_EXCLUDE', ' kernel-image-%s-*' % kernel_image_type.lower())
+    kernel_package_name = d.getVar('KERNEL_PACKAGE_NAME') or "kernel"
+    d.appendVar('PACKAGE_EXCLUDE',
+                ' %s-image-%s-*' % (kernel_package_name, kernel_image_type.lower()))
 }


### PR DESCRIPTION
Relates-to: https://balena.fibery.io/default/Cycles-1634#Work/Project/Hostapp-extensions-overlays---HUP-and-rollbacks-2334

Adds support for building more than one kernel image which is a pre-requisite for hostapp extension that include artifacts that depend on the kernel ABI. 

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
