### PR TITLE
.gitmodules: Declare a branch for every submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "tests/leviathan"]
 	path = tests/leviathan
 	url = https://github.com/balena-os/leviathan.git
+	branch = master
 [submodule "tests/suites/os/tests/secureboot/kernel-module-build"]
 	path = tests/suites/os/tests/secureboot/kernel-module-build
 	url = https://github.com/balena-os/kernel-module-build
+	branch = master
 [submodule "tests/suites/os/tests/extra-firmware/kernel-module-build"]
 	path = tests/suites/os/tests/extra-firmware/kernel-module-build
 	url = https://github.com/balena-os/kernel-module-build
+	branch = master


### PR DESCRIPTION
`check_gitmodules_branches` fails while any submodule has no branch declared, which currently blocks every PR in this repo including #3935.

All three submodules had none. Each pin is an ancestor of `master` on its remote, verified with the compare API:

| Submodule | Branch | Pin position |
|---|---|---|
| `tests/leviathan` | `master` | 3 behind tip |
| `tests/suites/os/tests/secureboot/kernel-module-build` | `master` | branch tip |
| `tests/suites/os/tests/extra-firmware/kernel-module-build` | `master` | branch tip |

The check went live in Flowzone between 2026-09-03 22:45 and 09-04, so older green `Versioned source` results in this repo predate it and do not mean the file was compliant.
