### PR TITLE
classes/image-balena: Cleanup /etc/issue file in Wrynose

### DIFF
--- a/meta-balena-common/classes/image-balena.bbclass
+++ b/meta-balena-common/classes/image-balena.bbclass
@@ -480,6 +480,14 @@ python do_image_size_check() {
 # But working on all Yocto versions
 python __anonymous() {
     import re
-    rootfs_postprocess_command = d.getVar('ROOTFS_POSTPROCESS_COMMAND')
-    d.setVar('ROOTFS_POSTPROCESS_COMMAND', re.sub(r'zap_empty_root_password ?;?', '', rootfs_postprocess_command))
+    rootfs_postprocess_command = d.getVar('ROOTFS_POSTPROCESS_COMMAND') or ''
+
+    cleaned_command = re.sub(r'zap_empty_root_password ?;?', '', rootfs_postprocess_command)
+    # Wrynose introduces an root empty password note in /etc/issue at build time,
+    # if passwordless root login is allowed. This breaks the /etc/issue file test
+    # and also, is meaningful only if developmentMode is 'true'. We thus remove it
+    # to keep the issue file clean.
+    cleaned_command = re.sub(r'add_empty_root_password_note ?;?', '', cleaned_command)
+
+    d.setVar('ROOTFS_POSTPROCESS_COMMAND', cleaned_command)
 }


### PR DESCRIPTION
Commit https://git.openembedded.org/openembedded-core/commit/?id=b650bd2c94f9aefd4dec82b27285ed1d439778bc introduces an empty root  password note in /etc/issue at build time, if passwordless root login is enabled.

The Scarthgap bbclass does not include this note at all and in Wrynose it breaks the /etc/issue file tests. It also is only meaningful if developmentMode is set to 'true'.

We thus remove the note altogether to keep the /etc/issue file clean and consistent across all versions.

The alternative is to modify the leviathan tests to allow for the test to pass even if the paswordless login note is included in /etc/issue

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested - https://github.com/balena-os/balena-jetson-thor/actions/runs/28013734573/job/83020165291
  - [x] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
