### PR TITLE
workflows: Pin yocto-scripts to master

### DIFF
--- a/.github/workflows/genericx86-64-ext.yml
+++ b/.github/workflows/genericx86-64-ext.yml
@@ -24,8 +24,6 @@ permissions:
 jobs:
   yocto:
     name: Yocto
-    # FIXME: This workflow has dependencies on scripts in the balena-yocto-scripts repository
-    # which is pinned separately as a submodule in the device repo. Expect some drift but try to retain compatibility.
     uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@master
     # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
     # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
@@ -38,6 +36,7 @@ jobs:
       machine: genericx86-64-ext
       device-repo: balena-os/balena-intel
       device-repo-ref: master
+      yocto-scripts-ref: master
       # Pin to the current commit
       meta-balena-ref: ${{ github.event.pull_request.head.sha }}
       # Use QEMU workers for testing and run cloud suite against balenaCloud production

--- a/.github/workflows/genericx86-64.yml
+++ b/.github/workflows/genericx86-64.yml
@@ -24,8 +24,6 @@ permissions:
 jobs:
   yocto:
     name: Yocto
-    # FIXME: This workflow has dependencies on scripts in the balena-yocto-scripts repository
-    # which is pinned separately as a submodule in the device repo. Expect some drift but try to retain compatibility.
     uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@master
     # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
     # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
@@ -38,5 +36,6 @@ jobs:
       machine: genericx86-64
       device-repo: balena-os/balena-intel
       device-repo-ref: master
+      yocto-scripts-ref: master
       # Pin to the current commit
       meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/iot-gate-imx8.yml
+++ b/.github/workflows/iot-gate-imx8.yml
@@ -37,5 +37,6 @@ jobs:
       build-args: '--templates-path layers/meta-balena-imx8mm'
       device-repo: balena-os/balena-iot-gate-imx8
       device-repo-ref: master
+      yocto-scripts-ref: master
       # Pin to the current commit
       meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/iot-gate-imx8plus.yml
+++ b/.github/workflows/iot-gate-imx8plus.yml
@@ -37,5 +37,6 @@ jobs:
       build-args: '--templates-path layers/meta-balena-imx8mplus'
       device-repo: balena-os/balena-iot-gate-imx8plus
       device-repo-ref: master
+      yocto-scripts-ref: master
       # Pin to the current commit
       meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/iotdin-imx8p-d1d8.yml
+++ b/.github/workflows/iotdin-imx8p-d1d8.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   yocto:
     name: Yocto
-    uses: balena-os/balena-iotdin-imx8p/.github/workflows/iotdin-imx8p-d1d8.yml@master
+    uses: balena-os/balena-compulab-imx8mp/.github/workflows/iotdin-imx8p-d1d8.yml@master
     # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
     # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
     # This condition will prevent the workflow from running twice for the same pull request while

--- a/.github/workflows/iotdin-imx8p.yml
+++ b/.github/workflows/iotdin-imx8p.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   yocto:
     name: Yocto
-    uses: balena-os/balena-iotdin-imx8p/.github/workflows/iotdin-imx8p.yml@master
+    uses: balena-os/balena-compulab-imx8mp/.github/workflows/iotdin-imx8p.yml@master
     # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
     # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
     # This condition will prevent the workflow from running twice for the same pull request while

--- a/.github/workflows/jetson-tx2.yml
+++ b/.github/workflows/jetson-tx2.yml
@@ -36,5 +36,6 @@ jobs:
       machine: jetson-tx2
       device-repo: balena-os/balena-jetson
       device-repo-ref: master
+      yocto-scripts-ref: master
       # Pin to the current commit
       meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/raspberrypi.yml
+++ b/.github/workflows/raspberrypi.yml
@@ -36,5 +36,6 @@ jobs:
       machine: raspberrypi
       device-repo: balena-os/balena-raspberrypi
       device-repo-ref: master
+      yocto-scripts-ref: master
       # Pin to the current commit
       meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/raspberrypi3-64.yml
+++ b/.github/workflows/raspberrypi3-64.yml
@@ -24,8 +24,6 @@ permissions:
 jobs:
   yocto:
     name: Yocto
-    # FIXME: This workflow has dependencies on scripts in the balena-yocto-scripts repository
-    # which is pinned separately as a submodule in the device repo. Expect some drift but try to retain compatibility.
     uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@master
     # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
     # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
@@ -38,5 +36,6 @@ jobs:
       machine: raspberrypi3-64
       device-repo: balena-os/balena-raspberrypi
       device-repo-ref: master
+      yocto-scripts-ref: master
       # Pin to the current commit
       meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/raspberrypi3.yml
+++ b/.github/workflows/raspberrypi3.yml
@@ -24,8 +24,6 @@ permissions:
 jobs:
   yocto:
     name: Yocto
-    # FIXME: This workflow has dependencies on scripts in the balena-yocto-scripts repository
-    # which is pinned separately as a submodule in the device repo. Expect some drift but try to retain compatibility.
     uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@master
     # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
     # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
@@ -38,5 +36,6 @@ jobs:
       machine: raspberrypi3
       device-repo: balena-os/balena-raspberrypi
       device-repo-ref: master
+      yocto-scripts-ref: master
       # Pin to the current commit
       meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/raspberrypi4-64.yml
+++ b/.github/workflows/raspberrypi4-64.yml
@@ -24,8 +24,6 @@ permissions:
 jobs:
   yocto:
     name: Yocto
-    # FIXME: This workflow has dependencies on scripts in the balena-yocto-scripts repository
-    # which is pinned separately as a submodule in the device repo. Expect some drift but try to retain compatibility.
     uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@master
     # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
     # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
@@ -38,5 +36,6 @@ jobs:
       machine: raspberrypi4-64
       device-repo: balena-os/balena-raspberrypi
       device-repo-ref: master
+      yocto-scripts-ref: master
       # Pin to the current commit
       meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/revpi-connect-4.yml
+++ b/.github/workflows/revpi-connect-4.yml
@@ -36,5 +36,6 @@ jobs:
       machine: revpi-connect-4
       device-repo: balena-os/balena-raspberrypi
       device-repo-ref: master
+      yocto-scripts-ref: master
       # Pin to the current commit
       meta-balena-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/var-som-mx6..yml
+++ b/.github/workflows/var-som-mx6..yml
@@ -36,5 +36,6 @@ jobs:
       machine: var-som-mx6
       device-repo: balena-os/balena-variscite
       device-repo-ref: master
+      yocto-scripts-ref: master
       # Pin to the current commit
       meta-balena-ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Release v1.42.0 has a dependency on the yocto-scripts submodule being updated in the device repo to match.

Fixes "prepare-image.py: No such file or directory"

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
