### PR TITLE
initrdscripts: more robustness looking for active root

### DIFF
--- a/meta-balena-common/recipes-core/initrdscripts/files/fsuuidsinit
+++ b/meta-balena-common/recipes-core/initrdscripts/files/fsuuidsinit
@@ -62,6 +62,23 @@ fsuuidsinit_run() {
         fi
         if regenerate_uuid "${dev}" "${fstype}"; then
             if [ -f "/run/initramfs/bootparam_root.mux" ]; then
+                # Sometimes changing the UUID makes the by-state
+                # symlinks disappear. Because resin_update_state_probe
+                # compares all partitions against the active root,
+                # it fails when it's triggered while the active root
+                # partition is also being processed by udev. It's
+                # a race condition that we only hit on very fast
+                # devices/CPUs and a subsequent udev trigger/settle
+                # usually resolves it.
+                # It is not a proper fix though. If you came here
+                # while debugging weird boot failures, don't add
+                # another hack, address the race condition and remove
+                # the trigger/settle below.
+                if ! wait4file "${dev}" 30; then
+                    info "by-state symlink for ${dev} vanished, re-triggering udev"
+                    udevadm trigger
+                    udevadm settle
+                fi
                 bootparam_root="UUID=$(get_dev_uuid "${dev}")"
                 echo "${bootparam_root}" > /run/initramfs/bootparam_root
                 rm -f "/run/initramfs/bootparam_root.mux"

--- a/meta-balena-common/recipes-core/initrdscripts/files/rootfs
+++ b/meta-balena-common/recipes-core/initrdscripts/files/rootfs
@@ -44,11 +44,22 @@ rootfs_run() {
 
             if [ "`echo ${bootparam_root} | cut -c1-6`" = "LABEL=" ]; then
                 root_label=`echo $bootparam_root | cut -c7-`
-                bootparam_root="$(get_state_path_from_label "$root_label")"
-                if [ "${bootparam_flasher}" = "true" ] && [ ! -L "${bootparam_root}" ]; then
-                    bootparam_root="/dev/disk/by-label/$root_label"
+                # get_state_path_from_label is making a best-effort
+                # guess and sometimes it picks wrong (e.g. if udev is
+                # still processing devices). Make sure it picked
+                # a device with ext4 filesystem before ultimately
+                # deciding to use it for bootparam_root.
+                _root="$(get_state_path_from_label "$root_label")"
+                _fstype="$(get_dev_fstype "${_root}")"
+                if echo "${_fstype}" | grep -q ext4; then
+                    bootparam_root="${_root}"
+                    if [ "${bootparam_flasher}" = "true" ] && [ ! -L "${bootparam_root}" ]; then
+                        bootparam_root="/dev/disk/by-label/$root_label"
+                    fi
+                    info "Using bootparam_root $bootparam_root for $root_label"
+                else
+                    warn "'${_root}' is '${_fstype}', can't use it for bootparam_root"
                 fi
-                info "Using bootparam_root $bootparam_root for $root_label"
             fi
 
             if [ -e "$bootparam_root" ]; then

--- a/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
+++ b/meta-balena-common/recipes-support/os-helpers/os-helpers/os-helpers-fs
@@ -148,7 +148,7 @@ get_state_path_from_label() {
 # Arguments:
 #   1 - Target block device
 get_dev_fstype() {
-	lsblk -nlo fstype "${1}"
+	lsblk -nldo fstype "${1}"
 }
 
 # Mount/unmount device to update mount time


### PR DESCRIPTION
This patch addresses two problems that we have discovered during automated QEMU tests:
1. regenerating UUIDs sometimes makes the `by-state` symlinks disappear
2. `get_state_path_from_label` sometimes picks wrong on encrypted devices

Both fixes have details explained in the comments.

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [x] `Change-type` present on at least one commit
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
