### PR TITLE
tests: os: led: check LED_FILE exists on device, and stop counting sd…

### DIFF
--- a/tests/suites/os/tests/led/index.js
+++ b/tests/suites/os/tests/led/index.js
@@ -52,10 +52,21 @@ module.exports = {
 			);
 		}, false);
 
+		// Ensure LED_FILE is set and the file actually exists
+		const checkFile = await this.context
+			.get()
+			.worker.executeCommandInHostOS(
+				`source /etc/balena-supervisor/supervisor.conf ; [ -n "$LED_FILE" ] && [ -f "$LED_FILE" ] ; echo $?`,
+				this.link,
+			);
+
+		test.is(checkFile, '0', 'LED file defined in supervisor.conf should exist on device');
+
+
 		await this.context
 			.get()
 			.worker.executeCommandInHostOS(
-				`source /etc/balena-supervisor/supervisor.conf ; systemd-run --unit=${serviceName} bash -c "while true ; do cat $LED_FILE ; done"`,
+				`source /etc/balena-supervisor/supervisor.conf ; systemd-run --unit=${serviceName} bash -c "while true ; do cat $LED_FILE 2>/dev/null ; done"`,
 				this.link,
 			);
 


### PR DESCRIPTION
…terr

If the LED_FILE didn't exist on the device, the checking of the file returned an error message, which was being evaluated as a toggling file.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
