### PR TITLE
Add ebpf and tracing extensions

### DIFF
--- a/docs/host-extensions-development.md
+++ b/docs/host-extensions-development.md
@@ -1,0 +1,107 @@
+# Building hostapp extensions
+
+## Overview
+
+This document covers how a hostapp extension that ships with balenaOS is built: the classes in meta-balena and how an extension reaches a device type's release.
+
+It assumes the runtime contract described in [Hostapp extensions support](host-extensions.md): the labels an extension image carries, how mobynit layers it, and what happens to it across a HUP. Read that first if the terms `io.balena.image.class`, `io.balena.image.override` or kernel override are new.
+
+Two kinds of extension have examples in-tree:
+
+* A userspace extension, which adds files to the root filesystem: `balena-tracing-extension`.
+* A kernel override extension, which additionally replaces the running kernel: `balena-ebpf-extension`.
+
+Extensions built outside a balenaOS release are plain container images and need none of this. They only have to carry the labels described in the runtime document.
+
+## Build infrastructure
+
+Extensions that ship with balenaOS are Yocto image recipes. The build infrastructure is split so that a recipe only states what its extension is for, and the classes handle packaging, labelling and, for kernel overrides, the second kernel.
+
+| Class | Inherited by | Role |
+| --- | --- | --- |
+| `balena-hostapp-extension` | image recipe | Turns an image into an extension: rootfs tarball, labels, OCI import |
+| `kernel-extension-image` | image recipe | The above plus the extension kernel, its modules, device trees and initramfs |
+| `kernel-extension` | kernel recipe | Brands a kernel recipe as the extension kernel (`virtual/kernel-extension`) |
+| `kernel-balena-override` | kernel recipe | Late kernel config fragment merge, with verification |
+| `kernel-ebpf` | kernel recipe | BTF, BPF LSM and the tracing surface |
+| `balena-tracing` | image recipe | The userspace tracing payload |
+
+All of them live in `meta-balena-common/classes/`. Capability classes carry the "why" of an extension and nothing else, so the same payload can be attached to more than one device type or recipe without duplication.
+
+## The extension image class
+
+`balena-hostapp-extension.bbclass` is the only class a userspace-only extension needs. It inherits `image`, so the recipe declares its payload through `IMAGE_INSTALL` and nothing else.
+
+The class then:
+
+* Forces a `tar.gz` rootfs with no init manager, no locales and no initramfs. An extension is a rootfs tarball, not a bootable image.
+* Removes `HOSTAPP_EXTENSION_REMOVE_PATHS` (`etc run var` by default) from the assembled rootfs. An overlay contributes its own content only; state directories come from the hostapp underneath it.
+* Installs `kernel-override-hooks`, which lays down `/hooks/{create,start}`. The hooks self-detect kernel content at runtime and no-op for a userspace extension.
+* Imports the tarball with `docker import --change`, adding the labels below, and saves the result as a `.docker` archive in the deploy directory.
+
+Labels are set from variables, so a recipe overrides only what it needs:
+
+| Variable | Label | Default |
+| --- | --- | --- |
+| `HOSTAPP_EXTENSION_LABEL_STORE` | `io.balena.image.store` | `data` |
+| `HOSTAPP_EXTENSION_LABEL_CLASS` | `io.balena.image.class` | `overlay` |
+| `HOSTAPP_EXTENSION_LABEL_REQUIRES_REBOOT` | `io.balena.update.requires-reboot` | `1` |
+| `HOSTAPP_EXTENSION_LABEL_OVERRIDE` | `io.balena.image.override` | unset, meaning extend-only |
+| not configurable | `io.balena.image.os-version` | the version of the OS being built |
+
+Two escape hatches cover anything else the image needs: `HOSTAPP_EXTENSION_LABELS` for extra `LABEL` changes and `HOSTAPP_EXTENSION_CHANGES` for other `docker import` changes such as `VOLUME` or `ENV`.
+
+Contribute to `HOSTAPP_EXTENSION_REMOVE_PATHS` with `:append`, as the kernel extension image class does for `bin` and `sbin`. Entries are matched literally, so an entry that escapes the rootfs (`/`, `.`, `..`, or anything containing `..`) fails the build rather than deleting outside the image.
+
+Because the OS version label is the exact version being built, an in-tree extension image is retained only for that release. See [image retention across HUPs](host-extensions.md#image-retention-across-hups) for what that means on a device.
+
+An extension must not ship `/usr/libexec/os-helpers-*`. Those files are sourced by every host process that uses them, `rollback-health` and `extension-rollback` included.
+
+## Kernel override build support
+
+A kernel override extension needs a second kernel: same device, different configuration, delivered as an overlay rather than in the rootfs. Three classes cover it.
+
+`kernel-extension.bbclass` is inherited by the kernel recipe and brands it as that second kernel. It:
+
+* Renames the kernel package and provides `virtual/kernel-extension` instead of `virtual/kernel`, which also moves its artifacts into their own deploy subdirectory.
+* Bundles the initramfs in a single compile pass instead of the stock `do_bundle_initramfs`, which would build the whole kernel a second time. Single-pass bundling is safe for an extension kernel only, which consumes just the initramfs-bundled image.
+
+The class must be inherited below the device recipe's `require` chain: `kernel.bbclass` adds `virtual/kernel` to `PROVIDES` unconditionally, and only a plain assignment evaluated afterwards drops it.
+
+`kernel-balena-override.bbclass` merges kernel config fragments late, after `do_kernel_resin_checkconfig` and before `do_compile`, so an extension fragment wins over the `BALENA_CONFIGS` processing that the base kernel shares. Fragments are listed explicitly in `KERNEL_BALENA_OVERRIDE_FRAGMENTS` and resolved on `FILESPATH`; `SRC_URI` is deliberately not used, because that merges too early. A verification task then asserts that every positively-set symbol from every fragment survived the merge, and re-asserts the secure boot posture when signing is enabled. Fragment contents are folded into the task hashes, so editing a fragment re-runs the merge and the check.
+
+Always contribute fragments to `KERNEL_BALENA_OVERRIDE_FRAGMENTS` with `:append`. A plain assignment from one class silently drops another's fragment, and the loss is invisible: the verification task derives its required symbols from the same variable it merges from, so a dropped fragment is neither merged nor missed.
+
+`kernel-extension-image.bbclass` is the image side. It inherits `balena-hostapp-extension` and:
+
+* Installs the extension kernel's modules, the initramfs-bundled kernel image, and the device trees when the machine defines any.
+* Sets the override priority to 100.
+* Disables `USE_DEPMOD`, a kirkstone-era limitation with multiple compiled kernels.
+* Removes the `/bin` and `/sbin` compatibility symlinks, which would otherwise shadow the hostapp's.
+
+## Automatic kernel-override detection
+
+Nothing in a recipe declares "this is a kernel override". The class decides from the assembled rootfs, which must contain both:
+
+* a `Module.symvers` under `/lib/modules/<release>/` (or `/usr/lib/modules/<release>/`), and
+* a kernel image under `/boot/`.
+
+When both are present, the import adds `io.balena.image.kernel-version`, `io.balena.image.kernel-abi-id` (the sha256 of the kernel image itself) and declares `/boot` as a volume. When neither is present the image is imported with the common labels only.
+
+Anything in between is a build failure rather than a silently degraded image: a kernel image without `Module.symvers`, a `Module.symvers` without a kernel image, more than one `Module.symvers` (the ABI claim would be ambiguous), or an empty or symlinked kernel image that cannot identify a build.
+
+`Module.symvers` is normally not in any runtime package, so the class copies it in from the matching kernel build in the deploy directory during image preprocessing, matching by the kernel version recorded in the deployed `.config`.
+
+The extension kernel is a separate recipe with its own source revision, so the two kernels can differ: out-of-tree modules destined for a kernel override extension have to be built against the extension's `Module.symvers`, not the hostapp kernel's.
+
+## Wiring an extension into a device type build
+
+The build pipeline reads a Docker Compose composition. The base composition in `layers/meta-balena/hostapp.yml` declares the hostapp service; a device repo adds its extensions in `${MACHINE}.hostapp.yml`, and the two are deep-merged with the device overlay winning.
+
+An extension service declares:
+
+* `image: __BUILD_OUTPUT__` and an `x-build.recipe` naming the bitbake image target.
+* A `labels` block, which `balena deploy` applies to the image.
+* A `profiles` entry, marking the extension as selectively activated.
+
+A device type opts out of a base-composition service by nulling it.

--- a/docs/host-extensions.md
+++ b/docs/host-extensions.md
@@ -8,6 +8,8 @@ Hostapp extension containers are meant to extend or modify the root filesystem i
 
 When deciding whether to use a hostapp extension for your content, first consider whether there is any reason why it could not be added to a standard application container.
 
+This document describes the runtime contract: the labels an extension image carries and what the OS does with them. For how the extensions that ship with balenaOS are built, including step by step guides for both kinds, see [Building hostapp extensions](host-extensions-development.md).
+
 ## How it works
 
 Mobynit runs as PID 1 and discovers container overlay filesystems by reading overlay2 metadata directly, without relying on Docker packages. During boot, it:
@@ -24,15 +26,19 @@ The rootfs is mounted as overlayfs lowerdirs and is intrinsically read-only.
 
 The last stage of a hostapp extension container is shown next:
 
-    FROM scratch
+```dockerfile
+FROM scratch
 
-    LABEL io.balena.image.class=overlay
+LABEL io.balena.image.class=overlay
 
-    COPY --from=builder /hostext /
+COPY --from=builder /hostext /
+```
 
 The example Dockerfile above starts with an empty container, then adds the `io.balena.image.class=overlay` label so that BalenaOS can identify it and overlay it at boot, and finally the desired content is copied from a space holder directory to the root of this container.
 
-By default, extensions are mounted to the right of the hostapp in the overlayfs lowerdir stack, meaning they can only contribute new files — they cannot replace existing hostapp content.
+By default, extensions are mounted to the right of the hostapp in the overlayfs lowerdir stack, meaning they can only contribute new files: they cannot replace existing hostapp content.
+
+The labels are the whole contract; how the image is produced is not constrained. Extensions that ship as part of a balenaOS release are built from Yocto image recipes instead of a Dockerfile, and the classes described in [Building hostapp extensions](host-extensions-development.md) emit the same labels at import time.
 
 ## Mount ordering
 
@@ -40,16 +46,20 @@ Extensions can define a mount order using the `io.balena.image.override=N` label
 
 Shadowing is opt-in through the presence of the label, not its value. Omit the label entirely for an extend-only extension that only contributes new files; there is no numeric value that means "extend only".
 
-    FROM scratch
+```dockerfile
+FROM scratch
 
-    LABEL io.balena.image.class=overlay
-    LABEL io.balena.image.override=10
+LABEL io.balena.image.class=overlay
+LABEL io.balena.image.override=10
 
-    COPY --from=builder /hostext /
+COPY --from=builder /hostext /
+```
 
 In overlayfs terminology, `lowerdir=A:B:C` means A has the highest lookup priority. The resulting lowerdir is: `lowerdir=<extensions with override sorted by N>:<hostapp>:<extensions without override>`.
 
 Care should be taken not to shadow root filesystem content which is essential for BalenaOS to function.
+
+The extensions built in-tree pick their priorities from the same scale: the kernel extension sits at 100 and the tracing extension at 200, so the kernel extension shadows the tracing one, and both leave room on either side for overlays added later.
 
 ## Number of layered extensions
 
@@ -64,30 +74,79 @@ Extensions that ship kernel modules or BPF-sensitive content should declare the 
 * `io.balena.image.kernel-version=M.m.p`: coarse userspace-visible kernel version (e.g. `6.12.61`). Checked against the running kernel's stripped `uname -r`. Missing label is fail-open (extension is mounted).
 * `io.balena.image.kernel-abi-id=<sha256>`: precise kernel build fingerprint. For kernel extensions the build sets it to the sha256 of the extension's kernel image.
 
-<!-- -->
+```dockerfile
+FROM scratch
 
-    FROM scratch
+LABEL io.balena.image.class=overlay
+LABEL io.balena.image.kernel-version=6.12.61
+LABEL io.balena.image.kernel-abi-id=<sha256 of the kernel image>
 
-    LABEL io.balena.image.class=overlay
-    LABEL io.balena.image.kernel-version=6.12.61
-    LABEL io.balena.image.kernel-abi-id=<sha256 of the kernel image>
+COPY --from=builder /lib/modules /lib/modules
+```
 
-    COPY --from=builder /lib/modules /lib/modules
+Recipes built with `balena-hostapp-extension.bbclass` do not hand-write these two labels: the class derives them from the assembled rootfs, as described in [automatic kernel-override detection](host-extensions-development.md#automatic-kernel-override-detection).
 
-A boot-time cleanup service (`balena-extension-manager cleanup`) complements this by removing dead extension containers, including those whose `kernel-version` label no longer matches the running kernel. After a HUP changes the kernel, the now-mismatched containers are pruned on the next boot. See [Managing hostapp extensions](#managing-hostapp-extensions).
+Mount-time filtering keeps an incompatible extension out of the root filesystem; it does not remove it.
+
+Reaping is done by the extension manager:
+
+* `balena-extension-manager cleanup` runs on every boot. It drops the containers the engine calls garbage, whose runtime create failed or that it reports as dead, and the fabricated `ext_*` volumes no container claims.
+* `balena-extension-manager cleanup --stale-os` runs at the HUP commit hook. It additionally drops the containers and images whose labels no longer match the running system.
+
+See [Managing hostapp extensions](#managing-hostapp-extensions).
+
+## Extension hooks
+
+An extension can ship executable scripts at `hooks/create`, `hooks/start` and `hooks/delete` in its rootfs.
+
+`balena-extension-runtime` runs each one at the matching point of the OCI lifecycle and skips any that is absent, so hooks are entirely optional. They run with a fixed `PATH`, `EXTENSION_ROOTFS` pointing at the extension's merged rootfs, every `io.balena.image.*` label forwarded as `EXTENSION_IMAGE_<NAME>`, and every mount forwarded as `EXTENSION_VOLUME_<DESTINATION>`. The runtime's own environment is not inherited.
+
+`hooks/start` is the only place an extension can decline to activate. A non-zero exit there records the container as `Exited (1)` while reporting the `start` call itself as successful, so the caller stops rather than retrying a decision that will not change. A non-zero exit from `hooks/create` fails the create call instead, because at that point there is no container status to carry a verdict.
+
+`hooks/delete` runs when the container is deleted. Note this is the wrong place for teardown as an extension can be reaped by a path that never reaches an orderly delete.
+
+Teardown needs no hook of its own. Withdrawing an extension is a plain container removal, and the state a kernel override publishes outside its rootfs is converged at the next boot; see [Withdrawing a kernel override](#withdrawing-a-kernel-override). `hooks/delete` remains available for extension only cleanup.
 
 ## Kernel override extensions
 
-A hostapp extension can replace the running kernel rather than only adding files to the root filesystem. Such an extension ships a kernel image and its `Module.symvers` in a `/boot` volume, and is booted directly instead of being layered into the read-only rootfs.
+A hostapp extension can replace the running kernel rather than only adding files to the root filesystem. Such an extension carries a kernel image in a `/boot` volume, plus the matching modules and their `Module.symvers` under `/usr/lib/modules/<release>/`.
+
+The kernel image is booted directly; the modules are layered into the read-only rootfs like any other extension content.
 
 A kernel override extension declares:
 
 * `io.balena.image.kernel-abi-id` and `io.balena.image.kernel-version` as above, identifying the kernel it provides.
-* `io.balena.update.requires-reboot=1`, because a new kernel only takes effect after a reboot (see [Extensions that require a reboot](#extensions-that-require-a-reboot)).
+* `io.balena.update.requires-reboot=1`, recording that the extension only takes effect after a reboot.
 
-On activation the OS registers the override kernel under `/mnt/data/boot-by-abi/<kernel-abi-id>` and selects it on the next boot by its build id. If the override kernel is missing or fails to load, the boot falls back to the stock kernel shipped with the OS.
+Installing the extension publishes its kernel under `/mnt/data/boot-by-abi/<kernel-abi-id>`; activating it arms that build id for the next boot. If the armed kernel is missing, or the initramfs cannot load it, the boot falls back to the stock kernel shipped with the OS.
 
-In production a kernel override is delivered as part of a HUP. If the override kernel fails to boot, the device rolls back to the kernel previously committed for that root filesystem slot, the same way a failed HUP rolls back the root filesystem. Applying a kernel override outside a HUP is a development-only path: it takes effect on the running slot but carries no automatic rollback, so a kernel that fails to boot there must be recovered manually.
+The activation path is driven by the `/hooks/{create,start}` scripts that `kernel-override-hooks` installs into every extension rootfs:
+
+* `create`, invoked by `balena-extension-runtime`, symlinks `/mnt/data/boot-by-abi/<abi>` to the extension's `/boot` volume, using a path relative to the data partition so the link resolves the same way in the initramfs and in the running OS.
+* `start`, also invoked by `balena-extension-runtime`, verifies that the symlink resolves to a real kernel image, refuses to re-arm an ABI that boot-time validation has already rejected, records whether the VPN was reachable before the change, and then writes `kernel_override_abi` into the boot environment. That write comes last, and it is what opens the validation window described below.
+* The initramfs `kexec` script reads `kernel_override_abi`, boots `/mnt/data/boot-by-abi/<abi>/<kernel image>` when it exists and falls back to the stock kernel otherwise. It publishes the kernel it loaded on the command line as `balena_kernel_abi=<abi>`, and that token is how the rest of the system knows which kernel is running.
+
+Each hook starts by testing whether the rootfs it was handed is a kernel override at all, so the same hooks are harmless in a userspace-only extension.
+
+### Validating a kernel override
+
+An armed override is on trial until a boot ratifies it. Three boot environment keys carry that state:
+
+* `kernel_override_abi`: the live intent, the ABI the next boot should load.
+* `kernel_override_abi_committed_<slot>`: the ABI that root filesystem slot has already proven healthy. An empty value means the slot is known good on the stock kernel.
+* `kernel_override_abi_rejected`: written by a rollback to tell the next boot which ABI it must undo.
+
+A boot whose live value matches the running slot's committed value is an ordinary boot and costs three reads. Anything else is a pending verdict, reached down one of two paths.
+
+Inside a HUP, `rollback-health` owns the verdict. Healthchecks passing commit the running ABI for the slot. Healthchecks failing restore the other slot's committed override and roll the root filesystem back with it, so the kernel and the rootfs move together.
+
+Outside a HUP, `extension-rollback.service` owns it. The unit runs on every boot, because an override can be armed with no update in progress and so leaves no breadcrumb to gate on. It stands aside while a HUP is in flight, then settles, runs the same healthchecks, and either commits the ABI for the running slot or rejects it.
+
+### Withdrawing a kernel override
+
+Withdrawal is a container removal and nothing else. Whoever manages the extension removes its container.
+
+What the removal does not touch is the state the override published outside the container: the armed `kernel_override_abi`, the committed snapshot in every slot that ratified it, and the `boot-by-abi` symlink. Those are converged at the next boot by `extension-rollback.service`, which reconciles before it reads any of the state its own validation depends on. The `/boot` volume is converged in the same boot by `balena-extension-manager cleanup`, which collects it once no container claims it. Losing the volume costs a refill: its content is a function of the image id it is named after, so a redeploy reproduces it locally.
 
 ## Image retention across HUPs
 
@@ -95,14 +154,14 @@ Extension images declare which OS versions they are valid for via the `io.balena
 
 * `io.balena.image.os-version=<pattern>[,<pattern>...]`: a comma-separated list of shell-style globs (`filepath.Match` semantics) matched against `/etc/os-release` `VERSION_ID`. Any match retains the image. A missing or empty label is a legacy-safe retain.
 
-<!-- -->
+```dockerfile
+FROM scratch
 
-    FROM scratch
+LABEL io.balena.image.class=overlay
+LABEL io.balena.image.os-version=2.119.*
 
-    LABEL io.balena.image.class=overlay
-    LABEL io.balena.image.os-version=2.119.*
-
-    COPY --from=builder /hostext /
+COPY --from=builder /hostext /
+```
 
 Common choices:
 
@@ -112,20 +171,38 @@ Common choices:
 
 Because `filepath.Match`'s `*` matches `.`, `2.119.*` also matches `2.119.0-staging`, `2.119.1+rev1`, and similar suffixed versions; this is intentional.
 
-At HUP commit, an image that fails the predicate is removed; the same HUP has already reconciled containers via the `kernel-version` and `kernel-abi-id` filters above, so no running extension is disrupted. Before the commit, during the rollback window, no image or container retention decisions are altered.
+Extensions built in-tree take the exact-version end of that scale: the build stamps the version of the OS being built, so the image is retained only for that OS version. This is the intended behaviour for an extension that ships with, and is rebuilt by, each release.
+
+The `--stale-os` pass applies one predicate to containers and images alike: any claim among `kernel-abi-id`, `kernel-version` and `os-version` that the running system violates makes the object stale. A stale container is removed outright, with no hook and no rejection recorded: the removal is a withdrawal rather than a verdict, and whatever a kernel override left armed behind it is swept at the next boot by `extension-rollback.service`. Before the commit, during the rollback window, no image is pruned: a stale image is what a rollback returns to.
+
+Volumes are not in that pass. A fabricated `ext_*` volume is collected on every boot by the plain `cleanup`, on the claim predicate rather than the staleness one. Gated on staleness it leaked: withdraw an override on a device that stays on its current OS and its volume is never stale, so nothing ever took it.
 
 ## Extensions that require a reboot
 
-* `io.balena.update.requires-reboot=1`: marks the extension as needing a host reboot after install/update. The supervisor sets a reboot breadcrumb when creating a container with this label; the host reboots on the next reconcile tick and mobynit layers the extension on the subsequent boot. This is the same label the supervisor already honors on regular services (via the `io.balena.update.*` namespace of update-time directives).
+* `io.balena.update.requires-reboot=1`: records that the extension needs a host reboot to take effect. The label carries no behaviour of its own today. Mobynit composes the root filesystem once, at boot, so the device agent treats every overlay as reboot-activated and schedules the reboot whether or not the label is present. It is reserved in the extension contract for a future runtime-activated class, and remains useful as a declaration of intent; extensions built in-tree set it to `1`.
 
 ## Managing hostapp extensions
 
 Extensions are meant to be managed by the supervisor or as part of a hostOS update. Manually installing, removing or updating hostapp extensions is neither advised nor supported.
 
-On-host lifecycle is handled by the `balena-extension-runtime` recipe, which ships two binaries: `balena-extension-runtime` (the OCI runtime) and `balena-extension-manager` (the lifecycle helper). The manager's cleanup runs at two points:
+On-host lifecycle is handled by the `balena-extension-runtime` recipe, which ships two binaries: `balena-extension-runtime` (the OCI runtime) and `balena-extension-manager` (the lifecycle helper).
 
-* **Every boot**: `hostapp-extensions-cleanup.service`, a oneshot ordered after `balena.service` and before the supervisor, runs `balena-extension-manager cleanup` to drop dead extension containers (see [Kernel ABI compatibility](#kernel-abi-compatibility)).
-* **At HUP commit**: the `85-fwd_commit_os-blocks-extensions` forward-commit hook runs `balena-extension-manager cleanup --stale-os` to drop extension images that no longer match the booted OS version (see [Image retention across HUPs](#image-retention-across-hups)).
+Three sweepers converge what an extension leaves behind. Each collects what it can reach at the moment it must run, and only what its own claim source can prove is unreferenced. That rule, rather than the object type or the update window, is what decides who owns what:
+
+| Sweeper | When | Claim source | Predicate | Owns |
+|---|---|---|---|---|
+| `extension-rollback.service` | every boot, before the armed override is judged, with the engine possibly down | mobynit, reading the container store off the disk | no container claims this ABI | boot environment keys, the `boot-by-abi` symlink |
+| `balena-extension-manager cleanup` | every boot, with the engine up | the engine's container list | the engine calls the container garbage; no container claims this volume | containers, fabricated `ext_*` volumes |
+| `balena-extension-manager cleanup --stale-os` | HUP commit | the engine plus the running system's identity | a declared compatibility claim is violated | containers, images |
+
+Two consequences are worth stating:
+
+* The first two key on the same fact, that no container claims the object, so they need no ordering between them. `hostapp-extensions-cleanup.service` and `extension-rollback.service` are unordered, and stay that way.
+* `--stale-os` is not the primary convergence path for containers. The device agent already drops a container whose claim the running kernel did not honour, at its next poll and with no window gating. The manager's stale-container pass is the orphan net for extensions the agent cannot see: a manual deploy, or a release it no longer tracks. Images are the part only `--stale-os` can do, and that is what the `os-version` label was designed for.
+
+The call sites: `hostapp-extensions-cleanup.service` is a oneshot ordered after `balena.service` and before the supervisor; the `85-fwd_commit_os-blocks-extensions` forward-commit hook adds `--stale-os` (see [Image retention across HUPs](#image-retention-across-hups)).
+
+Removal is a plain container removal, issued by whatever manages the extension. The image is kept until the commit, so a rollback still finds it on disk. The `ext_*` volume is not: it is collected at the next boot once no container claims it, and a redeploy refills it from the image. There is no separate disarm step and the manager carries no verb for one; see [Withdrawing a kernel override](#withdrawing-a-kernel-override) for what the next boot does with the state a kernel override left behind.
 
 ## Disabling hostapp extension overlays
 

--- a/meta-balena-common/classes/balena-hostapp-extension.bbclass
+++ b/meta-balena-common/classes/balena-hostapp-extension.bbclass
@@ -10,9 +10,17 @@
 #   inherit balena-hostapp-extension
 #   IMAGE_INSTALL = "<your extension packages>"
 #
+# Use :append instead whenever something else already contributes to the
+# payload, which is the case for every class inheriting this one. A plain
+# assignment in a recipe parses after its inherit line and silently drops what
+# the class installed.
+#
 # Inheriting recipes can append more docker-import directives via:
 #   HOSTAPP_EXTENSION_LABELS  - extra `--change "LABEL ..."` lines
-#   HOSTAPP_EXTENSION_CHANGES - extra `--change "..."` lines (VOLUME, ENV, ...)
+#   HOSTAPP_EXTENSION_CHANGES - extra `--change "..."` lines (ENV, WORKDIR, ...)
+#
+# The paths stripped from the assembled rootfs are configurable via:
+#   HOSTAPP_EXTENSION_REMOVE_PATHS - rootfs-relative paths (default: etc run var)
 #
 # The values of the conventional labels can be overridden per-recipe:
 #   HOSTAPP_EXTENSION_LABEL_STORE            - io.balena.image.store          (default: data)
@@ -38,6 +46,31 @@ HOSTAPP_EXTENSION_LABEL_REQUIRES_REBOOT ?= "1"
 
 # Unset by default: extend-only extension
 HOSTAPP_EXTENSION_LABEL_OVERRIDE        ?= ""
+
+# Every extension is a rootfs tarball imported as an image
+IMAGE_LINGUAS = ""
+VIRTUAL-RUNTIME_init_manager = ""
+INITRAMFS_IMAGE = ""
+IMAGE_FSTYPES = "tar.gz"
+
+# An overlay contributes its own content only
+HOSTAPP_EXTENSION_REMOVE_PATHS ?= "etc run var"
+
+# rm -rf unlinks a symlink without following it, so the same form covers both
+# the state directories and the /bin and /sbin compatibility symlinks.
+remove_unnecessary_files() {
+    for p in ${HOSTAPP_EXTENSION_REMOVE_PATHS}; do
+        # The value is reachable from local.conf and a machine conf, so an entry
+        # that escapes the rootfs would rm -rf the build tree.
+        case "$p" in
+            /|.|..|../*|*/..|*/../*) bbfatal "invalid HOSTAPP_EXTENSION_REMOVE_PATHS entry: '$p'" ;;
+        esac
+        rm -rf "${IMAGE_ROOTFS}/$p"
+    done
+}
+# Ordered before install_kernel_override_symvers below, which writes under
+# /usr/lib/modules/<ver>/ and would be undone by a removal running after it.
+IMAGE_PREPROCESS_COMMAND += "remove_unnecessary_files;"
 
 # Always-on: the hooks self-detect kernel content at runtime and
 # silently no-op for non-kernel extensions.
@@ -88,6 +121,7 @@ do_create_docker_image() {
             --change "LABEL io.balena.image.class=${HOSTAPP_EXTENSION_LABEL_CLASS}" \
             --change "LABEL io.balena.update.requires-reboot=${HOSTAPP_EXTENSION_LABEL_REQUIRES_REBOOT}" \
             --change "LABEL io.balena.image.os-version=${HOSTOS_VERSION}" \
+            --change 'CMD ["none"]' \
             "$@"
 
         # Only emit the override label when a priority is set.
@@ -124,8 +158,7 @@ do_create_docker_image() {
 
         _docker_import_extension \
             --change "LABEL io.balena.image.kernel-version=${KERNEL_VER}" \
-            --change "LABEL io.balena.image.kernel-abi-id=${KERNEL_ABI_ID}" \
-            --change "VOLUME /boot"
+            --change "LABEL io.balena.image.kernel-abi-id=${KERNEL_ABI_ID}"
     elif [ -z "${HAS_SYMVERS}" ] && [ "${HAS_KERNEL_IMG}" = "0" ]; then
         # Not a kernel-override extension, common labels only.
         _docker_import_extension

--- a/meta-balena-common/classes/balena-tracing.bbclass
+++ b/meta-balena-common/classes/balena-tracing.bbclass
@@ -1,0 +1,11 @@
+# balena-tracing.bbclass
+#
+# The userspace tracing payload: syscall, library call, network and kernel
+# event tracing.
+
+BALENA_TRACING_LTRACE = "ltrace"
+BALENA_TRACING_LTRACE:riscv32 = ""
+BALENA_TRACING_LTRACE:riscv64 = ""
+
+# :append so inherit order cannot clobber an IMAGE_INSTALL set by the recipe.
+IMAGE_INSTALL:append = " perf strace tcpdump ${BALENA_TRACING_LTRACE}"

--- a/meta-balena-common/classes/kernel-ebpf.bbclass
+++ b/meta-balena-common/classes/kernel-ebpf.bbclass
@@ -1,0 +1,57 @@
+# kernel-ebpf.bbclass
+#
+# Gives a kernel what a CO-RE eBPF agent needs: BTF type information, the BPF
+# core, the BPF LSM, and the kprobe/perf tracing surface.
+
+inherit kernel-balena-override
+
+# BPF_PROG_TYPE_LSM attaches through bpf_trampoline_link_prog, which arm32 does
+# not implement
+COMPATIBLE_HOST = "(x86_64|aarch64).*-linux"
+
+# ebpf.cfg lives in this layer, not next to the recipe inheriting the class, so
+# it has to be put on FILESPATH explicitly. Appended rather than prepended, so
+# a device fragment of the same name still wins.
+FILESEXTRAPATHS:append := ":${BALENA_COREBASE}/recipes-kernel/linux/files"
+
+# :append rather than +=, because a recipe assigning
+# KERNEL_BALENA_OVERRIDE_FRAGMENTS with a plain "=" would clobber a "+=", and
+# the loss is silent: do_kernel_balena_verify_fragments derives its required
+# symbols from the same variable it merges from, so a dropped fragment is
+# neither merged nor missed and the build ships a kernel with no BTF.
+KERNEL_BALENA_OVERRIDE_FRAGMENTS:append = " ebpf.cfg"
+
+# CONFIG_DEBUG_INFO_BTF is gated in kconfig on PAHOLE_VERSION >= 121. Without
+# pahole in the build olddefconfig drops it and the kernel is useless to a
+# CO-RE agent, which do_kernel_balena_verify_fragments then reports.
+DEPENDS += "pahole-native"
+
+# ebpf.cfg forces CONFIG_DEBUG_INFO=y, and with compressed modules the standard
+# strip does not reach debug symbols, so modules would ship full DWARF.
+# INSTALL_MOD_STRIP=1 drops the debug sections while preserving .BTF.
+do_install:prepend() {
+    if grep -q '^CONFIG_MODULE_COMPRESS=y$' "${B}/.config"; then
+        export INSTALL_MOD_STRIP=1
+    fi
+}
+
+# To support the ebpf extension BSPs need to configure bpf in the LSM list.
+# The LSM list varies between device type, so this layer cannot force it.
+python do_kernel_ebpf_verify_lsm() {
+    import os
+
+    config = os.path.join(d.getVar("B"), ".config")
+    lsm = kernel_balena_parse_config(config).get("CONFIG_LSM")
+    if lsm is None:
+        bb.fatal("kernel-ebpf: CONFIG_LSM is absent from %s, so the active LSM " % config)
+
+    entries = [entry.strip() for entry in lsm.strip('"').split(",")]
+    if "bpf" not in entries:
+        bb.fatal("kernel-ebpf: CONFIG_LSM=%s does not list \"bpf\", so BPF LSM "
+                 "programs cannot attach to this kernel. Add \"bpf\" to this "
+                 "device's list; do not set CONFIG_LSM from ebpf.cfg, which "
+                 "would replace the list and drop: %s"
+                 % (lsm, ", ".join(entries)))
+}
+addtask kernel_ebpf_verify_lsm after do_kernel_balena_merge_fragments before do_compile
+do_kernel_ebpf_verify_lsm[dirs] += "${B}"

--- a/meta-balena-common/classes/kernel-extension-image.bbclass
+++ b/meta-balena-common/classes/kernel-extension-image.bbclass
@@ -1,0 +1,31 @@
+# kernel-extension-image.bbclass
+#
+# Packages the extension kernel and its modules as a hostapp overlay. Inherit
+# it from an image recipe and append whatever userspace the extension exists to
+# deliver.
+
+inherit balena-hostapp-extension
+
+# :append rather than =, so the payload cannot be dropped by a recipe or another
+# class assigning IMAGE_INSTALL. bitbake processes inherit inline, so a recipe
+# body parses after this class and a plain assignment there wins. That failure
+# is silent: an extension with no kernel content still builds, and
+# do_create_docker_image imports it as an ordinary extension.
+IMAGE_INSTALL:append = " kernel-extension-modules kernel-extension-image-initramfs"
+
+# x86 device types have no devicetree to package.
+IMAGE_INSTALL:append = " ${@'kernel-extension-devicetree' if d.getVar('KERNEL_DEVICETREE') else ''}"
+
+# Mount left of the hostapp in mobynit's overlay stack. 100 leaves headroom
+# both directions for overlays that need to shadow or be shadowed by the
+# extension kernel.
+HOSTAPP_EXTENSION_LABEL_OVERRIDE = "100"
+
+# revisit once the poky submodule moves off kirkstone
+# Fixed in upstream openembedded-core
+# commit efa88e1c227d695319197f511701e0230d301f39 ("rootfs.py: Run depmod(wrapper) against each compiled kernel"
+USE_DEPMOD = "0"
+
+# This extension carries no userspace, so the /bin and /sbin compatibility
+# symlinks would only shadow the hostapp's.
+HOSTAPP_EXTENSION_REMOVE_PATHS:append = " bin sbin"

--- a/meta-balena-common/classes/kernel-extension.bbclass
+++ b/meta-balena-common/classes/kernel-extension.bbclass
@@ -1,0 +1,37 @@
+# kernel-extension.bbclass
+#
+# Turns a kernel recipe into the device's hostapp kernel extension: a second
+# kernel, pinned independently of the base one and delivered as an overlay
+# rather than in the rootfs. It carries no opinion about why the extension
+# exists; inherit a capability class alongside it, kernel-ebpf for example.
+#
+# Inherit it below the device recipe's require chain, for the reason below.
+
+# Brand this recipe as the extension kernel rather than a second provider of
+# virtual/kernel. kernel.bbclass adds virtual/kernel to PROVIDES
+# unconditionally and the require chain is what pulls that class in, so only a
+# plain "=" evaluated afterwards drops it.
+KERNEL_PACKAGE_NAME = "kernel-extension"
+PROVIDES = "virtual/kernel-extension"
+
+# Bundle the initramfs in a single pass, since stock do_bundle_initramfs
+# compiles the whole kernel a second time to bake the initramfs in.
+#
+# Safe for an extension kernel and only for one: it leaves <imageType> and
+# <imageType>.initramfs identical, and the extension consumes only the latter,
+# through kernel-extension-image-initramfs.bb. A base kernel would end up
+# deploying a plain image carrying an initramfs it should not have.
+KERNEL_EXTRA_ARGS:append = " CONFIG_INITRAMFS_SOURCE=${B}/usr/${INITRAMFS_IMAGE_NAME}.cpio"
+
+# An empty INITRAMFS_IMAGE here is a parse error rather than a no-op.
+do_compile[depends] += "${@'${INITRAMFS_IMAGE}:do_image_complete' if d.getVar('INITRAMFS_IMAGE') else ''}"
+
+do_compile:prepend() {
+    copy_initramfs
+}
+
+do_bundle_initramfs() {
+    for imageType in ${KERNEL_IMAGETYPE_FOR_MAKE}; do
+        cp -fL ${KERNEL_OUTPUT_DIR}/$imageType ${KERNEL_OUTPUT_DIR}/$imageType.initramfs
+    done
+}

--- a/meta-balena-common/conf/distro/include/balena-os.inc
+++ b/meta-balena-common/conf/distro/include/balena-os.inc
@@ -142,6 +142,10 @@ PREFERRED_VERSION_upx-native:arm = "3.94"
 # let's pin linux-firmware to the version we imported from Poky scarthgap release
 PREFERRED_VERSION_linux-firmware = "20240909"
 
+# meta-oe restricts bpftool to x86_64; balena-ebpf-extension installs it on
+# aarch64 too
+COMPATIBLE_HOST:pn-bpftool = "(x86_64|aarch64).*-linux"
+
 # Go version from walnascar, meets balena-engine v25 requirement
 GOVERSION = "1.24.6"
 PREFERRED_PROVIDER_go-native = "go-binary-native"

--- a/meta-balena-common/recipes-containers/balena-extension-runtime/balena-extension-runtime/hostapp-extensions-cleanup.service
+++ b/meta-balena-common/recipes-containers/balena-extension-runtime/balena-extension-runtime/hostapp-extensions-cleanup.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Clean up dead hostapp extension containers
+Description=Collect withdrawn hostapp extension containers and volumes
 After=balena.service
 Before=balena-supervisor.service
 

--- a/meta-balena-common/recipes-core/images/balena-ebpf-extension.bb
+++ b/meta-balena-common/recipes-core/images/balena-ebpf-extension.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "eBPF hostapp extension: a kernel with BTF and the BPF tracing surface, its matching modules, and the userspace tooling"
+LICENSE = "MIT"
+
+inherit kernel-extension-image
+
+# :append rather than a plain assignment, which would parse after the inherit
+# above and drop the kernel payload the class contributes.
+IMAGE_INSTALL:append = " bpftool libbpf"

--- a/meta-balena-common/recipes-core/images/balena-tracing-extension.bb
+++ b/meta-balena-common/recipes-core/images/balena-tracing-extension.bb
@@ -1,0 +1,4 @@
+DESCRIPTION = "Tracing hostapp extension"
+LICENSE = "MIT"
+
+inherit balena-hostapp-extension balena-tracing

--- a/meta-balena-common/recipes-kernel/linux/files/ebpf.cfg
+++ b/meta-balena-common/recipes-kernel/linux/files/ebpf.cfg
@@ -1,0 +1,32 @@
+# BPF LSM + BTF + tracing/observability
+#
+
+# BTF needs full DWARF
+CONFIG_DEBUG_KERNEL=y
+CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT=y
+# Not settable directly. Kept because do_kernel_balena_verify_fragments turns it
+# into the assertion that the prerequisite survived the merge.
+CONFIG_DEBUG_INFO=y
+# CONFIG_DEBUG_INFO_NONE is not set
+# CONFIG_DEBUG_INFO_REDUCED is not set
+CONFIG_DEBUG_INFO_BTF=y
+
+# BPF core.
+CONFIG_BPF=y
+CONFIG_BPF_SYSCALL=y
+CONFIG_BPF_JIT=y
+CONFIG_BPF_JIT_ALWAYS_ON=y
+CONFIG_BPF_LSM=y
+# CONFIG_LSM is deliberately not set here. It is a whole-list value, so a
+# fragment can only replace the device's list, never add to it, and replacing
+# it would drop every other LSM the device enables. Every kconfig default ends
+# in "bpf", so the list is expected to already carry it;
+# do_kernel_ebpf_verify_lsm asserts that rather than assuming it.
+
+# Tracing surface for observability.
+CONFIG_FTRACE=y
+CONFIG_FUNCTION_TRACER=y
+CONFIG_KPROBES=y
+CONFIG_KPROBE_EVENTS=y
+CONFIG_PERF_EVENTS=y
+CONFIG_BPF_EVENTS=y

--- a/meta-balena-common/recipes-kernel/linux/kernel-extension-image-initramfs.bb
+++ b/meta-balena-common/recipes-kernel/linux/kernel-extension-image-initramfs.bb
@@ -1,0 +1,4 @@
+require recipes-kernel/linux/kernel-image-initramfs.bb
+
+KERNEL_INITRAMFS_PROVIDER = "virtual/kernel-extension"
+KERNEL_INITRAMFS_DEPLOY_DIR = "${DEPLOY_DIR_IMAGE}/kernel-extension"

--- a/meta-balena-common/recipes-support/kernel-override-hooks/files/create
+++ b/meta-balena-common/recipes-support/kernel-override-hooks/files/create
@@ -22,7 +22,7 @@ BOOT_BY_ABI_DIR="/mnt/data/boot-by-abi"
 
 extension_kernel_override_prelude "${EXTENSION_ROOTFS}" || exit 0
 
-VOLUME_DATA="${EXTENSION_VOLUME_BOOT:?EXTENSION_VOLUME_BOOT not set; image is missing VOLUME /boot}"
+VOLUME_DATA="${EXTENSION_VOLUME_BOOT:?kernel override volume not found}"
 
 mkdir -p "${BOOT_BY_ABI_DIR}"
 

--- a/meta-balena-kirkstone/recipes-kernel/perf/perf.bbappend
+++ b/meta-balena-kirkstone/recipes-kernel/perf/perf.bbappend
@@ -1,0 +1,2 @@
+PERF_SRC:append:aarch64 = " arch/arm64/include/uapi/asm/bpf_perf_event.h arch/arm64/tools"
+RDEPENDS:${PN}-tests += "perl"


### PR DESCRIPTION
Includes the abstraction of the shared extension logic into reusable classes.

Relates to: https://balena.fibery.io/Work/Project/Hostapp-extensions-overlays---HUP-and-rollbacks-2334

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
