### PR TITLE
os-helpers-bootenv: route bootenv writes through fatrw

### DIFF
--- a/meta-balena-common/recipes-support/hostapp-update-hooks/files/99-balena-bootloader
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/files/99-balena-bootloader
@@ -8,6 +8,7 @@ set -o errexit
 
 . /usr/sbin/balena-config-vars
 . /usr/libexec/os-helpers-logging
+. /usr/libexec/os-helpers-bootenv
 
 DURING_UPDATE=${DURING_UPDATE:-0}
 
@@ -29,7 +30,7 @@ BOOTENV_FILE="${BALENA_NONENC_BOOT_MOUNTPOINT}/bootenv"
 rm -f "${BALENA_NONENC_BOOT_MOUNTPOINT}/resinOS_uEnv.txt"
 rm -f "${BALENA_NONENC_BOOT_MOUNTPOINT}/grubenv"
 
-grub-editenv "${BOOTENV_FILE}" set "resin_root_part=${NEW_ROOT}"
-grub-editenv "${BOOTENV_FILE}" set "upgrade_available=${DURING_UPDATE}"
+bootenv_set "${BOOTENV_FILE}" "resin_root_part" "${NEW_ROOT}"
+bootenv_set "${BOOTENV_FILE}" "upgrade_available" "${DURING_UPDATE}"
 
 info "Will use root ${NEW_ROOT} during next boot"

--- a/meta-balena-common/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bb
+++ b/meta-balena-common/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bb
@@ -65,6 +65,7 @@ RDEPENDS:${PN} = " \
     balena-extension-runtime \
     dropbear \
     openssh-keygen \
+    os-helpers-bootenv \
     util-linux \
     "
 RDEPENDS:${PN}:append = "${@oe.utils.conditional('SIGN_API','','',' os-helpers-sb',d)}"

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-bootenv
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-bootenv
@@ -17,6 +17,11 @@
 # POSIX /bin/sh compatible; safe to source from busybox sh (initrd) and
 # the host OS.
 #
+# The file lives on the FAT boot partition, where an interrupted write
+# can corrupt the environment block and leave the device unbootable.
+# Every mutation therefore goes through bootenv_edit, which stages the
+# change off-partition and publishes it with fatrw.
+#
 
 # bootenv_get <file> <key>
 #   Prints the value of <key> on stdout if present; prints nothing if
@@ -32,14 +37,59 @@ bootenv_get() {
     grub-editenv "${_file}" list 2>/dev/null | sed -n "s/^${_key}=//p"
 }
 
+# bootenv_publish <source> <target>
+#   Replaces <target> with the contents of <source>.
+bootenv_publish() {
+    if command -v /usr/bin/fatrw >/dev/null 2>&1; then
+        /usr/bin/fatrw copy "$1" "$2"
+    else
+        cp "$1" "$2" && sync
+    fi
+}
+
+# bootenv_stage <file> <scratch>
+#   Seeds <scratch> with the current environment block of <file>, or with
+#   a fresh block when <file> does not exist.
+bootenv_stage() {
+    if [ -f "$1" ]; then
+        cp "$1" "$2"
+    else
+        grub-editenv "$2" create
+    fi
+}
+
+# bootenv_edit <file> <grub-editenv arguments...>
+#   Applies a grub-editenv operation to <file> without editing it in
+#   place. Staging the change on a scratch copy and
+#   publishing the result keeps <file> at either the old or the new
+#   block.
+#   Returns non-zero and leaves <file> untouched on failure.
+bootenv_edit() {
+    _file="$1"
+    shift
+    [ -n "${_file}" ] || return 1
+    command -v grub-editenv >/dev/null 2>&1 || return 1
+
+    # An explicit template keeps this working under busybox mktemp, which
+    # unlike coreutils refuses to run without one.
+    _tmp=$(mktemp "${TMPDIR:-/tmp}/bootenv.XXXXXX") || return 1
+    _rc=1
+    if bootenv_stage "${_file}" "${_tmp}" && grub-editenv "${_tmp}" "$@"; then
+        bootenv_publish "${_tmp}" "${_file}"
+        _rc=$?
+    fi
+    rm -f "${_tmp}"
+    return "${_rc}"
+}
+
 # bootenv_set <file> <key> <value>
 bootenv_set() {
-    grub-editenv "$1" set "$2=$3"
+    bootenv_edit "$1" set "$2=$3"
 }
 
 # bootenv_unset <file> <key>
 bootenv_unset() {
-    grub-editenv "$1" unset "$2"
+    bootenv_edit "$1" unset "$2"
 }
 
 # bootenv_commit_override <file> <slot>
@@ -47,8 +97,8 @@ bootenv_unset() {
 bootenv_commit_override() {
     _f="$1"
     _slot="$2"
-    grub-editenv "${_f}" set \
-        "kernel_override_abi_committed_${_slot}=$(bootenv_get "${_f}" "kernel_override_abi")"
+    bootenv_set "${_f}" "kernel_override_abi_committed_${_slot}" \
+        "$(bootenv_get "${_f}" "kernel_override_abi")"
 }
 
 # bootenv_restore_kernel_override <file> <slot>


### PR DESCRIPTION
grub-editenv rewrites the entire environment block in place. On the FAT boot partition an interrupted write can leave that block unparseable, which makes the device unbootable.

This commit stages every mutation on a scratch copy and publish it with fatrw so the on-disk file holds either the old or the new block.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
