### PR TITLE
hostapp.yml: Set network_mode none on the hostapp service

### DIFF
--- a/hostapp.yml
+++ b/hostapp.yml
@@ -1,9 +1,13 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/balena-os/balena-yocto-scripts/refs/heads/master/schemas/hostapp-composition.json
 version: '2.4'
+# Every service must set network_mode, or compose-go injects a `default` network into the
+# published composition and the supervisor creates a real bridge for it, whose auto-assigned
+# subnet can collide with the device's LAN. Declaring `networks: {}` does not suppress it.
 services:
 
   hostapp:
     image: __BUILD_OUTPUT__
+    network_mode: none
     x-build:
       assets:
         - "images/__MACHINE__/VERSION"


### PR DESCRIPTION
Without it, compose-go adds a default network to the published composition and the supervisor creates a real bridge whose subnet can collide with the device's LAN.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [x] Manual test case recorded - when setting network_mode, the default bridge does not get injected by compose-go.
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
