### PR TITLE
kernel-headers-test: move the test image off Debian bullseye

### DIFF
--- a/meta-balena-common/recipes-kernel/linux/files/Dockerfile
+++ b/meta-balena-common/recipes-kernel/linux/files/Dockerfile
@@ -1,4 +1,4 @@
-FROM balenalib/intel-nuc-debian:bullseye-20230328
+FROM debian:bookworm-20260824-slim
 
 # Install dependencies
 RUN apt-get update && apt-get install -y curl wget build-essential libelf-dev bc flex libssl-dev bison gcc-arm-linux-gnueabi gcc-aarch64-linux-gnu python3-minimal


### PR DESCRIPTION
Debian 11 security support ended on 2026-08-31.

Moves to the official Debian image instead.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
