### PR TITLE
balena-proxy-config: engage the redirect only while redsocks serves

### DIFF
--- a/meta-balena-common/recipes-connectivity/balena-proxy-config/balena-proxy-config.bb
+++ b/meta-balena-common/recipes-connectivity/balena-proxy-config/balena-proxy-config.bb
@@ -7,13 +7,15 @@ SRC_URI = " \
     file://redsocks.service \
     file://balena-proxy-config \
     file://balena-proxy-config.service \
+    file://balena-proxy-watchdog.service \
+    file://balena-proxy-watchdog.timer \
     "
 
 inherit allarch systemd useradd
 
 PACKAGES = "${PN}"
 
-SYSTEMD_SERVICE:${PN} = "balena-proxy-config.service redsocks.service"
+SYSTEMD_SERVICE:${PN} = "balena-proxy-config.service redsocks.service balena-proxy-watchdog.service balena-proxy-watchdog.timer"
 RDEPENDS:${PN} = "redsocks iptables"
 
 USERADD_PACKAGES = "${PN}"
@@ -27,6 +29,8 @@ do_install() {
         install -d ${D}${systemd_unitdir}/system
         install -c -m 0644 ${UNPACKDIR}/balena-proxy-config.service ${D}${systemd_unitdir}/system
         install -c -m 0644 ${UNPACKDIR}/redsocks.service ${D}${systemd_unitdir}/system
+        install -c -m 0644 ${UNPACKDIR}/balena-proxy-watchdog.service ${D}${systemd_unitdir}/system
+        install -c -m 0644 ${UNPACKDIR}/balena-proxy-watchdog.timer ${D}${systemd_unitdir}/system
         sed -i -e 's,@BASE_BINDIR@,${base_bindir},g' \
             -e 's,@BINDIR@,${bindir},g' \
             ${D}${systemd_unitdir}/system/*.service

--- a/meta-balena-common/recipes-connectivity/balena-proxy-config/balena-proxy-config/balena-proxy-config
+++ b/meta-balena-common/recipes-connectivity/balena-proxy-config/balena-proxy-config/balena-proxy-config
@@ -8,6 +8,21 @@ set -e
 IPTABLES_WAIT_SECS="10"
 IPTABLES="iptables -w $IPTABLES_WAIT_SECS"
 
+REDSOCKS_ADDR="10.114.103.1"
+REDSOCKS_PORT="12345"
+REDSOCKS_DNS_PORT="5313"
+
+# The same REDSOCKS_ADDR and REDSOCKS_PORT as above, written the way
+# /proc/net/tcp renders a local address.
+REDSOCKS_LISTEN_HEX=$(IFS=.; set -- ${REDSOCKS_ADDR}; \
+	printf '%02X%02X%02X%02X:%04X' "$4" "$3" "$2" "$1" "${REDSOCKS_PORT}")
+
+DNS_INTERFACE_NAME="resin-redsocks"
+LOCKFILE="/run/lock/balena-proxy-config"
+PROC_NET_TCP="/proc/net/tcp"
+ATTACH_TIMEOUT_SECS="10"
+LOCK_TIMEOUT_SECS="30"
+
 . /usr/sbin/balena-config-vars
 . /usr/libexec/os-helpers-logging
 
@@ -38,8 +53,6 @@ removeRulesFromChain() {
 
 if [ ! -f "$CONFIG_PATH" ]; then
 	fail "$CONFIG_PATH does not exist."
-else
-	info "Found config.json in $CONFIG_PATH ."
 fi
 
 if [ ! -d "$BALENA_BOOT_MOUNTPOINT" ]; then
@@ -48,73 +61,316 @@ fi
 
 REDSOCKSCONF=${BALENA_BOOT_MOUNTPOINT}/system-proxy/redsocks.conf
 NOPROXYFILE=${BALENA_BOOT_MOUNTPOINT}/system-proxy/no_proxy
+FAILUREFILE=${BALENA_BOOT_MOUNTPOINT}/system-proxy/on_proxy_failure
 
 # README!
 # The entire following configuration depends on the redsocks configuration.
 # Currently the values used here are forced with a patch on redsocks. If these
 # change, you need to refresh the redsocks patch as well.
 
-# Always clear the REDSOCKS chain if it exists (in case we're restarting with a changed configuration)
-$IPTABLES -t nat -D OUTPUT -p udp -m owner ! --uid-owner redsocks -j DNAT --dport 53 --to-destination 10.114.103.1:5313 || true
-$IPTABLES -t nat -D PREROUTING -p udp -j DNAT --dport 53 --to-destination 10.114.103.1:5313 || true
-removeRulesFromChain OUTPUT REDSOCKS
-removeRulesFromChain PREROUTING REDSOCKS
-$IPTABLES -t nat -F REDSOCKS || true
-$IPTABLES -t nat -X REDSOCKS || true
-
-if [ ! -f "$REDSOCKSCONF" ]; then
-	info "No proxy configuration found, skipping."
-	exit 0
+# On proxy failure allow direct connections.
+# Recoverability wins over keeping egress proxied.
+# To forbid unproxied egress the proxy can be configured with reject.
+FAILURE_ACTION="direct"
+if [ "$(cat "${FAILUREFILE}" 2>/dev/null)" = "reject" ]; then
+	FAILURE_ACTION="reject"
 fi
 
-# Setup a bridge interface for redsocks
-DNS_INTERFACE_NAME="resin-redsocks"
-DNS_INTERFACE_IP="10.114.103.1"
-if [ ! -d "/sys/class/net/${DNS_INTERFACE_NAME}" ]; then
-	ip link add name ${DNS_INTERFACE_NAME} type bridge
+# Disengaging the redirect means sending TCP straight past the REDSOCKS chain.
+BYPASS_RULE="-p tcp -j RETURN"
+
+# When the dnsu2t module is enabled in redsocks, UDP DNS is redirected into it
+# to force DNS over TCP. These move with the TCP redirect, never independently.
+DNS_OUTPUT_RULE="-p udp -m owner ! --uid-owner redsocks --dport 53 -j DNAT --to-destination ${REDSOCKS_ADDR}:${REDSOCKS_DNS_PORT}"
+DNS_PREROUTING_RULE="-p udp --dport 53 -j DNAT --to-destination ${REDSOCKS_ADDR}:${REDSOCKS_DNS_PORT}"
+
+# iptables has no idempotent add or delete, so every change is a -C guarded -A/-D.
+add_rule() {
+	_chain="$1"
+	shift
+	if ! $IPTABLES -t nat -C "${_chain}" "$@" > /dev/null 2>&1; then
+		$IPTABLES -t nat -A "${_chain}" "$@"
+	fi
+}
+
+# Loops because an external actor can leave duplicates that a single -D would
+# not clear, and reconcile promises to restore the invariant from any state.
+del_rule() {
+	_chain="$1"
+	shift
+	while $IPTABLES -t nat -C "${_chain}" "$@" > /dev/null 2>&1; do
+		$IPTABLES -t nat -D "${_chain}" "$@"
+	done
+}
+
+# Proves the socket is bound, which is all that can be observed from outside the
+# process: the kernel completes the handshake from the listen backlog whether or
+# not redsocks ever calls accept(). Matches REDSOCKS_LISTEN_HEX in state 0A,
+# TCP_LISTEN. Read from /proc rather than through ss, which is not installed.
+serving() {
+	awk -v a="${REDSOCKS_LISTEN_HEX}" '$2 == a && $4 == "0A" { f = 1 } END { exit !f }' \
+		"${PROC_NET_TCP}"
+}
+
+dns_redirect_enabled() {
+	grep ^dnsu2t "${REDSOCKSCONF}" > /dev/null 2>&1
+}
+
+chain_exists() {
+	$IPTABLES -t nat -S REDSOCKS > /dev/null 2>&1
+}
+
+jumps_installed() {
+	$IPTABLES -t nat -C OUTPUT -m owner ! --uid-owner redsocks -p tcp -j REDSOCKS \
+		> /dev/null 2>&1
+}
+
+installed() {
+	chain_exists && jumps_installed
+}
+
+# The subnet exemptions all carry -d, so they never collide with the bypass.
+bypassed() {
+	$IPTABLES -t nat -C REDSOCKS ${BYPASS_RULE} > /dev/null 2>&1
+}
+
+engage() {
+	if bypassed; then
+		$IPTABLES -t nat -D REDSOCKS ${BYPASS_RULE}
+		info "Redirecting traffic through redsocks."
+	fi
+	if dns_redirect_enabled; then
+		add_rule OUTPUT ${DNS_OUTPUT_RULE}
+		add_rule PREROUTING ${DNS_PREROUTING_RULE}
+	fi
+}
+
+disengage() {
+	if ! bypassed; then
+		$IPTABLES -t nat -I REDSOCKS 1 ${BYPASS_RULE}
+		warn "redsocks is not serving, sending traffic directly."
+	fi
+	del_rule OUTPUT ${DNS_OUTPUT_RULE}
+	del_rule PREROUTING ${DNS_PREROUTING_RULE}
+}
+
+# TCP and DNS engage and disengage together
+apply_redirect() {
+	if serving || [ "${FAILURE_ACTION}" = "reject" ]; then
+		engage
+	else
+		disengage
+	fi
+}
+
+ensure_bridge() {
+	# Setup a bridge interface for redsocks
+	if [ ! -d "/sys/class/net/${DNS_INTERFACE_NAME}" ]; then
+		ip link add name ${DNS_INTERFACE_NAME} type bridge
+	fi
+	if [ "$(cat /sys/class/net/${DNS_INTERFACE_NAME}/operstate)" = "down" ]; then
+		ip link set ${DNS_INTERFACE_NAME} up
+	fi
+	if [ "$(ip addr show ${DNS_INTERFACE_NAME} | grep -o "inet [0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | grep -o "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*")" != "${REDSOCKS_ADDR}" ]; then
+		ip address add ${REDSOCKS_ADDR}/24 dev ${DNS_INTERFACE_NAME}
+	fi
+
+	# Redsocks needs a redsocks user to work properly with our setup
+	id -u redsocks > /dev/null 2>&1 || fail "redsocks user doesn't exist"
+}
+
+build_chain() {
+	# Set up iptables chain for redsocks
+	$IPTABLES -t nat -N REDSOCKS
+
+	# Use every line in the no_proxy file as an IP/subnet to not redirect through redsocks
+	if [ -f "$NOPROXYFILE" ]; then
+		info "Noproxy configuration found in $NOPROXYFILE ..."
+		while IFS= read -r line || [ -n "${line}" ]; do
+			echo "Setting no proxy for $line ..."
+			$IPTABLES -t nat -A REDSOCKS -d "$line" -j RETURN
+		done < "$NOPROXYFILE"
+	fi
+
+	# Setup a new user chain for redsocks
+	$IPTABLES -t nat -A REDSOCKS -d 0.0.0.0/8 -j RETURN
+	$IPTABLES -t nat -A REDSOCKS -d 10.0.0.0/8 -j RETURN
+	$IPTABLES -t nat -A REDSOCKS -d 100.64.0.0/10 -j RETURN
+	$IPTABLES -t nat -A REDSOCKS -d 127.0.0.0/8 -j RETURN
+	$IPTABLES -t nat -A REDSOCKS -d 169.254.0.0/16 -j RETURN
+	$IPTABLES -t nat -A REDSOCKS -d 172.16.0.0/12 -j RETURN
+	$IPTABLES -t nat -A REDSOCKS -d 192.168.0.0/16 -j RETURN
+	$IPTABLES -t nat -A REDSOCKS -d 224.0.0.0/4 -j RETURN
+	$IPTABLES -t nat -A REDSOCKS -d 240.0.0.0/4 -j RETURN
+	$IPTABLES -t nat -A REDSOCKS -p tcp -j DNAT --to ${REDSOCKS_ADDR}:${REDSOCKS_PORT}
+}
+
+install_jumps() {
+	# Redirect TCP connections to redsocks
+	$IPTABLES -t nat -A OUTPUT -m owner --uid-owner redsocks -p tcp --dport 53 -j REDSOCKS
+	$IPTABLES -t nat -A OUTPUT -m owner ! --uid-owner redsocks -p tcp -j REDSOCKS
+	$IPTABLES -t nat -A PREROUTING -p tcp -j REDSOCKS
+}
+
+teardown() {
+	# Always clear the REDSOCKS chain if it exists (in case we're restarting with a changed configuration)
+	del_rule OUTPUT ${DNS_OUTPUT_RULE}
+	del_rule PREROUTING ${DNS_PREROUTING_RULE}
+	removeRulesFromChain OUTPUT REDSOCKS
+	removeRulesFromChain PREROUTING REDSOCKS
+	$IPTABLES -t nat -F REDSOCKS || true
+	$IPTABLES -t nat -X REDSOCKS || true
+}
+
+setup() {
+	teardown
+
+	if [ ! -f "$REDSOCKSCONF" ]; then
+		info "No proxy configuration found, skipping."
+		return 0
+	fi
+
+	ensure_bridge
+	build_chain
+
+	# Settle the redirect before the jumps go in, so no code path can leave the
+	# device redirecting into a redsocks that is not there. Also covers a restart
+	# of this service on its own while redsocks is already up, which is what the
+	# supervisor does on a proxy configuration change.
+	apply_redirect
+	install_jumps
+}
+
+attach() {
+	if [ ! -f "$REDSOCKSCONF" ]; then
+		fail "No proxy configuration found."
+	fi
+	if ! chain_exists; then
+		fail "REDSOCKS chain does not exist."
+	fi
+
+	# ExecStartPost fires when redsocks is spawned, not when it binds
+	_waited=0
+	while ! serving; do
+		if [ "${_waited}" -ge "${ATTACH_TIMEOUT_SECS}" ]; then
+			fail "redsocks is not listening on ${REDSOCKS_ADDR}:${REDSOCKS_PORT}."
+		fi
+		sleep 1
+		_waited=$((_waited + 1))
+	done
+
+	engage
+}
+
+detach() {
+	if ! chain_exists; then
+		info "REDSOCKS chain does not exist, nothing to detach."
+		return 0
+	fi
+
+	apply_redirect
+}
+
+# Restores the invariant below from any state the device can be found in. Every
+# operation it calls is idempotent, so a pass that finds nothing wrong is silent.
+reconcile() {
+	if [ ! -f "$REDSOCKSCONF" ]; then
+		if chain_exists || jumps_installed; then
+			warn "Proxy configuration is gone but the redirect is still installed. Tearing it down."
+			teardown
+		fi
+		return 0
+	fi
+
+	# A missing chain or missing jumps is repaired by rebuilding, which also
+	# engages the redirect when redsocks is already up.
+	if ! installed; then
+		warn "Proxy is configured but the redirect is not installed. Rebuilding."
+		setup
+		return 0
+	fi
+
+	apply_redirect
+}
+
+# While a proxy is configured the redirect is installed and engaged if and only
+# if redsocks is listening.
+violation() {
+	if [ ! -f "$REDSOCKSCONF" ]; then
+		if chain_exists || jumps_installed; then
+			echo "proxy configuration is absent but the redirect is still installed"
+		fi
+		return 0
+	fi
+
+	if ! installed; then
+		echo "proxy is configured but the redirect is not installed"
+	elif serving && bypassed; then
+		echo "redsocks is serving but traffic is not redirected through it"
+	elif ! serving && ! bypassed && [ "${FAILURE_ACTION}" = "direct" ]; then
+		echo "traffic is redirected into a redsocks that is not serving"
+	fi
+}
+
+status() {
+	_violation=$(violation)
+
+	if [ "${1:-}" != "--quiet" ]; then
+		_config="absent"
+		if [ -f "$REDSOCKSCONF" ]; then
+			_config="present"
+		fi
+		_serving="no"
+		if serving; then
+			_serving="yes"
+		fi
+		_redirect="absent"
+		if chain_exists; then
+			_redirect="engaged"
+			if bypassed; then
+				_redirect="disengaged"
+			fi
+		fi
+		_jumps="no"
+		if jumps_installed; then
+			_jumps="yes"
+		fi
+
+		echo "config=${_config} serving=${_serving} redirect=${_redirect} jumps=${_jumps} on_failure=${FAILURE_ACTION}"
+		if [ -n "${_violation}" ]; then
+			echo "violation: ${_violation}"
+		fi
+	fi
+
+	[ -z "${_violation}" ]
+}
+
+# Serialise against a supervisor driven restart and against the reconcile timer.
+exec 9>"${LOCKFILE}"
+if ! flock -w "${LOCK_TIMEOUT_SECS}" 9; then
+	fail "Timed out waiting for ${LOCKFILE}."
 fi
-if [ "$(cat /sys/class/net/${DNS_INTERFACE_NAME}/operstate)" = "down" ]; then
-	ip link set ${DNS_INTERFACE_NAME} up
-fi
-if [ "$(ip addr show ${DNS_INTERFACE_NAME} | grep -o "inet [0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | grep -o "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*")" != "${DNS_INTERFACE_IP}" ]; then
-	ip address add ${DNS_INTERFACE_IP}/24 dev ${DNS_INTERFACE_NAME}
-fi
 
-# Redsocks needs a redsocks user to work properly with our setup
-id -u redsocks > /dev/null 2>&1 || (echo "ERROR: redsocks user doesn't exist" && exit 1)
-
-# Set up iptables chain for redsocks
-$IPTABLES -t nat -N REDSOCKS
-
-# Use every line in the no_proxy file as an IP/subnet to not redirect through redsocks
-if [ -f "$NOPROXYFILE" ]; then
-	info "Noproxy configuration found in $NOPROXYFILE ..."
-	while IFS= read -r line || [ -n "${line}" ]; do
-		echo "Setting no proxy for $line ..."
-		$IPTABLES -t nat -A REDSOCKS -d "$line" -j RETURN
-	done < "$NOPROXYFILE"
-fi
-
-# Setup a new user chain for redsocks
-$IPTABLES -t nat -A REDSOCKS -d 0.0.0.0/8 -j RETURN
-$IPTABLES -t nat -A REDSOCKS -d 10.0.0.0/8 -j RETURN
-$IPTABLES -t nat -A REDSOCKS -d 100.64.0.0/10 -j RETURN
-$IPTABLES -t nat -A REDSOCKS -d 127.0.0.0/8 -j RETURN
-$IPTABLES -t nat -A REDSOCKS -d 169.254.0.0/16 -j RETURN
-$IPTABLES -t nat -A REDSOCKS -d 172.16.0.0/12 -j RETURN
-$IPTABLES -t nat -A REDSOCKS -d 192.168.0.0/16 -j RETURN
-$IPTABLES -t nat -A REDSOCKS -d 224.0.0.0/4 -j RETURN
-$IPTABLES -t nat -A REDSOCKS -d 240.0.0.0/4 -j RETURN
-$IPTABLES -t nat -A REDSOCKS -p tcp -j DNAT --to 10.114.103.1:12345
-
-if grep ^dnsu2t /mnt/boot/system-proxy/redsocks.conf > /dev/null 2>&1; then
-	# If dnsu2t module is enabled in redsocks, redirect any DNS UDP packets to
-	# REDSOCKS to force DNS over TCP
-	$IPTABLES -t nat -A OUTPUT -p udp -m owner ! --uid-owner redsocks -j DNAT --dport 53 --to-destination 10.114.103.1:5313
-	$IPTABLES -t nat -A PREROUTING -p udp -j DNAT --dport 53 --to-destination 10.114.103.1:5313
-fi
-
-# Redirect TCP connections to redsocks
-$IPTABLES -t nat -A OUTPUT -m owner --uid-owner redsocks -p tcp --dport 53 -j REDSOCKS
-$IPTABLES -t nat -A OUTPUT -m owner ! --uid-owner redsocks -p tcp -j REDSOCKS
-$IPTABLES -t nat -A PREROUTING -p tcp -j REDSOCKS
+case "${1:-setup}" in
+	setup)
+		setup
+		;;
+	attach)
+		attach
+		;;
+	detach)
+		detach
+		;;
+	reconcile)
+		reconcile
+		;;
+	teardown)
+		teardown
+		;;
+	status)
+		status "${2:-}"
+		;;
+	*)
+		fail "Unknown command: $1"
+		;;
+esac

--- a/meta-balena-common/recipes-connectivity/balena-proxy-config/balena-proxy-config/balena-proxy-config.service
+++ b/meta-balena-common/recipes-connectivity/balena-proxy-config/balena-proxy-config/balena-proxy-config.service
@@ -5,7 +5,7 @@ After=resin-boot.service dnsmasq.service
 
 [Service]
 Type=oneshot
-ExecStart=@BASE_BINDIR@/sh @BINDIR@/balena-proxy-config
+ExecStart=@BASE_BINDIR@/sh @BINDIR@/balena-proxy-config setup
 RemainAfterExit=yes
 
 [Install]

--- a/meta-balena-common/recipes-connectivity/balena-proxy-config/balena-proxy-config/balena-proxy-watchdog.service
+++ b/meta-balena-common/recipes-connectivity/balena-proxy-config/balena-proxy-config/balena-proxy-watchdog.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Reconcile the redsocks redirect with redsocks health
+After=balena-proxy-config.service
+
+[Service]
+Type=oneshot
+ExecStart=@BASE_BINDIR@/sh @BINDIR@/balena-proxy-config reconcile

--- a/meta-balena-common/recipes-connectivity/balena-proxy-config/balena-proxy-config/balena-proxy-watchdog.timer
+++ b/meta-balena-common/recipes-connectivity/balena-proxy-config/balena-proxy-config/balena-proxy-watchdog.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Periodically reconcile the redsocks redirect
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=30s
+AccuracySec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-balena-common/recipes-connectivity/balena-proxy-config/balena-proxy-config/redsocks.service
+++ b/meta-balena-common/recipes-connectivity/balena-proxy-config/balena-proxy-config/redsocks.service
@@ -3,11 +3,17 @@ Description=redsocks transparent proxy redirector
 Requires=resin-boot.service balena-proxy-config.service
 After=resin-boot.service balena-proxy-config.service dnsmasq.service
 ConditionPathExists=/mnt/boot/system-proxy/redsocks.conf
+# Retry for as long as a proxy stays configured. Giving up would leave the
+# device on the configured failure action with nothing driving it back.
+StartLimitIntervalSec=0
 
 [Service]
 User=redsocks
 ExecStart=@BINDIR@/redsocks -c /mnt/boot/system-proxy/redsocks.conf
-Restart=on-failure
+ExecStartPost=+@BASE_BINDIR@/sh @BINDIR@/balena-proxy-config attach
+ExecStopPost=+@BASE_BINDIR@/sh @BINDIR@/balena-proxy-config detach
+# always, not on-failure: a clean exit is not a reason to leave the proxy down
+Restart=always
 RestartSec=10s
 LimitNOFILE=16384
 

--- a/tests/suites/os/tests/connectivity/index.js
+++ b/tests/suites/os/tests/connectivity/index.js
@@ -199,5 +199,154 @@ module.exports = {
 				};
 			}),
 		},
+		{
+			title: 'Proxy redirect reconciliation tests',
+			run: async function(test) {
+				const host = async (cmd) =>
+					this.worker.executeCommandInHostOS(cmd, this.link);
+				const status = async () => host('balena-proxy-config status');
+				const reconcile = async () =>
+					host('systemctl start balena-proxy-watchdog.service');
+				// The DNS redirect has to track the TCP one. Left behind while redsocks
+				// is down it points UDP 53 at a closed port, which keeps the device off
+				// the network however the TCP redirect is set.
+				const DNS_RULE =
+					'-p udp -m owner ! --uid-owner redsocks --dport 53 ' +
+					'-j DNAT --to-destination 10.114.103.1:5313';
+				const dnsRedirected = async () =>
+					(
+						await host(
+							`iptables -w 10 -t nat -C OUTPUT ${DNS_RULE} && echo yes || echo no`,
+						)
+					).includes('yes');
+
+				// The upstream proxy is deliberately absent. Every assertion below is
+				// about the local listener and the iptables state, so an unreachable
+				// proxy must not influence any of them.
+				test.comment('Configuring a proxy with nothing listening upstream...');
+				await host('mkdir -p /mnt/boot/system-proxy');
+				await host(
+					'printf "' +
+						'base { \n' +
+						'log_debug = off; \n' +
+						'log_info = on; \n' +
+						'log = stderr; \n' +
+						'daemon = off; \n' +
+						'redirector = iptables; \n' +
+						'} \n' +
+						'redsocks { \n' +
+						'type = socks5; \n' +
+						'ip = 127.0.0.1; \n' +
+						'port = 8123; \n' +
+						'local_ip = 127.0.0.1; \n' +
+						'local_port = 12345; \n' +
+						'} \n' +
+						'dnsu2t { \n' +
+						'local_ip = 127.0.0.1; \n' +
+						'local_port = 5313; \n' +
+						'remote_ip = 127.0.0.1; \n' +
+						'remote_port = 53; \n' +
+						'} \n" > /mnt/boot/system-proxy/redsocks.conf',
+				);
+				await host(
+					'systemctl restart balena-proxy-config.service redsocks.service',
+				);
+
+				test.ok(
+					(await status()).includes('redirect=engaged'),
+					'Traffic should be redirected once redsocks is listening',
+				);
+				test.ok(
+					await dnsRedirected(),
+					'DNS should be redirected once redsocks is listening',
+				);
+
+				// The condition the reported outage happened under: the proxy itself is
+				// unreachable. That is not a local fault and must not move the redirect.
+				await reconcile();
+				test.ok(
+					(await status()).includes('redirect=engaged'),
+					'Reconciling should leave the redirect alone when only the upstream proxy is unreachable',
+				);
+
+				test.comment('Stopping redsocks...');
+				await host('systemctl stop redsocks.service');
+				test.ok(
+					(await status()).includes('redirect=disengaged'),
+					'Stopping redsocks should disengage the redirect immediately',
+				);
+				test.is(
+					await dnsRedirected(),
+					false,
+					'Stopping redsocks should take the DNS redirect out with the TCP one',
+				);
+				test.ok(
+					(
+						await host(
+							`curl -I -sS -o /dev/null -w "%{http_code}" --connect-timeout 5 ${URL_TEST}`,
+						)
+					).includes('200'),
+					`${URL_TEST} should resolve and respond directly while redsocks is down`,
+				);
+
+				test.comment('Forcing a redirect into a dead redsocks...');
+				await host('iptables -w 10 -t nat -D REDSOCKS -p tcp -j RETURN');
+				await host(`iptables -w 10 -t nat -A OUTPUT ${DNS_RULE}`);
+				await reconcile();
+				test.ok(
+					(await status()).includes('redirect=disengaged'),
+					'Reconciling should undo a redirect that points at a dead redsocks',
+				);
+				test.is(
+					await dnsRedirected(),
+					false,
+					'Reconciling should undo a DNS redirect that points at a dead redsocks',
+				);
+
+				test.comment('Starting redsocks again...');
+				await host('systemctl start redsocks.service');
+				test.ok(
+					(await status()).includes('redirect=engaged'),
+					'Starting redsocks should engage the redirect again',
+				);
+
+				test.comment('Flushing the nat table under a healthy redsocks...');
+				await host('iptables -w 10 -t nat -F');
+				await reconcile();
+				test.ok(
+					(await status()).includes('redirect=engaged'),
+					'Reconciling should rebuild the chain and the redirect after an external flush',
+				);
+
+				test.comment('Switching the failure action to reject...');
+				await host('echo reject > /mnt/boot/system-proxy/on_proxy_failure');
+				await host('systemctl stop redsocks.service');
+				await reconcile();
+				test.ok(
+					(await status()).includes('redirect=engaged'),
+					'The reject action should keep the redirect in place while redsocks is down',
+				);
+				await host('rm -f /mnt/boot/system-proxy/on_proxy_failure');
+
+				test.is(
+					await host('systemctl is-active balena-proxy-watchdog.timer'),
+					'active',
+					'The reconcile timer should be active',
+				);
+
+				// Nothing restarts balena-proxy-config here on purpose: reconciliation is
+				// the only thing left to notice the configuration is gone.
+				test.comment('Removing the proxy configuration...');
+				await host('rm -rf /mnt/boot/system-proxy');
+				await reconcile();
+				const finalStatus = await status();
+				test.ok(
+					finalStatus.includes('config=absent') &&
+						finalStatus.includes('redirect=absent') &&
+						finalStatus.includes('jumps=no'),
+					'Removing the configuration should leave no redirect behind',
+				);
+			},
+		},
 	],
 };


### PR DESCRIPTION
Nothing verified redsocks was listening before all outbound TCP was redirected into it, so a redsocks that never bound left the device with no egress and no remote recovery path.

This commit:

* Makes sure the redirect is engaged only while redsocks is confirmed listening.
* Has liveness proven by the bound socket, not by process state.
* Makes DNS move alongside TCP.
* Introduces a `on_proxy_failure` policy file in `/mnt/boot/system-proxy/`. Absent or anything other than reject means direct (bypass, recoverability wins). reject keeps both redirects engaged while redsocks is down so the kernel refuses the connection on the closed port.
* Adds periodic reconciliation. A new `balena-proxy-watchdog.timer` (1 min after boot, every 30 s) runs `balena-proxy-config reconcile`, which restores the invariant from any state: tears down a redirect whose configuration is gone, rebuilds a chain or jumps that went missing, and engages or disengages to match redsocks health. Every operation it calls is idempotent, so a clean pass is silent.
* redsocks restarts on clean exit and retries indefinitely. Restart=always replaces Restart=on-failure; StartLimitIntervalSec=0 in [Unit] means a persistently configured proxy is never abandoned.
* Serialised against concurrent invocations. flock on /run/lock/balena-proxy-config covers the supervisor restarting the service while the timer or a redsocks state change is mid-flight.


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
