### PR TITLE
renovate: Append major/minor/patch updates with change-type footer

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,6 +44,11 @@
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "!/^v?0/",
       "automerge": true
+    },
+    {
+      "description": "Append major/minor/patch updates with change-type footer",
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "commitBody": "Update {{depName}} from {{currentVersion}} to {{newVersion}}\n\nChange-type: patch"
     }
   ]
 }


### PR DESCRIPTION
The existing top-level property is being overridden by a packageRule in the balena-os/renovate-config shared settings, so we need a local package rule to take priority.

Change-type: patch
See: https://balena.fibery.io/Work/Improvement/Fix-incorrect-versionist-footers-in-balena-os-PRs-4554


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
