### PR TITLE
extra-udev-rules: Disable power management on mlan* wireless network …

### DIFF
--- a/meta-balena-common/recipes-core/extra-udev-rules/files/79-wlan-power.rules
+++ b/meta-balena-common/recipes-core/extra-udev-rules/files/79-wlan-power.rules
@@ -1,1 +1,1 @@
-ACTION=="add", KERNEL=="wl*", SUBSYSTEM=="net", RUN+="/usr/sbin/iw dev $name set power_save off"
+ACTION=="add", KERNEL=="wl*|mlan*", SUBSYSTEM=="net", RUN+="/usr/sbin/iw dev $name set power_save off"


### PR DESCRIPTION
…interfaces

The moal driver used in various hardware exposes the wireless network interfaces as mlan*

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
