### PR TITLE
initrdscripts: check alignment of data partition in resindataexpander

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/resindataexpander
+++ b/meta-balena-common/recipes-core/initrdscripts/files/resindataexpander
@@ -63,6 +63,25 @@ resindataexpander_run() {
             fi
             info "resindataexpander: Expand data partition... "
             parted -s "/dev/$datadev" -- resizepart "${part_number}" 100%
+
+            # Make sure the partition size is aligned with the physical sector size.
+            # parted aligns to logical sector size, which on some drives is smaller than physical.
+            # This is a compatibility feature - drives with 4KB sector size accept 512B writes
+            # for backwards compatibility.
+            # We have seen at least one SSD that advertises 4KB sector size, while its total size
+            # is *not* a multiple of 4KB. In this case we want to ignore the last incomplete sector.
+            # It doesn't play well with LUKS which expects to be aligned with physical sector borders.
+            _phys_sector_size=$(lsblk -nbldo phy-sec "/dev/${datapartdev}")
+            _current_size=$(lsblk -nbldo size "/dev/${datapartdev}")
+            _aligned_size=$(( (_current_size / _phys_sector_size) * _phys_sector_size ))
+            if [ "${_current_size}" != "${_aligned_size}" ]; then
+                _start=$(lsblk -nldo start "/dev/${datapartdev}")
+                # lsblk says that 'start' is in 512-byte sectors and -b doesn't affect it
+                # even though it feels wrong, hardcoding 512 here
+                _end=$(( (_start * 512) + _aligned_size - 1 ))
+                yes | parted ---pretend-input-tty "/dev/$datadev" -- resizepart "${part_number}" "${_end}B"
+            fi
+
             info "resindataexpander: Finished expanding data partition."
             partprobe
             sync


### PR DESCRIPTION
We have seen an SSD that reports physical sector size 4KB and logical sector size 512B. The total length of the disk is not a multiple of 4KB, but the parted command that we're currently using in the resindataexpander script aligns to 512B and ends the partition in the middle of a physical sector.

This is not a problem for regular devices that just format the partition as ext4, but devices that use disk encryption with LUKS always align to physical sector size - in this case 4KB. When trying to access the partition after resizing, LUKS complains about the misalignment and refuses to unlock the partition.

This patch adds a check that makes sure the partition is properly aligned after resizing and trims the extra space if necessary.


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
