### PR TITLE
hostapp: Add deploy assets to hostapp composition

### DIFF
--- a/hostapp.yml
+++ b/hostapp.yml
@@ -4,7 +4,17 @@ services:
 
   hostapp:
     image: __BUILD_OUTPUT__
-    x-build: {}
+    x-build:
+      assets:
+        - "images/__MACHINE__/VERSION"
+        - "images/__MACHINE__/VERSION_HOSTOS"
+        - "images/__MACHINE__/image*.json"
+        - "images/__MACHINE__/compressed*/part-*.deflate"
+        - "images/__MACHINE__/*.manifest"
+        - "images/__MACHINE__/kernel_modules_headers.tar.gz"
+        - "images/__MACHINE__/rpi-eeprom/secure-boot-lock/"
+        - "cyclonedx-export/**/*.json"
+        - "licenses/**"
     labels:
       io.balena.image.store: 'root'
       io.balena.image.class: 'hostapp'


### PR DESCRIPTION
These assets must exist relative to the build/tmp/deploy path and will be deployed as resources on the release.

For the hostapp only, some of these resources get transformations before being uploaded:
- cyclonedx-export/ is renamed to cyclonedx/
- licenses/ is tarred
- secure-boot-lock/ is tarred
- images/__MACHINE__/ subdirs are flattened

Change-type: patch
See: https://balena.fibery.io/Work/Project/hostapps-One-composition-driven-publishing-path-for-every-built-service-2773
See: https://github.com/balena-os/balena-yocto-scripts/pull/907

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
