### PR TITLE
docs: Fix obsolete link to application update locking documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Host OS update scripts (`safe_reboot` in `hostapp-update`) check for an exclusiv
 
 This is independent from the application update lock mechanism managed by the Supervisor. The Supervisor uses a lockfile (file existence) to prevent application updates, while the host OS uses `flock()` to prevent reboots during OS updates.
 
-During critical operations, both mechanisms should be used together for full protection. For details on the application update lock and how to combine both, see the [Supervisor update locking documentation](https://github.com/balena-os/balena-supervisor/blob/master/docs/update-locking.md).
+During critical operations, both mechanisms should be used together for full protection. For details on the application update lock and how to combine both, see the online [update locking documentation](https://docs.balena.io/learn/deploy/release-strategy/update-locking).
 
 #### Creating the flock
 


### PR DESCRIPTION
Old link target removed in balena-os/balena-supervisor#2521

Change-type: patch

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [x] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [?] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
