### PR TITLE
balena: bump balena-engine to restore 1777 default for bare tmpfs mounts

### DIFF
--- a/meta-balena-common/recipes-containers/balena/balena_git.bb
+++ b/meta-balena-common/recipes-containers/balena/balena_git.bb
@@ -18,7 +18,7 @@ inherit useradd
 BALENA_VERSION = "v25.0.14"
 BALENA_BRANCH = "release/v25.0"
 
-SRCREV = "d66b2681e54650c9ebf22bd8d0c3570e8360ad3c"
+SRCREV = "d7af640472d60e72bf086cfdc5a3e35a35a0cf2e"
 # NOTE: update patches when bumping major versions
 # [0] will have up-to-date versions, make sure poky version matches what
 # meta-balena uses


### PR DESCRIPTION
Pin balena-engine to the merged tmpfs fix (https://github.com/balena-os/balena-runc/pull/5), restoring the 1777 default for bare tmpfs mounts so non-root containers can write again. Only the vendor.mod runc replace directive + re-vendor.

Fixes the regression tracked in https://github.com/balena-os/meta-balena/issues/3885 (upstream https://github.com/opencontainers/runc/issues/4971 / https://github.com/opencontainers/runc/pull/4974).

See: https://balena.fibery.io/Work/Improvement/balenaEngine-Restore-1777-tmpfs-default-4401

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
