### PR TITLE
tests: os: Bluetooth: Scan for autokit address directly

### DIFF
--- a/tests/suites/os/tests/bluetooth/index.js
+++ b/tests/suites/os/tests/bluetooth/index.js
@@ -37,20 +37,34 @@ module.exports = {
 					// get the testbot bluetooth name
 					let btName = await this.worker.executeCommandInWorker('bluetoothctl show | grep Name');
 					let btNameParsed = /(.*): (.*)/.exec(btName); // the bluetoothctl command returns "Name: <btname>", so extract the <btname here>
+					let showOutput = await this.worker.executeCommandInWorker('bluetoothctl show');
 
-          // leave the host discoverable for a longer period of time to prevent sporadic discover failures with Pi3
-          await this.worker.executeCommandInWorker('bluetoothctl discoverable-timeout 1200');
-          // make testbot bluetooth discoverable
+					// Extract the MAC address using regex (matches "Controller XX:XX:XX:XX:XX:XX")
+					let macMatch = showOutput.match(/Controller\s+([0-9A-Fa-f:]{17})/);
+
+					if (!macMatch) {
+						throw new Error('Failed to parse Bluetooth MAC address from "bluetoothctl show"');
+					}
+
+					let btMac = macMatch[1]; // Returns "2C:CF:67:0C:FD:81"
+					test.comment(`Extracted DUT MAC Address: ${btMac}`);
+
+					// leave the host discoverable for a longer period of time to prevent sporadic discover failures with Pi3
+					await this.worker.executeCommandInWorker('bluetoothctl discoverable-timeout 1200');
+					// make testbot bluetooth discoverable
 					await this.worker.executeCommandInWorker('bluetoothctl discoverable on');
+					await this.worker.executeCommandInWorker('bluetoothctl show');
 
 					// scan for bluetooth devices on DUT, we retry a couple of times
 					let scan = '';
 					await this.utils.waitUntil(async () => {
 						test.comment('Scanning for bluetooth devices...');
+						// Use "name" to search for a specific MAC address - this is to avoid false negatives when there are too many 
+						// devices returned by the scan
 						scan = await this.context
 							.get()
 							.worker.executeCommandInHostOS(
-								'hcitool scan',
+								`hcitool name ${btMac}`,
 								this.link,
 							);
 						return scan.includes(btNameParsed[2]);
@@ -64,11 +78,11 @@ module.exports = {
 
 					test.comment('Checking if BD Address is initialized');
 					const devMac = await this.context
-							.get()
-							.worker.executeCommandInHostOS(
-								'hcitool dev',
-								this.link,
-							);
+						.get()
+						.worker.executeCommandInHostOS(
+							'hcitool dev',
+							this.link,
+						);
 
 					test.is(
 						devMac.includes('AA:AA:AA:AA:AA:AA'),
@@ -77,6 +91,5 @@ module.exports = {
 					);
 				}
 			},
-		},
-	],
-};
+		}],
+	};


### PR DESCRIPTION
There can be failures in the bluetoth test as we blindly scan for bluetooth devices - if there are enough present, the buffer doesn't always show the one the DUT is looking for. Changing the test to specifically search for the autokit address instead of a blind scan

Starting on draft to test on a larger group of devices first. So far:

- 3 successful attempts on cm4-ioboard
- pi3: TBD
- pi5: TBD

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
