### PR TITLE
image_types_balena: increase default boot/root/state partition sizes

### DIFF
--- a/meta-balena-common/classes/image_types_balena.bbclass
+++ b/meta-balena-common/classes/image_types_balena.bbclass
@@ -92,12 +92,12 @@ def disk_aligned(d, rootfs_size):
     return rootfs_size
 
 # The rootfs size is calculated by substracting from the maximum BalenaOS image
-# 700 MiB size, the size  of all other partitions except the data partition,
+# 1420 MiB size, the size  of all other partitions except the data partition,
 # dividing by 2, and substracting filesystem metadata and reserved allocations
 def balena_rootfs_size(d):
     boot_part_size = int(d.getVar("BALENA_BOOT_SIZE"))
     state_part_size = int(d.getVar("BALENA_STATE_SIZE"))
-    balena_rootfs_size = int(((700 * 1024) - boot_part_size - state_part_size) / 2)
+    balena_rootfs_size = int(((1420 * 1024) - boot_part_size - state_part_size) / 2)
     return int(disk_aligned(d, balena_rootfs_size))
 
 BALENA_BOOT_FS_LABEL ?= "resin-boot"
@@ -110,9 +110,9 @@ BALENA_DATA_FS_LABEL ?= "resin-data"
 BALENA_BOOT_FAT32 ?= "0"
 
 # Sizes in KiB
-BALENA_BOOT_SIZE ?= "40960"
+BALENA_BOOT_SIZE ?= "102400"
 BALENA_ROOTB_SIZE ?= ""
-BALENA_STATE_SIZE ?= "20480"
+BALENA_STATE_SIZE ?= "40960"
 BALENA_IMAGE_ALIGNMENT ?= "4096"
 IMAGE_ROOTFS_ALIGNMENT = "${BALENA_IMAGE_ALIGNMENT}"
 DEVICE_SPECIFIC_SPACE ?= "${BALENA_IMAGE_ALIGNMENT}"

--- a/meta-balena-common/classes/image_types_balena.bbclass
+++ b/meta-balena-common/classes/image_types_balena.bbclass
@@ -321,7 +321,7 @@ IMAGE_CMD:balenaos-img () {
         BALENA_STATE_BLOCKS=$(LC_ALL=C parted -s ${BALENA_RAW_IMG} unit b print | grep -E "^(| )${BALENA_STATE_PN} " | awk '{ print substr($4, 1, length($4 -1)) / 512 /2 }')
         rm -rf ${BALENA_STATE_FS}
         truncate -s "$(expr ${BALENA_STATE_BLOCKS} \* 1024 )" "${BALENA_STATE_FS}"
-        mkfs.ext4 -F -L "${BALENA_STATE_FS_LABEL}" ${BALENA_STATE_FS}
+        mkfs.ext4 -b 4096 -F -L "${BALENA_STATE_FS_LABEL}" ${BALENA_STATE_FS}
     fi
 
     # Label what is not labeled

--- a/meta-balena-common/classes/image_types_balena.bbclass
+++ b/meta-balena-common/classes/image_types_balena.bbclass
@@ -92,12 +92,12 @@ def disk_aligned(d, rootfs_size):
     return rootfs_size
 
 # The rootfs size is calculated by substracting from the maximum BalenaOS image
-# 700 MiB size, the size  of all other partitions except the data partition,
+# 1460 MiB size, the size  of all other partitions except the data partition,
 # dividing by 2, and substracting filesystem metadata and reserved allocations
 def balena_rootfs_size(d):
     boot_part_size = int(d.getVar("BALENA_BOOT_SIZE"))
     state_part_size = int(d.getVar("BALENA_STATE_SIZE"))
-    balena_rootfs_size = int(((700 * 1024) - boot_part_size - state_part_size) / 2)
+    balena_rootfs_size = int(((1460 * 1024) - boot_part_size - state_part_size) / 2)
     return int(disk_aligned(d, balena_rootfs_size))
 
 BALENA_BOOT_FS_LABEL ?= "resin-boot"
@@ -110,9 +110,9 @@ BALENA_DATA_FS_LABEL ?= "resin-data"
 BALENA_BOOT_FAT32 ?= "0"
 
 # Sizes in KiB
-BALENA_BOOT_SIZE ?= "40960"
+BALENA_BOOT_SIZE ?= "102400"
 BALENA_ROOTB_SIZE ?= ""
-BALENA_STATE_SIZE ?= "20480"
+BALENA_STATE_SIZE ?= "81920"
 BALENA_IMAGE_ALIGNMENT ?= "4096"
 IMAGE_ROOTFS_ALIGNMENT = "${BALENA_IMAGE_ALIGNMENT}"
 DEVICE_SPECIFIC_SPACE ?= "${BALENA_IMAGE_ALIGNMENT}"

--- a/meta-balena-common/recipes-core/images/balena-image.bb
+++ b/meta-balena-common/recipes-core/images/balena-image.bb
@@ -9,7 +9,7 @@ BALENA_FLAG_FILE = "${BALENA_IMAGE_FLAG_FILE}"
 
 #
 # The default root filesystem partition size is set in such a way that the
-# entire space taken by resinOS would not exceed 700 MiB. This  can be
+# entire space taken by resinOS would not exceed 1420 MiB. This  can be
 # overwritten by board specific layers.
 #
 IMAGE_ROOTFS_SIZE = "${@balena_rootfs_size(d)}"

--- a/meta-balena-common/recipes-core/images/balena-image.bb
+++ b/meta-balena-common/recipes-core/images/balena-image.bb
@@ -9,7 +9,7 @@ BALENA_FLAG_FILE = "${BALENA_IMAGE_FLAG_FILE}"
 
 #
 # The default root filesystem partition size is set in such a way that the
-# entire space taken by resinOS would not exceed 700 MiB. This  can be
+# entire space taken by resinOS would not exceed 1460 MiB. This  can be
 # overwritten by board specific layers.
 #
 IMAGE_ROOTFS_SIZE = "${@balena_rootfs_size(d)}"


### PR DESCRIPTION
Double the default root A/B partition size (320 MiB -> 640 MiB) and grow the boot (40 MiB -> 100 MiB) and state (20 MiB -> 80 MiB) partitions, keeping the total raw image budget in sync (700 MiB -> 1460 MiB) in balena_rootfs_size().

Also forces a 4K block size for the resin-state ext4 filesystem. mkfs.ext4 otherwise defaults to 1K blocks for a filesystem this size, which fails to mount once the partition is LUKS2-formatted for secure boot, since dm-crypt exposes a hard 4096-byte block size with no legacy 512e compatibility.

Change-type: major
Changelog-entry: Increase default boot, root and state partition sizes


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)